### PR TITLE
BRS-55: Add CRUD for Protected Areas

### DIFF
--- a/docs/postman/BCParks PRDT Reservation System.postman_collection.json
+++ b/docs/postman/BCParks PRDT Reservation System.postman_collection.json
@@ -559,6 +559,39 @@
 							"response": []
 						},
 						{
+							"name": "Create Protected Area By ORCS",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n   \"pk\": \"protectedArea\",\r\n   \"sk\": \"999\",\r\n   \"orcs\": 999,\r\n   \"displayName\": \"Whole New Protected Area\",\r\n   \"schema\": \"protectedArea\",\r\n   \"location\": {\r\n      \"type\": \"Point\",\r\n      \"coordinates\": [\r\n         89,\r\n         -89\r\n      ]\r\n   },\r\n   \"boundary\": {\r\n      \"type\": \"Polygon\",\r\n      \"coordinates\": [\r\n         [\r\n            [\r\n               89.123,\r\n               -89.123\r\n            ],\r\n            [\r\n               88.122,\r\n               -88.122\r\n            ],\r\n            [\r\n               87.121,\r\n               -87.121\r\n            ],\r\n            [\r\n               86.12,\r\n               -86.12\r\n            ]\r\n         ]\r\n      ]\r\n   },\r\n   \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n   \"timezone\": \"America\/Vancouver\",\r\n   \"minMapZoom\": 100,\r\n   \"maxMapZoom\": 125,\r\n   \"imageUrl\": \"www.example.com\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/protected-areas/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"protected-areas",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Update Protected Area By ORCS",
 							"request": {
 								"method": "PUT",
@@ -584,7 +617,31 @@
 									"variable": [
 										{
 											"key": "orcs",
-											"value": "1"
+											"value": "999"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Geozone by Collection ID",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/protected-areas/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"protected-areas",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
 										}
 									]
 								}
@@ -618,13 +675,13 @@
 					"response": []
 				},
 				{
-					"name": "Batch Update Protected Areas",
+					"name": "Batch Create Protected Areas",
 					"request": {
-						"method": "PUT",
+						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n  {\n    \"orcs\": 1,\n    \"displayName\": \"Strathcona - Batch update\",\n    \"maxMapZoom\": 20},\n  {\n    \"orcs\": 2,\n    \"displayName\": \"Mount Robson Park - Batch update\",\n    \"maxMapZoom\": 20\n  }\n]",
+							"raw": "[\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"998\",\r\n      \"orcs\": 998,\r\n      \"displayName\": \"Whole New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   },\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"999\",\r\n      \"orcs\": 999,\r\n      \"displayName\": \"Another New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   }\r\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -633,6 +690,32 @@
 						},
 						"url": {
 							"raw": "{{base_url}}/protected-areas",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"protected-areas"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Batch Delete Protected Areas",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "[\r\n   {\r\n      \"sk\": \"998\"\r\n   },\r\n   {\r\n      \"sk\": \"999\"\r\n   }\r\n]",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/protected-areas/",
 							"host": [
 								"{{base_url}}"
 							],

--- a/lib/handlers/protectedAreas/DELETE/index.js
+++ b/lib/handlers/protectedAreas/DELETE/index.js
@@ -1,0 +1,43 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
+
+exports.handler = async (event, context) => {
+  logger.info('Batch Delete Protected Areas by ORCS', event);
+  try {
+    const body = JSON.parse(event?.body);
+    if (!body) {
+      throw new Exception('Body is required', { code: 400 });
+    }
+
+    if (!Array.isArray(body)) {
+      throw new Exception('Body must be an array', { code: 400 });
+    }
+
+    let deleteItems = [];
+    for (const item of body) {
+      if (!item?.sk) {
+        throw new Exception('sk', { code: 400 });
+      }
+
+      const pk = 'protectedArea';
+      const sk = item.sk;
+
+      let deleteCommand = {
+        action: 'Delete',
+        data: {
+          TableName: TABLE_NAME,
+          Key: marshall({ pk: pk, sk: sk }),
+          ConditionExpression: 'attribute_exists(pk) AND attribute_exists(sk)',
+        }
+      };
+
+      deleteItems.push(deleteCommand);
+    }
+
+    // Use batchTransactData to put the database
+    const res = await batchTransactData(deleteItems);
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (error) {
+    return sendResponse(Number(error?.code) || 400, error?.data || null, error?.message || 'Error', error?.error || error, context);
+  }
+};

--- a/lib/handlers/protectedAreas/POST/index.js
+++ b/lib/handlers/protectedAreas/POST/index.js
@@ -1,6 +1,6 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { quickApiUpdateHandler } = require("/opt/data-utils");
-const { PROTECTED_AREA_API_UPDATE_CONFIG } = require("/opt/protectedAreas/configs");
+const { quickApiPutHandler } = require("/opt/data-utils");
+const { PROTECTED_AREA_API_PUT_CONFIG } = require("/opt/protectedAreas/configs");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {
@@ -15,29 +15,33 @@ exports.handler = async (event, context) => {
       throw new Exception('Body must be an array', { code: 400 });
     }
 
-    // extract orcs and actions from body
-    let updateRequests = [];
+    // extract ORCS and actions from body
+    let putRequests = [];
     for (const item of body) {
+
       if (!item?.orcs) {
-        throw new Exception('ORCS number is required for every update item', { code: 400 });
+        throw new Exception('ORCS is required for each item', { code: 400 });
       }
+      
+      const sk = String(item?.orcs);
 
-      const sk = String(item.orcs);
-      delete item.orcs;
+      item.pk = 'protectedArea';
+      item.sk = sk;
+      item.orcs = item?.orcs;
 
-      const updateItem = {
+      const putItem = {
         key: { pk: 'protectedArea', sk: sk },
         data: item,
       };
 
-      updateRequests.push(updateItem);
+      putRequests.push(putItem);
     }
 
-    // Use quickApiUpdateHandler to create the update items
-    const updateItems = await quickApiUpdateHandler(TABLE_NAME, updateRequests, PROTECTED_AREA_API_UPDATE_CONFIG);
+    // Use quickApiPutHandler to create the put items
+    const putItems = await quickApiPutHandler(TABLE_NAME, putRequests, PROTECTED_AREA_API_PUT_CONFIG);
 
-    // Use batchTransactData to update the database
-    const res = await batchTransactData(updateItems);
+    // Use batchTransactData to put the database
+    const res = await batchTransactData(putItems);
 
     return sendResponse(200, res, 'Success', null, context);
   } catch (error) {

--- a/lib/handlers/protectedAreas/_orcs/DELETE/index.js
+++ b/lib/handlers/protectedAreas/_orcs/DELETE/index.js
@@ -1,0 +1,19 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { TABLE_NAME, deleteItem } = require("/opt/dynamodb");
+
+exports.handler = async (event, context) => {
+  logger.info('Delete single Protected Area by ORCS', event);
+  try {
+    const orcs = String(event?.pathParameters?.orcs);
+    
+    if (!orcs) {
+      throw new Exception('ORCS is required', { code: 400 });
+    }
+
+    const item = { pk: 'protectedArea', sk: orcs }
+    const res = await deleteItem(item.pk, item.sk, TABLE_NAME)
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (error) {
+    return sendResponse(Number(error?.code) || 400, error?.data || null, error?.message || 'Error', error?.error || error, context);
+  }
+};

--- a/lib/handlers/protectedAreas/_orcs/GET/index.js
+++ b/lib/handlers/protectedAreas/_orcs/GET/index.js
@@ -14,7 +14,7 @@ exports.handler = async (event, context) => {
   }
 
   try {
-    const orcs = event?.pathParameters?.orcs;
+    const orcs = String(event?.pathParameters?.orcs);
 
     if (!orcs) {
       throw new Exception('ORCS is required', { code: 400 });

--- a/lib/handlers/protectedAreas/_orcs/POST/index.js
+++ b/lib/handlers/protectedAreas/_orcs/POST/index.js
@@ -1,0 +1,40 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { quickApiPutHandler } = require("/opt/data-utils");
+const { PROTECTED_AREA_API_PUT_CONFIG } = require("/opt/protectedAreas/configs");
+const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+
+exports.handler = async (event, context) => {
+  logger.info('Post single Protected Area ID', event);
+  try {
+    const body = JSON.parse(event?.body);
+    if (!body) {
+      throw new Exception('Body is required', { code: 400 });
+    }
+
+    const orcs = Number(event?.pathParameters?.orcs);
+    
+    if (!orcs) {
+      throw new Exception('ORCS is required', { code: 400 });
+    }
+
+    // Set the sk and orcs if they're not provided in the body
+    body.sk = String(orcs);
+    body.orcs = orcs;
+
+    // Format body with key
+    const postItem = {
+      key: { pk: `protectedArea`, sk: String(orcs) },
+      data: body,
+    };
+
+    // Use quickApiUpdateHandler to create the update item
+    const postItems = await quickApiPutHandler(TABLE_NAME, [postItem], PROTECTED_AREA_API_PUT_CONFIG);
+
+    // Use batchTransactData to update the database
+    const res = await batchTransactData(postItems);
+
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (error) {
+    return sendResponse(Number(error?.code) || 400, error?.data || null, error?.message || 'Error', error?.error || error, context);
+  }
+};

--- a/lib/handlers/protectedAreas/resources.js
+++ b/lib/handlers/protectedAreas/resources.js
@@ -20,19 +20,27 @@ function protectedAreasSetup(scope, props) {
     environment: props.env,
     layers: props.layers,
   });
-
   protectedAreasResource.addMethod('GET', new apigateway.LambdaIntegration(protectedAreasGetFunction));
 
-  // PUT /protected-areas/
-  const protectedAreasPutFunction = new NodejsFunction(scope, 'ProtectedAreasPut', {
-    code: lambda.Code.fromAsset('lib/handlers/protectedAreas/PUT'),
+  // POST /protected-areas/
+  const protectedAreasPostFunction = new NodejsFunction(scope, 'ProtectedAreasPost', {
+    code: lambda.Code.fromAsset('lib/handlers/protectedAreas/POST'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-
-  protectedAreasResource.addMethod('PUT', new apigateway.LambdaIntegration(protectedAreasPutFunction));
+  protectedAreasResource.addMethod('POST', new apigateway.LambdaIntegration(protectedAreasPostFunction));
+  
+  // DELETE /protected-areas/
+  const protectedAreasDeleteFunction = new NodejsFunction(scope, 'ProtectedAreasDelete', {
+    code: lambda.Code.fromAsset('lib/handlers/protectedAreas/DELETE'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  protectedAreasResource.addMethod('DELETE', new apigateway.LambdaIntegration(protectedAreasDeleteFunction));
 
   // {orcs} identifier
   const protectedAreasResourceByOrcs = protectedAreasResource.addResource('{orcs}')
@@ -45,8 +53,17 @@ function protectedAreasSetup(scope, props) {
     environment: props.env,
     layers: props.layers,
   });
-
   protectedAreasResourceByOrcs.addMethod('GET', new apigateway.LambdaIntegration(protectedAreasGetByOrcsFunction));
+
+  // POST /protected-areas/{orcs}
+  const protectedAreasPostByOrcsFunction = new NodejsFunction(scope, 'ProtectedAreasPostByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/protectedAreas/_orcs/POST'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  protectedAreasResourceByOrcs.addMethod('POST', new apigateway.LambdaIntegration(protectedAreasPostByOrcsFunction));
 
   // PUT /protected-areas/{orcs}
   const protectedAreasPutByOrcsFunction = new NodejsFunction(scope, 'ProtectedAreasPutByOrcs', {
@@ -56,8 +73,17 @@ function protectedAreasSetup(scope, props) {
     environment: props.env,
     layers: props.layers,
   });
-
   protectedAreasResourceByOrcs.addMethod('PUT', new apigateway.LambdaIntegration(protectedAreasPutByOrcsFunction));
+  
+  // DELETE /protected-areas/{orcs}
+  const protectedAreasDeleteByOrcsFunction = new NodejsFunction(scope, 'ProtectedAreasDeleteByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/protectedAreas/_orcs/DELETE'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  protectedAreasResourceByOrcs.addMethod('DELETE', new apigateway.LambdaIntegration(protectedAreasDeleteByOrcsFunction));
 
   // Add DynamoDB query & getItem policies to the functions
   const dynamoDbPolicy = new iam.PolicyStatement({
@@ -66,20 +92,27 @@ function protectedAreasSetup(scope, props) {
       'dynamodb:GetItem',
       'dynamodb:BatchWrite*',
       'dynamodb:PutItem',
+      'dynamodb:Delete*'
     ],
     resources: [props.mainTable.tableArn],
   });
 
   protectedAreasGetFunction.addToRolePolicy(dynamoDbPolicy);
-  protectedAreasPutFunction.addToRolePolicy(dynamoDbPolicy);
+  protectedAreasPostFunction.addToRolePolicy(dynamoDbPolicy);
+  protectedAreasDeleteFunction.addToRolePolicy(dynamoDbPolicy);
   protectedAreasGetByOrcsFunction.addToRolePolicy(dynamoDbPolicy);
+  protectedAreasPostByOrcsFunction.addToRolePolicy(dynamoDbPolicy);
   protectedAreasPutByOrcsFunction.addToRolePolicy(dynamoDbPolicy);
+  protectedAreasDeleteByOrcsFunction.addToRolePolicy(dynamoDbPolicy);
 
   return {
     protectedAreasGetFunction: protectedAreasGetFunction,
-    protectedAreasPutFunction: protectedAreasPutFunction,
+    protectedAreasPostFunction: protectedAreasPostFunction,
+    protectedAreasDeleteFunction: protectedAreasDeleteFunction,
     protectedAreasGetByOrcsFunction: protectedAreasGetByOrcsFunction,
+    protectedAreasPostByOrcsFunction: protectedAreasPostByOrcsFunction,
     protectedAreasPutByOrcsFunction: protectedAreasPutByOrcsFunction,
+    protectedAreasDeleteByOrcsFunction: protectedAreasDeleteByOrcsFunction,
     protectedAreasResource: protectedAreasResource
   };
 }

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -244,7 +244,7 @@ async function quickApiPutHandler(tableName, createList, config) {
 
         // Prevent overwrites if config.allowOverwrite is false
         if (!itemConfig?.allowOverwrite) {
-          createCommand.data.ConditionExpression = 'attribute_not_exists(pk)';
+          createCommand.data.ConditionExpression = 'attribute_not_exists(pk) AND attribute_not_exists(sk)';
         }
 
         createItems.push(createCommand);

--- a/lib/layers/dataUtils/protectedAreas/configs.js
+++ b/lib/layers/dataUtils/protectedAreas/configs.js
@@ -4,6 +4,98 @@ const rf = new rulesFns();
 
 const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston']
 
+const PROTECTED_AREA_API_PUT_CONFIG = {
+  allowOverwrite: true,
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    orcs: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    displayName: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    schema : {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ['protectedArea']),
+        rf.expectAction(action, ['add']);
+      }
+    },
+    location: {
+      isMandatory: true,
+        rulesFn: ({value, action}) => {
+          rf.expectGeopoint(value);
+          rf.expectAction(action, ['add']);
+        }
+      },
+    boundary: {
+      isMandatory: true,
+        rulesFn: ({value, action}) => {
+          rf.expectGeoshape(value);
+          rf.expectAction(action, ['add']);
+        }
+      },
+    boundaryUrl: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    timezone : {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, TIMEZONE_ENUMS);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    minMapZoom: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    maxMapZoom: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    }
+  }
+}
+
 const PROTECTED_AREA_API_UPDATE_CONFIG = {
   failOnError: true,
   autoTimestamp: true,
@@ -29,7 +121,7 @@ const PROTECTED_AREA_API_UPDATE_CONFIG = {
       },
     boundary: {
         rulesFn: ({value, action}) => {
-          rf.expectGeopoint(value);
+          rf.expectGeoshape(value);
           rf.expectAction(action, ['set']);
         }
       },
@@ -62,28 +154,11 @@ const PROTECTED_AREA_API_UPDATE_CONFIG = {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
-    },
-    version: {
-      rulesFn: ({ value, action }) => {
-        rf.expectInteger(value);
-        rf.expectAction(action, ['set']);
-      }
-    },
-    creationDate: {
-      rulesFn: ({ value, action }) => {
-        rf.expectISODateTimeObjFormat(value);
-        rf.expectAction(action, ['set']);
-      }
-    },
-    lastUpdated: {
-      rulesFn: ({ value, action }) => {
-        rf.expectISODateTimeObjFormat(value);
-        rf.expectAction(action, ['set']);
-      }
     }
   }
 }
 
 module.exports = {
+  PROTECTED_AREA_API_PUT_CONFIG,
   PROTECTED_AREA_API_UPDATE_CONFIG
 }

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -249,7 +249,7 @@ class rulesFns {
    */
   expectGeoshape(value) {
     // Type validation
-    if (!value?.type || value.type !== 'Envelope') {
+    if (!value?.type || (value.type !== 'Envelope' && value.type !== 'Polygon')) {
       throw new Exception(`Invalid geoshape type: Expected 'type' to be 'Envelope'`, { code: 400 });
     }
 
@@ -270,8 +270,8 @@ class rulesFns {
     const points = coords[0];
     
     // Ensure we have at least two points
-    if (!Array.isArray(points) || points.length !== 2) {
-      throw new Exception('Invalid geoshape point coordinates: Expected coordinates to be an array with two elements', { code: 400 });
+    if (!Array.isArray(points) || points.length < 2) {
+      throw new Exception('Invalid geoshape point coordinates: Expected coordinates to be an array with at least two elements', { code: 400 });
     }
 
     // Validate each point


### PR DESCRIPTION
### Ticket:
BRS-55

### Ticket URL:
#55

### Description:
- First-pass at adding endpoints for Protected Areas
- Add new `POST` endpoint for creating `protectedArea`s
- Add new `POST` endpoint for creating single `protectedArea` by `orcs`
- Update validation rules to support creation operations
- Add new configuration for `protectedArea` creation
- Update Postman collection with new endpoints

#### Protection Area `/protection-areas/` (batch requests)
- `GET` to `/protection-areas/` retrieves all `protectedArea`s
- `POST` to `/protection-areas/` with an array of `protectedArea`-acceptable data attributes in the `body` of the request will create multiple `protectedArea`s.
- Can't create a `PUT` without  `orcs` in the body, but `orcs` is also the sk and therefore would indicate this is a new item. `POST` allows overwrite (for now)
- `DELETE` to `/protection-areas/` with an array of `sk`s in the `body` of the request will delete multiple `protectedArea`s.

 #### Protection Area `/protection-areas/{orcs}`
- `GET` to `/protection-areas/1` retrieve a `protectedArea` with `orcs` 1
- `POST` to `/protection-areas/1` with acceptable data attributes in the `body` of the request will create a `protectedArea` for `orcs` 1
- `PUT` to `/protection-areas/1` with acceptable data attributes in the `body` of the request will create a `protectedArea` for `orcs` 1
- `DELETE` to `/protection-areas/1` will delete `protectedArea` with `orcs` 1