### PR TITLE
Adding Data Register sync for protected areas

### DIFF
--- a/.github/workflows/deploy-api-dev.yaml
+++ b/.github/workflows/deploy-api-dev.yaml
@@ -71,12 +71,14 @@ jobs:
           INSTANCE_TYPE: ${{ vars.INSTANCE_TYPE }}
           OPEN_SEARCH_MAIN_INDEX: ${{ vars.OPEN_SEARCH_MAIN_INDEX }}
           EBS_IOPS: ${{ vars.EBS_IOPS }}
+          DATA_REGISTER_ENDPOINT: ${{ vars.DATA_REGISTER_ENDPOINT }}
+          DATA_REGISTER_API_KEY: ${{ secrets.DATA_REGISTER_API_KEY }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "TableName=$TABLE_NAME" "TableNameAudit=$TABLE_NAME_AUDIT" "Stage=$STAGE" "AccountId=$ACCOUNT_ID" "DomainName=$DOMAIN_NAME" "KMSKeyId=$KMS_KEY_ID" "InstanceCount=$INSTANCE_COUNT" "InstanceType=$INSTANCE_TYPE" "OpenSearchMainIndex=$OPEN_SEARCH_MAIN_INDEX" "EBSIops=$EBS_IOPS"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "TableName=$TABLE_NAME" "TableNameAudit=$TABLE_NAME_AUDIT" "Stage=$STAGE" "AccountId=$ACCOUNT_ID" "DomainName=$DOMAIN_NAME" "KMSKeyId=$KMS_KEY_ID" "InstanceCount=$INSTANCE_COUNT" "InstanceType=$INSTANCE_TYPE" "OpenSearchMainIndex=$OPEN_SEARCH_MAIN_INDEX" "EBSIops=$EBS_IOPS" "DataRegisterEndpoint=$DATA_REGISTER_ENDPOINT" "DataRegisterApiKey=$DATA_REGISTER_API_KEY"
 
       # - shell: bash
       #   env:
       #     WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       #   run: |
       #     curl -X POST -H 'Content-Type: application/json' $WEBHOOK_URL --data '{"text":"Data Register - Deploy Reserve Rec API Dev Complete"}'
-      
+

--- a/env.json
+++ b/env.json
@@ -1,0 +1,8 @@
+{
+  "Parameters": {
+    "TABLE_NAME": "ds-pos-main",
+    "IS_OFFLINE": true,
+    "AWS_REGION": "local-env",
+    "DYNAMODB_ENDPOINT_URL": "<Add your local dynamodb endpoint here>"
+  }
+}

--- a/handlers/syncDataRegister/index.js
+++ b/handlers/syncDataRegister/index.js
@@ -1,0 +1,125 @@
+/**
+ * Syncs protected area data from the Data Register to the Reserve Rec Database.
+ * If a protected area is not already in the Reserve Rec Database, it will be added.
+ */
+
+const { getNowISO, logger, sendResponse } = require('/opt/base');
+const { TABLE_NAME, batchTransactData, getOne, marshall } = require('/opt/dynamodb');
+const { getDataRegisterRecords } = require('/opt/dataRegister');
+
+const DATA_REGISTER_ENDPOINT = process.env.DATA_REGISTER_ENDPOINT || 'https://dev-data.bcparks.ca/api';
+const DATA_REGISTER_SUBDIRECTORY = '/parks/names';
+const DATA_REGISTER_API_KEY = process.env.DATA_REGISTER_API_KEY;
+const ESTABLISHED_STATE = 'established';
+
+// Add data register fields to sync here
+const FIELDS_TO_SYNC = [
+  'legalName',
+  'displayName'
+];
+
+exports.handler = async (event, context) => {
+  try {
+    // Get list of park names from the Data Register
+    const params = {
+      status: ESTABLISHED_STATE
+    };
+    const url = `${DATA_REGISTER_ENDPOINT}${DATA_REGISTER_SUBDIRECTORY}`;
+    const list = await getDataRegisterRecords(url, DATA_REGISTER_API_KEY, params);
+
+    // get the protected areas from the response
+    const protectedAreas = list?.data?.data?.items || [];
+
+    // Add each protected area to the database
+    if (!protectedAreas || protectedAreas.length === 0) {
+      throw new Error('No protected areas found');
+    }
+    await syncData(protectedAreas);
+    return sendResponse(200, [], 'Success', null, context);
+  } catch (error) {
+    return sendResponse(400, error.message);
+  }
+};
+
+async function syncData(protectedAreas) {
+  let updateList = [];
+  let now = getNowISO();
+  for (const protectedArea of protectedAreas) {
+    // Don't include Sites for now.
+    // TODO: Update this check when Sites are added to the database
+    if (protectedArea?.pk.includes('Site::')) {
+      continue;
+    }
+    // DynamoDB RRUs are 20% the cost of WRUs, so we can afford to check if the item exists before
+    // adding it, instead of doing a PUT with a conditional expression.
+    // Usually this should be cheaper since we expect most items to already exist.
+    const existingItem = await getOne('protectedArea', protectedArea.pk);
+
+    // If the item does not exist, add it to the database
+    if (!existingItem) {
+      updateList.push(await createPutPAItem(protectedArea, now));
+      continue;
+    }
+
+    // If the item exists but one of the syncing fields has changed, update the item in the database
+    const shouldUpdate = FIELDS_TO_SYNC.some(field => {
+      return protectedArea?.[field] !== existingItem?.[field];
+    });
+
+    if (shouldUpdate) {
+      updateList.push(await createUpdatePAItem(protectedArea, now));
+    }
+  }
+  logger.info(`Updating ${updateList.length} protected areas.`);
+  await batchTransactData(updateList);
+}
+
+async function createPutPAItem(protectedArea, timestamp) {
+  let item = {
+    pk: 'protectedArea',
+    sk: protectedArea.pk,
+    orcs: protectedArea.pk,
+    creationDate: timestamp,
+    lastUpdated: timestamp
+  };
+  for (const field of FIELDS_TO_SYNC) {
+    item[field] = protectedArea[field];
+  }
+  const putItem = {
+    action: 'Put',
+    data: {
+      TableName: TABLE_NAME,
+      Item: marshall(item),
+      ConditionExpression: 'attribute_not_exists(pk)'
+    }
+  };
+  return putItem;
+}
+
+function createUpdatePAItem(protectedArea, timestamp) {
+  let expressionAttributeNames = {};
+  let expressionAttributeValues = {
+    ':lastUpdated': { S: timestamp }
+  };
+  let updateClauses = [`lastUpdated = :lastUpdated`];
+  for (const field of FIELDS_TO_SYNC) {
+    updateClauses.push(`#${field} = :${field}`);
+    expressionAttributeNames[`#${field}`] = field;
+    expressionAttributeValues[`:${field}`] = marshall(protectedArea[field]);
+  }
+  let updateExpression = `SET ${updateClauses.join(', ')}`;
+  const updateItem = {
+    action: 'Update',
+    data: {
+      TableName: TABLE_NAME,
+      Key: {
+        pk: { S: 'protectedArea' },
+        sk: { S: protectedArea.pk }
+      },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues
+    }
+  };
+  return updateItem;
+}

--- a/layers/base/base.js
+++ b/layers/base/base.js
@@ -68,13 +68,16 @@ const checkWarmup = function (event) {
   }
 };
 
-const getNowISO = function () {
-  return getNow().toISO();
+const getNowISO = function (tz = null) {
+  return getNow(tz).toISO();
 };
 
 
-const getNow = function () {
-  return DateTime.now().setZone(TIMEZONE);
+const getNow = function (tz = null) {
+  if (!tz) {
+    tz = 'UTC'
+  }
+  return DateTime.now().setZone(tz);
 };
 
 const Exception = class extends Error {

--- a/layers/base/dataRegister.js
+++ b/layers/base/dataRegister.js
@@ -1,0 +1,27 @@
+/**
+ * AWS Layer: dataRegister.js for Data Register functions.
+ */
+
+const axios = require('axios');
+const { logger } = require('/opt/base');
+
+async function getDataRegisterRecords(url, apiKey, params) {
+  try {
+    return await axios.get(encodeURI(url), {
+      params: params,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'None',
+        'Accept': 'application/json',
+        'x-api-key': apiKey
+      }
+    });
+  } catch (error) {
+    logger.debug('Error getting data register records: getDataRegisterRecords function in dataRegister layer');
+    throw error;
+  }
+}
+
+module.exports = {
+  getDataRegisterRecords
+};

--- a/layers/base/nodejs/package.json
+++ b/layers/base/nodejs/package.json
@@ -4,9 +4,10 @@
   "author": "Team Osprey",
   "license": "MIT",
   "dependencies": {
+    "axios": "^1.7.7",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.0.0",
-    "luxon": "^3.4.4",
+    "luxon": "^3.5.0",
     "winston": "^3.10.0"
   },
   "scripts": {

--- a/layers/base/nodejs/yarn.lock
+++ b/layers/base/nodejs/yarn.lock
@@ -147,6 +147,20 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -286,6 +300,13 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 debug@^4.3.4, debug@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
@@ -304,6 +325,11 @@ deep-eql@^4.1.3:
   integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
   dependencies:
     type-detect "^4.0.0"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 diff@^5.2.0:
   version "5.2.0"
@@ -366,6 +392,20 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
+follow-redirects@^1.15.6:
+  version "1.15.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.8.tgz#ae67b97ae32e0a7b36066a5448938374ec18d13d"
+  integrity sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -633,10 +673,22 @@ lru-memoizer@^2.2.0:
     lodash.clonedeep "^4.5.0"
     lru-cache "6.0.0"
 
-luxon@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
-  integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
+luxon@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
+  integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 minimatch@^5.0.1, minimatch@^5.1.6:
   version "5.1.6"
@@ -728,6 +780,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 randombytes@^2.1.0:
   version "2.1.0"

--- a/template.yaml
+++ b/template.yaml
@@ -11,7 +11,7 @@ Globals:
     Environment:
       Variables:
         IS_OFFLINE: false
-        DYNAMODB_ENDPOINT_URL: dynamodb.ca-central-1.amazonaws.com
+        DYNAMODB_ENDPOINT_URL: https://dynamodb.ca-central-1.amazonaws.com
 
 Parameters:
   TableName:
@@ -45,9 +45,15 @@ Parameters:
   EBSIops:
     Type: String
     Default: 3000
+  DataRegisterEndpoint:
+    Type: String
+    Default: 'https://dev-data.bcparks.ca/api'
+  DataRegisterApiKey:
+    Type: String
+    Default: 'dev-api'
 
 Resources:
-  DynamoDBTable: 
+  DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref TableName
@@ -195,6 +201,39 @@ Resources:
           QueryStringsConfig:
             QueryStringBehavior: all
 
+  ### LAMBDAS ###
+
+  # Data Register Integration
+  SyncDataRegisterFunction:
+    FunctionName: SyncDataRegisterFunction
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/syncDataRegister/
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Description: Syncs Data Register protected areas every day at 08:00 UTC (00:00 PDT)
+      MemorySize: 512
+      Timeout: 900
+      Layers:
+        - !Ref BaseLayer
+        - !Ref AWSUtilsLayer
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableName
+            # TableName: !Ref TableNameAudit
+      Environment:
+        Variables:
+          LOG_LEVEL: info
+          DATA_REGISTER_ENDPOINT: !Ref DataRegisterEndpoint
+          DATA_REGISTER_API_KEY: !Ref DataRegisterApiKey
+      Events:
+        UpdateProtectedAreas:
+          Type: Schedule
+          Properties:
+            Name: "SyncDataRegisterFunctionSchedule"
+            Schedule: cron(0 8 * * ? *)
+            Description: "Sync Data Register protected areas every day at 08:00 UTC (00:00 PDT)"
+
   SearchFunction:
     FunctionName: SearchFunction
     Type: AWS::Serverless::Function
@@ -209,7 +248,7 @@ Resources:
       Architectures:
         - x86_64
       MemorySize: 128
-      Timeout: 7
+      Timeout: 20
       Description: Search Handler
       Policies:
         - ElasticsearchHttpPostPolicy:


### PR DESCRIPTION
Similar to DUP and A&R, this script pulls the list of established names from the Data Register every night and updates the PRDT database accordingly. If a protected area doesn't already exist, it will be created with a few basic fields:

```
pk: protectedArea
sk: <orcs>
orcs: <orcs>
creationDate: <timestamp>
lastUpdated: <timestamp>
```