### PR TITLE
BRS-58: Add CRUD for Activities

### DIFF
--- a/docs/postman/BCParks PRDT Reservation System.postman_collection.json
+++ b/docs/postman/BCParks PRDT Reservation System.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "d5314b6f-3178-44eb-9a6f-e3111e217cf5",
+		"_postman_id": "5cceae33-8bf4-4250-95e6-fa833bd21be6",
 		"name": "BCParks PRDT Reservation System",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14509064",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-d5314b6f-3178-44eb-9a6f-e3111e217cf5?action=share&source=collection_link&creator=14509064"
+		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-d5314b6f-3178-44eb-9a6f-e3111e217cf5?action=share&source=collection_link&creator=14509064",
+		"_exporter_id": "43291325"
 	},
 	"item": [
 		{
@@ -49,7 +49,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n   {\r\n      \"displayName\": \"Cheakamus 4\",\r\n      \"gzCollectionId\": \"7\",\r\n      \"orcs\": 7,\r\n      \"identifier\": 4,\r\n      \"schema\": \"geozone\",\r\n      \"geozoneId\": 4,\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  89.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   },\r\n   {\r\n      \"displayName\": \"Cheakamus 5\",\r\n      \"gzCollectionId\": \"7\",\r\n      \"orcs\": 7,\r\n      \"identifier\": 5,\r\n      \"schema\": \"geozone\",\r\n      \"geozoneId\": 5,\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            88,\r\n            -88\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  88.123,\r\n                  -88.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   }\r\n]",
+									"raw": "[\r\n   {\r\n      \"displayName\": \"Cheakamus 4\",\r\n      \"gzCollectionId\": \"7\",\r\n      \"orcs\": 7,\r\n      \"identifier\": 4,\r\n      \"schema\": \"geozone\",\r\n      \"geozoneId\": 4,\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  89.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   },\r\n   {\r\n      \"displayName\": \"Cheakamus 5\",\r\n      \"gzCollectionId\": \"7\",\r\n      \"orcs\": 7,\r\n      \"identifier\": 5,\r\n      \"schema\": \"geozone\",\r\n      \"geozoneId\": 5,\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            88,\r\n            -88\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  88.123,\r\n                  -88.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -87,7 +87,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n   {\r\n      \"displayName\": \"New Cheakamus 4\",\r\n      \"identifier\": 4,\r\n      \"schema\": \"geozone\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  89.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   },\r\n   {\r\n      \"displayName\": \"New Cheakamus 5\",\r\n      \"identifier\": 5,\r\n      \"schema\": \"geozone\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            88,\r\n            -88\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  88.123,\r\n                  -88.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   }\r\n]",
+									"raw": "[\r\n   {\r\n      \"displayName\": \"New Cheakamus 4\",\r\n      \"identifier\": 4,\r\n      \"schema\": \"geozone\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  89.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   },\r\n   {\r\n      \"displayName\": \"New Cheakamus 5\",\r\n      \"identifier\": 5,\r\n      \"schema\": \"geozone\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            88,\r\n            -88\r\n         ]\r\n      },\r\n      \"envelope\": {\r\n         \"type\": \"Envelope\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  88.123,\r\n                  -88.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"isVisible\": true,\r\n      \"minMapZoom\": 123,\r\n      \"maxMapZoom\": 456,\r\n      \"facilities\": [\r\n         \"parking::1\",\r\n         \"parking::2\"\r\n      ],\r\n      \"activities\": [\r\n         \"dayuse::1\"\r\n      ]\r\n   }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -202,7 +202,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"displayName\": \"New New Cheakamus\",\r\n    \"gzCollectionId\": \"7\",\r\n    \"orcs\": 7,\r\n    \"identifier\": 3,\r\n    \"schema\": \"geozone\",\r\n    \"geozoneId\": 3,\r\n    \"location\": {\r\n        \"type\": \"Point\",\r\n        \"coordinates\": [\r\n            89,\r\n            -89\r\n        ]\r\n    },\r\n    \"envelope\": {\r\n        \"type\": \"Envelope\",\r\n        \"coordinates\": [\r\n            [\r\n                [\r\n                    89.123,\r\n                    -89.123\r\n                ],\r\n                [\r\n                    89.122,\r\n                    -88.122\r\n                ]\r\n            ]\r\n        ]\r\n    },\r\n    \"timezone\": \"America\/Vancouver\",\r\n    \"isVisible\": true,\r\n    \"minMapZoom\": 123,\r\n    \"maxMapZoom\": 456,\r\n    \"facilities\": [\r\n        \"parking::1\",\r\n        \"parking::2\"\r\n    ],\r\n    \"activities\": [\r\n        \"dayuse::1\"\r\n    ]\r\n}",
+									"raw": "{\r\n    \"displayName\": \"New New Cheakamus\",\r\n    \"gzCollectionId\": \"7\",\r\n    \"orcs\": 7,\r\n    \"identifier\": 3,\r\n    \"schema\": \"geozone\",\r\n    \"geozoneId\": 3,\r\n    \"location\": {\r\n        \"type\": \"Point\",\r\n        \"coordinates\": [\r\n            89,\r\n            -89\r\n        ]\r\n    },\r\n    \"envelope\": {\r\n        \"type\": \"Envelope\",\r\n        \"coordinates\": [\r\n            [\r\n                [\r\n                    89.123,\r\n                    -89.123\r\n                ],\r\n                [\r\n                    89.122,\r\n                    -88.122\r\n                ]\r\n            ]\r\n        ]\r\n    },\r\n    \"timezone\": \"America/Vancouver\",\r\n    \"isVisible\": true,\r\n    \"minMapZoom\": 123,\r\n    \"maxMapZoom\": 456,\r\n    \"facilities\": [\r\n        \"parking::1\",\r\n        \"parking::2\"\r\n    ],\r\n    \"activities\": [\r\n        \"dayuse::1\"\r\n    ]\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -565,7 +565,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n   \"pk\": \"protectedArea\",\r\n   \"sk\": \"999\",\r\n   \"orcs\": 999,\r\n   \"displayName\": \"Whole New Protected Area\",\r\n   \"schema\": \"protectedArea\",\r\n   \"location\": {\r\n      \"type\": \"Point\",\r\n      \"coordinates\": [\r\n         89,\r\n         -89\r\n      ]\r\n   },\r\n   \"boundary\": {\r\n      \"type\": \"Polygon\",\r\n      \"coordinates\": [\r\n         [\r\n            [\r\n               89.123,\r\n               -89.123\r\n            ],\r\n            [\r\n               88.122,\r\n               -88.122\r\n            ],\r\n            [\r\n               87.121,\r\n               -87.121\r\n            ],\r\n            [\r\n               86.12,\r\n               -86.12\r\n            ]\r\n         ]\r\n      ]\r\n   },\r\n   \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n   \"timezone\": \"America\/Vancouver\",\r\n   \"minMapZoom\": 100,\r\n   \"maxMapZoom\": 125,\r\n   \"imageUrl\": \"www.example.com\"\r\n}",
+									"raw": "{\r\n   \"pk\": \"protectedArea\",\r\n   \"sk\": \"999\",\r\n   \"orcs\": 999,\r\n   \"displayName\": \"Whole New Protected Area\",\r\n   \"schema\": \"protectedArea\",\r\n   \"location\": {\r\n      \"type\": \"Point\",\r\n      \"coordinates\": [\r\n         89,\r\n         -89\r\n      ]\r\n   },\r\n   \"boundary\": {\r\n      \"type\": \"Polygon\",\r\n      \"coordinates\": [\r\n         [\r\n            [\r\n               89.123,\r\n               -89.123\r\n            ],\r\n            [\r\n               88.122,\r\n               -88.122\r\n            ],\r\n            [\r\n               87.121,\r\n               -87.121\r\n            ],\r\n            [\r\n               86.12,\r\n               -86.12\r\n            ]\r\n         ]\r\n      ]\r\n   },\r\n   \"boundaryUrl\": \"http://s3.amazonaws.com/bucket/\",\r\n   \"timezone\": \"America/Vancouver\",\r\n   \"minMapZoom\": 100,\r\n   \"maxMapZoom\": 125,\r\n   \"imageUrl\": \"www.example.com\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -681,7 +681,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"998\",\r\n      \"orcs\": 998,\r\n      \"displayName\": \"Whole New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   },\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"999\",\r\n      \"orcs\": 999,\r\n      \"displayName\": \"Another New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http:\/\/s3.amazonaws.com\/bucket\/\",\r\n      \"timezone\": \"America\/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   }\r\n]",
+							"raw": "[\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"998\",\r\n      \"orcs\": 998,\r\n      \"displayName\": \"Whole New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http://s3.amazonaws.com/bucket/\",\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   },\r\n   {\r\n      \"pk\": \"protectedArea\",\r\n      \"sk\": \"999\",\r\n      \"orcs\": 999,\r\n      \"displayName\": \"Another New Protected Area\",\r\n      \"schema\": \"protectedArea\",\r\n      \"location\": {\r\n         \"type\": \"Point\",\r\n         \"coordinates\": [\r\n            89,\r\n            -89\r\n         ]\r\n      },\r\n      \"boundary\": {\r\n         \"type\": \"Polygon\",\r\n         \"coordinates\": [\r\n            [\r\n               [\r\n                  89.123,\r\n                  -89.123\r\n               ],\r\n               [\r\n                  88.122,\r\n                  -88.122\r\n               ],\r\n               [\r\n                  87.121,\r\n                  -87.121\r\n               ],\r\n               [\r\n                  86.12,\r\n                  -86.12\r\n               ]\r\n            ]\r\n         ]\r\n      },\r\n      \"boundaryUrl\": \"http://s3.amazonaws.com/bucket/\",\r\n      \"timezone\": \"America/Vancouver\",\r\n      \"minMapZoom\": 100,\r\n      \"maxMapZoom\": 125,\r\n      \"imageUrl\": \"www.example.com\"\r\n   }\r\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -715,7 +715,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/protected-areas/",
+							"raw": "{{base_url}}/protected-areas",
 							"host": [
 								"{{base_url}}"
 							],
@@ -957,19 +957,13 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
 										":orcs"
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "999"
-										}
 									],
 									"query": [
 										{
@@ -979,6 +973,12 @@
 										{
 											"key": "activityId",
 											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
 										}
 									]
 								}
@@ -992,7 +992,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"pk\": \"activity::999\",\r\n    \"sk\": \"dayuse::1\",\r\n    \"orcs\": 999,\r\n    \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n    \"description\": \"Hiking trail north side\",\r\n    \"schema\": \"activity\",\r\n    \"activityType\": \"dayuse\",\r\n    \"subActivityType\": \"vehicleParking\",\r\n    \"identifier\": 1,\r\n    \"activityId\": 1,\r\n    \"geozone\": \"geozone::bcparks::999#1\",\r\n    \"facilities\": [\r\n        \"parking::1\"\r\n    ],\r\n    \"isVisible\": true,\r\n    \"imageUrl\": \"www.example.com\",\r\n    \"searchTerms\": [\r\n        \"Cheakamus\",\r\n        \"Activity\",\r\n        \"Dayuse\"\r\n    ]\r\n}",
+									"raw": "{\r\n    \"orcs\": 999,\r\n    \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n    \"description\": \"Hiking trail north side\",\r\n    \"schema\": \"activity\",\r\n    \"activityType\": \"dayuse\",\r\n    \"subActivityType\": \"vehicleParking\",\r\n    \"identifier\": 1,\r\n    \"activityId\": 1,\r\n    \"geozone\": \"geozone::bcparks::999#1\",\r\n    \"facilities\": [\r\n        \"parking::1\"\r\n    ],\r\n    \"isVisible\": true,\r\n    \"imageUrl\": \"www.example.com\",\r\n    \"searchTerms\": [\r\n        \"Cheakamus\",\r\n        \"Activity\",\r\n        \"Dayuse\"\r\n    ]\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1000,19 +1000,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
 										":orcs"
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "999"
-										}
 									],
 									"query": [
 										{
@@ -1022,6 +1016,12 @@
 										{
 											"key": "activityId",
 											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
 										}
 									]
 								}
@@ -1043,19 +1043,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
 										":orcs"
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "999"
-										}
 									],
 									"query": [
 										{
@@ -1065,6 +1059,12 @@
 										{
 											"key": "activityId",
 											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
 										}
 									]
 								}
@@ -1077,19 +1077,13 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
 										":orcs"
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "999"
-										}
 									],
 									"query": [
 										{
@@ -1099,6 +1093,12 @@
 										{
 											"key": "activityId",
 											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
 										}
 									]
 								}
@@ -1116,7 +1116,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse",
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
 									"host": [
 										"{{base_url}}"
 									],
@@ -1124,16 +1124,16 @@
 										"activities",
 										":orcs"
 									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "998"
-										}
-									],
 									"query": [
 										{
 											"key": "activityType",
 											"value": "dayuse"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
 										}
 									]
 								}
@@ -1163,16 +1163,16 @@
 										"activities",
 										":orcs"
 									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "998"
-										}
-									],
 									"query": [
 										{
 											"key": "activityType",
 											"value": "dayuse"
+										}
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
 										}
 									]
 								}
@@ -1186,7 +1186,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Dayuse Spot 1 New Name Here\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\",\r\n        \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Dayuse Spot 1 New Name Here\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1202,55 +1202,16 @@
 										"activities",
 										":orcs"
 									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "998"
-										}
-									],
 									"query": [
 										{
 											"key": "activityType",
 											"value": "dayuse"
 										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Batch Delete Activity by Activity Type",
-							"request": {
-								"method": "DELETE",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\"\r\n    }\r\n]",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"activities",
-										":orcs"
 									],
 									"variable": [
 										{
 											"key": "orcs",
 											"value": "998"
-										}
-									],
-									"query": [
-										{
-											"key": "activityType",
-											"value": "dayuse"
 										}
 									]
 								}
@@ -1293,7 +1254,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::1\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1326,40 +1287,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed here too\"\r\n    }\r\n]",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{base_url}}/activities/:orcs",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"activities",
-										":orcs"
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "997"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Batch Delete Activity by ORCS",
-							"request": {
-								"method": "DELETE",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityType\": \"dayuse\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Hiking trail renamed\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed here too\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/docs/postman/BCParks PRDT Reservation System.postman_collection.json
+++ b/docs/postman/BCParks PRDT Reservation System.postman_collection.json
@@ -949,27 +949,443 @@
 			"name": "Activities",
 			"item": [
 				{
-					"name": "Get Activities",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/activities?orcs=7",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"activities"
-							],
-							"query": [
-								{
-									"key": "orcs",
-									"value": "7"
+					"name": "Activity by Activity ID",
+					"item": [
+						{
+							"name": "Get Activity by Activity ID",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										},
+										{
+											"key": "activityId",
+											"value": "1"
+										}
+									]
 								}
-							]
+							},
+							"response": []
+						},
+						{
+							"name": "Post Activity by Activity ID",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"pk\": \"activity::999\",\r\n    \"sk\": \"dayuse::1\",\r\n    \"orcs\": 999,\r\n    \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n    \"description\": \"Hiking trail north side\",\r\n    \"schema\": \"activity\",\r\n    \"activityType\": \"dayuse\",\r\n    \"subActivityType\": \"vehicleParking\",\r\n    \"identifier\": 1,\r\n    \"activityId\": 1,\r\n    \"geozone\": \"geozone::bcparks::999#1\",\r\n    \"facilities\": [\r\n        \"parking::1\"\r\n    ],\r\n    \"isVisible\": true,\r\n    \"imageUrl\": \"www.example.com\",\r\n    \"searchTerms\": [\r\n        \"Cheakamus\",\r\n        \"Activity\",\r\n        \"Dayuse\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										},
+										{
+											"key": "activityId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Put Activity by Activity ID",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"sk\": \"dayuse::1\",\r\n    \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										},
+										{
+											"key": "activityId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Activity by Activity ID",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse&activityId=1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "999"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										},
+										{
+											"key": "activityId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
+				},
+				{
+					"name": "Activity by Activity Type",
+					"item": [
+						{
+							"name": "Get Activity by Activity Type",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs/?activityType=dayuse",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Post Activities by Activity Type",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"pk\": \"activity::998\",\r\n        \"sk\": \"dayuse::1\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::998#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::998\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::998#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Put Activities by Activity Type",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Dayuse Spot 1 New Name Here\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\",\r\n        \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Delete Activity by Activity Type",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\"\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "998"
+										}
+									],
+									"query": [
+										{
+											"key": "activityType",
+											"value": "dayuse"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Activity by ORCS",
+					"item": [
+						{
+							"name": "Get Activity by ORCS",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "997"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Post Activities by ORCS",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::1\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "997"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Put Activities by ORCS",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityId\": \"2\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed here too\"\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "997"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Batch Delete Activity by ORCS",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\"\r\n    },\r\n    {\r\n        \"sk\": \"dayuse::2\",\r\n        \"activityType\": \"dayuse\"\r\n    }\r\n]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/activities/:orcs",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"activities",
+										":orcs"
+									],
+									"variable": [
+										{
+											"key": "orcs",
+											"value": "997"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				}
 			]
 		},

--- a/lib/handlers/activities/_orcs/DELETE/index.js
+++ b/lib/handlers/activities/_orcs/DELETE/index.js
@@ -16,20 +16,21 @@ exports.handler = async (event, context) => {
       throw new Exception("orcs is required", { code: 400 });
     }
 
-    const { activityType, activityId } = event?.queryStringParameters || {};
-    const deleteItems = [];
-    // Check if request is a batch request or a single request
-    if (Array.isArray(body)) {
-      for (let item of body) {
-        const { sk } = item;
-        deleteItems.push(processItem(orcs, activityType, activityId, sk))
-      }
-    } else {
-      deleteItems.push(createDeleteCommand(orcs, activityType, activityId))
+    if (body) {
+      throw new Exception("Body is not allowed", { code: 400 });
     }
 
-    // Use batchTransactData to put the database
-    const res = await batchTransactData(deleteItems);
+    // Grab the activityType or activityId
+    const { activityType, activityId } = event?.queryStringParameters || {};
+
+    if (!activityType && !activityId) {
+      throw new Exception("activityType and activityId are required", { code: 400 });
+    }
+    
+    const deleteItem = createDeleteCommand(orcs, activityType, activityId)
+    
+    // Use batchTransactData to delete the database item
+    const res = await batchTransactData([deleteItem]);
     return sendResponse(200, res, "Success", null, context);
   } catch (error) {
     return sendResponse(
@@ -42,15 +43,10 @@ exports.handler = async (event, context) => {
   }
 };
 
-function processItem(orcs, activityType, activityId, sk, item) {
-  validateSortKey(activityType, activityId, sk);
-  return createDeleteCommand(orcs, activityType, activityId, sk);
-}
-
-function createDeleteCommand(orcs, activityType, activityId, sk = undefined) {
+function createDeleteCommand(orcs, activityType, activityId) {
   // Use sk if provided in a batch request, otherwise there won't be an sk
   // so use the pathParams to create sk
-  const sortKey = sk || `${activityType}::${activityId}`;
+  const sortKey = `${activityType}::${activityId}`;
   return {
     action: "Delete",
     data: {

--- a/lib/handlers/activities/_orcs/DELETE/index.js
+++ b/lib/handlers/activities/_orcs/DELETE/index.js
@@ -1,0 +1,65 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
+const { validateSortKey } = require("/opt/activities/methods");
+
+/**
+ * @api {delete} /activities/{orcs}/ DELETE
+ * Delete Activities
+ */
+exports.handler = async (event, context) => {
+  logger.info("DELETE Activities", event);
+  try {
+    const orcs = event?.pathParameters?.orcs;
+    const body = JSON.parse(event?.body);
+
+    if (!orcs) {
+      throw new Exception("orcs is required", { code: 400 });
+    }
+
+    const { activityType, activityId } = event?.queryStringParameters || {};
+    const deleteItems = [];
+    // Check if request is a batch request or a single request
+    if (Array.isArray(body)) {
+      for (let item of body) {
+        const { sk } = item;
+        deleteItems.push(processItem(orcs, activityType, activityId, sk))
+      }
+    } else {
+      deleteItems.push(createDeleteCommand(orcs, activityType, activityId))
+    }
+
+    // Use batchTransactData to put the database
+    const res = await batchTransactData(deleteItems);
+    return sendResponse(200, res, "Success", null, context);
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};
+
+function processItem(orcs, activityType, activityId, sk, item) {
+  validateSortKey(activityType, activityId, sk);
+  return createDeleteCommand(orcs, activityType, activityId, sk);
+}
+
+function createDeleteCommand(orcs, activityType, activityId, sk = undefined) {
+  // Use sk if provided in a batch request, otherwise there won't be an sk
+  // so use the pathParams to create sk
+  const sortKey = sk || `${activityType}::${activityId}`;
+  return {
+    action: "Delete",
+    data: {
+      TableName: TABLE_NAME,
+      Key: marshall({
+        pk: `activity::${orcs}`,
+        sk: sortKey,
+      }),
+      ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",
+    },
+  };
+}

--- a/lib/handlers/activities/_orcs/GET/index.js
+++ b/lib/handlers/activities/_orcs/GET/index.js
@@ -43,9 +43,7 @@ exports.handler = async (event, context) => {
     });
 
     if (activityType && activityId) {
-      console.log('asdf >>>', activityType, activityId)
       res = await getActivityByActivityId(orcs, activityType, activityId);
-      console.log('res', res)
     }
 
     if (activityType && !activityId) {

--- a/lib/handlers/activities/_orcs/GET/index.js
+++ b/lib/handlers/activities/_orcs/GET/index.js
@@ -4,7 +4,7 @@ const {
   getActivityByActivityId,
 } = require("/opt/activities/methods");
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { ALLOWED_FILTERS } = require("/opt/activities/constants");
+const { ALLOWED_FILTERS } = require("/opt/activities/configs");
 
 /**
  * @api {get} /activities/{orcs} GET
@@ -19,9 +19,8 @@ exports.handler = async (event, context) => {
 
   try {
     const orcs = event?.pathParameters?.orcs;
-
     if (!orcs) {
-      throw new Exception("Orcs is required", { code: 400 });
+      throw new Exception("ORCS is required", { code: 400 });
     }
 
     const { activityType, activityId, ...queryParams } =

--- a/lib/handlers/activities/_orcs/GET/index.js
+++ b/lib/handlers/activities/_orcs/GET/index.js
@@ -1,0 +1,80 @@
+const {
+  getActivitiesByOrcs,
+  getActivitiesByActivityType,
+  getActivityByActivityId,
+} = require("/opt/activities/methods");
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { ALLOWED_FILTERS } = require("/opt/activities/constants");
+
+/**
+ * @api {get} /activities/{orcs} GET
+ * Fetch Activities
+ */
+exports.handler = async (event, context) => {
+  logger.info("GET Activities", event);
+
+  if (event?.httpMethod === "OPTIONS") {
+    return sendResponse(200, null, "Success", null, context);
+  }
+
+  try {
+    const orcs = event?.pathParameters?.orcs;
+
+    if (!orcs) {
+      throw new Exception("Orcs is required", { code: 400 });
+    }
+
+    const { activityType, activityId, ...queryParams } =
+      event?.queryStringParameters || {};
+
+    let filters = {};
+    let allowedFilters = ALLOWED_FILTERS;
+    // Loop through each allowed filter to check if it's in queryParams
+    allowedFilters.forEach((filter) => {
+      if (queryParams[filter.name]) {
+        // If the filter.name is found in queryParams, add it to the result object
+        filters[filter.name] =
+          queryParams[filter.name] === "true"
+            ? true
+            : queryParams[filter.name] === "false"
+            ? false
+            : queryParams[filter.name];
+      }
+    });
+
+    if (activityType && activityId) {
+      console.log('asdf >>>', activityType, activityId)
+      res = await getActivityByActivityId(orcs, activityType, activityId);
+      console.log('res', res)
+    }
+
+    if (activityType && !activityId) {
+      res = await getActivitiesByActivityType(
+        orcs,
+        activityType,
+        filters,
+        event?.queryStringParameters || null
+      );
+    }
+
+    if (!activityType && !activityId) {
+      res = await getActivitiesByOrcs(
+        orcs,
+        filters,
+        event?.queryStringParameters || null
+      );
+    }
+
+    return sendResponse(200, res, "Success", null, context);
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};
+
+

--- a/lib/handlers/activities/_orcs/POST/index.js
+++ b/lib/handlers/activities/_orcs/POST/index.js
@@ -1,0 +1,77 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { quickApiPutHandler } = require("/opt/data-utils");
+const { ACTIVITY_API_PUT_CONFIG } = require("/opt/activities/configs");
+const { validateSortKey } = require("/opt/activities/methods");
+const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+
+/**
+ * @api {post} /activities/{orcs} POST
+ * Create Activities
+ */
+exports.handler = async (event, context) => {
+  logger.info("POST Activities", event);
+  try {
+    const orcs = String(event?.pathParameters?.orcs);
+
+    if (!orcs) {
+      throw new Exception("Orcs is required", { code: 400 });
+    }
+
+    const body = JSON.parse(event?.body);
+    if (!body) {
+      throw new Exception("Body is required", { code: 400 });
+    }
+
+    // Grab the activityType or activityId if provided
+    const { activityType, activityId } = event?.queryStringParameters || {};
+    let postRequests = [];
+    // Process batch request or a single request
+    if (Array.isArray(body)) {
+      for (let item of body) {
+        const { sk } = item;
+        postRequests.push(processItem(orcs, activityType, activityId, sk, item));
+      }
+    } else {
+      const { sk } = body;
+      postRequests.push(processItem(orcs, activityType, activityId, sk, body));
+    }
+
+    // Use quickApiPutHandler to create the put items
+    const putItems = await quickApiPutHandler(
+      TABLE_NAME,
+      postRequests,
+      ACTIVITY_API_PUT_CONFIG
+    );
+
+    // Use batchTransactData to put the database
+    const res = await batchTransactData(putItems);
+
+    return sendResponse(200, res, "Success", null, context);
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};
+
+function processItem(orcs, activityType, activityId, sk, item) {
+  validateSortKey(activityType, activityId, sk)
+  return createPostCommand(orcs, activityType, activityId, sk, item);
+}
+
+function createPostCommand(orcs, activityType, activityId, sk, item) {
+  const pk = `activity::${orcs}`;
+  sk = sk ? sk : `${activityType}::${activityId}`;
+
+  item.pk = pk;
+  item.sk = sk
+
+  return {
+    key: { pk: pk, sk: sk },
+    data: item,
+  };
+}

--- a/lib/handlers/activities/_orcs/POST/index.js
+++ b/lib/handlers/activities/_orcs/POST/index.js
@@ -1,7 +1,7 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { quickApiPutHandler } = require("/opt/data-utils");
 const { ACTIVITY_API_PUT_CONFIG } = require("/opt/activities/configs");
-const { validateSortKey } = require("/opt/activities/methods");
+const { parseRequest } = require("/opt/activities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
@@ -12,7 +12,6 @@ exports.handler = async (event, context) => {
   logger.info("POST Activities", event);
   try {
     const orcs = String(event?.pathParameters?.orcs);
-
     if (!orcs) {
       throw new Exception("Orcs is required", { code: 400 });
     }
@@ -22,19 +21,8 @@ exports.handler = async (event, context) => {
       throw new Exception("Body is required", { code: 400 });
     }
 
-    // Grab the activityType or activityId if provided
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let postRequests = [];
-    // Process batch request or a single request
-    if (Array.isArray(body)) {
-      for (let item of body) {
-        const { sk } = item;
-        postRequests.push(processItem(orcs, activityType, activityId, sk, item));
-      }
-    } else {
-      const { sk } = body;
-      postRequests.push(processItem(orcs, activityType, activityId, sk, body));
-    }
+    let postRequests = parseRequest(orcs, activityType, activityId, body, "POST");
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(
@@ -57,21 +45,3 @@ exports.handler = async (event, context) => {
     );
   }
 };
-
-function processItem(orcs, activityType, activityId, sk, item) {
-  validateSortKey(activityType, activityId, sk)
-  return createPostCommand(orcs, activityType, activityId, sk, item);
-}
-
-function createPostCommand(orcs, activityType, activityId, sk, item) {
-  const pk = `activity::${orcs}`;
-  sk = sk ? sk : `${activityType}::${activityId}`;
-
-  item.pk = pk;
-  item.sk = sk
-
-  return {
-    key: { pk: pk, sk: sk },
-    data: item,
-  };
-}

--- a/lib/handlers/activities/_orcs/PUT/index.js
+++ b/lib/handlers/activities/_orcs/PUT/index.js
@@ -1,9 +1,7 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { quickApiUpdateHandler } = require("/opt/data-utils");
 const { ACTIVITY_API_UPDATE_CONFIG } = require("/opt/activities/configs");
-const {
-  validateSortKey,
-} = require("/opt/activities/methods");
+const { parseRequest } = require("/opt/activities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
@@ -14,30 +12,17 @@ exports.handler = async (event, context) => {
   logger.info("PUT Activities", event);
   try {
     const orcs = event?.pathParameters?.orcs;
-    const body = JSON.parse(event?.body);
-
     if (!orcs) {
       throw new Exception("Orcs is required", { code: 400 });
     }
-
+    
+    const body = JSON.parse(event?.body);
     if (!body) {
       throw new Exception("Body is required", { code: 400 });
     }
 
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let updateRequests = [];
-    // Check if the request is a batch request
-    if (Array.isArray(body)) {
-      for (let item of body) {
-        const { sk } = item;
-        updateRequests.push(processItem(orcs, activityType, activityId, sk, item));
-      }
-    } else {
-      const { sk } = body;
-      updateRequests.push(
-        processItem(orcs, activityType, activityId, sk, body)
-      );
-    }
+    let updateRequests = parseRequest(orcs, activityType, activityId, body, "PUT");
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(

--- a/lib/handlers/activities/_orcs/PUT/index.js
+++ b/lib/handlers/activities/_orcs/PUT/index.js
@@ -2,7 +2,6 @@ const { Exception, logger, sendResponse } = require("/opt/base");
 const { quickApiUpdateHandler } = require("/opt/data-utils");
 const { ACTIVITY_API_UPDATE_CONFIG } = require("/opt/activities/configs");
 const {
-  validateRequiredFields,
   validateSortKey,
 } = require("/opt/activities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
@@ -31,7 +30,6 @@ exports.handler = async (event, context) => {
     if (Array.isArray(body)) {
       for (let item of body) {
         const { sk } = item;
-        console.log('item >>>', item)
         updateRequests.push(processItem(orcs, activityType, activityId, sk, item));
       }
     } else {
@@ -64,13 +62,11 @@ exports.handler = async (event, context) => {
 };
 
 function processItem(orcs, activityType, activityId, sk, item) {
-  console.log('item2 >>>', item)
   validateSortKey(activityType, activityId, sk);
   return createPutCommand(orcs, activityType, activityId, sk, item);
 }
 
 function createPutCommand(orcs, activityType, activityId, sk, item) {
-  console.log('item3 >>>', item)
   const pk = `activity::${orcs}`;
   sk = sk ? sk : `${activityType}::${activityId}`;
 

--- a/lib/handlers/activities/_orcs/PUT/index.js
+++ b/lib/handlers/activities/_orcs/PUT/index.js
@@ -1,0 +1,88 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { quickApiUpdateHandler } = require("/opt/data-utils");
+const { ACTIVITY_API_UPDATE_CONFIG } = require("/opt/activities/configs");
+const {
+  validateRequiredFields,
+  validateSortKey,
+} = require("/opt/activities/methods");
+const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+
+/**
+ * @api {put} /activities/{orcs} PUT
+ * Update Activities
+ */
+exports.handler = async (event, context) => {
+  logger.info("PUT Activities", event);
+  try {
+    const orcs = event?.pathParameters?.orcs;
+    const body = JSON.parse(event?.body);
+
+    if (!orcs) {
+      throw new Exception("Orcs is required", { code: 400 });
+    }
+
+    if (!body) {
+      throw new Exception("Body is required", { code: 400 });
+    }
+
+    const { activityType, activityId } = event?.queryStringParameters || {};
+    let updateRequests = [];
+    // Check if the request is a batch request
+    if (Array.isArray(body)) {
+      for (let item of body) {
+        const { sk } = item;
+        console.log('item >>>', item)
+        updateRequests.push(processItem(orcs, activityType, activityId, sk, item));
+      }
+    } else {
+      const { sk } = body;
+      updateRequests.push(
+        processItem(orcs, activityType, activityId, sk, body)
+      );
+    }
+
+    // Use quickApiPutHandler to create the put items
+    const updateItems = await quickApiUpdateHandler(
+      TABLE_NAME,
+      updateRequests,
+      ACTIVITY_API_UPDATE_CONFIG
+    );
+
+    // Use batchTransactData to update the database
+    const res = await batchTransactData(updateItems);
+
+    return sendResponse(200, res, "Success", null, context);
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};
+
+function processItem(orcs, activityType, activityId, sk, item) {
+  console.log('item2 >>>', item)
+  validateSortKey(activityType, activityId, sk);
+  return createPutCommand(orcs, activityType, activityId, sk, item);
+}
+
+function createPutCommand(orcs, activityType, activityId, sk, item) {
+  console.log('item3 >>>', item)
+  const pk = `activity::${orcs}`;
+  sk = sk ? sk : `${activityType}::${activityId}`;
+
+  // Remove pk, sk, activityType, and activityId as these can't be updated
+  delete item.pk;
+  delete item.sk;
+  delete item.activityType;
+  delete item.activityId;
+
+  return {
+    key: { pk: pk, sk: sk },
+    data: item,
+  };
+}
+

--- a/lib/handlers/activities/resources.js
+++ b/lib/handlers/activities/resources.js
@@ -1,0 +1,86 @@
+/**
+ * CDK resources for the activities API.
+ */
+const lambda = require('aws-cdk-lib/aws-lambda');
+const apigateway = require('aws-cdk-lib/aws-apigateway');
+const iam = require('aws-cdk-lib/aws-iam');
+const { NodejsFunction } = require("aws-cdk-lib/aws-lambda-nodejs");
+
+function activitiesSetup(scope, props) {
+  console.log('activities handlers setup...')
+
+  // /activities resource
+  const activitiesResource = props.api.root.addResource('activities');
+
+  // /activities/{orcs}/ resource
+  const activitiesOrcsResource = activitiesResource.addResource('{orcs}');
+
+  // GET /activities/{orcs}
+  const activitiesGetByOrcs = new NodejsFunction(scope, 'ActivitiesGetByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/GET'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  activitiesOrcsResource.addMethod('GET', new apigateway.LambdaIntegration(activitiesGetByOrcs));
+  
+  // POST /activities/{orcs}
+  const activitiesPostByOrcs = new NodejsFunction(scope, 'ActivitiesPostByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/POST'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  activitiesOrcsResource.addMethod('POST', new apigateway.LambdaIntegration(activitiesPostByOrcs));
+  
+  // PUT /activities/{orcs}
+  const activitiesPutByOrcs = new NodejsFunction(scope, 'ActivitiesPutByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/PUT'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  activitiesOrcsResource.addMethod('PUT', new apigateway.LambdaIntegration(activitiesPutByOrcs));
+  
+  // DELETE /activities/{orcs}
+  const activitiesDeleteByOrcs = new NodejsFunction(scope, 'ActivitiesDeleteByOrcs', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/DELETE'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  activitiesOrcsResource.addMethod('DELETE', new apigateway.LambdaIntegration(activitiesDeleteByOrcs));
+
+  // Add DynamoDB query & getItem policies to the functions
+  const dynamoDbPolicy = new iam.PolicyStatement({
+    actions: [
+      'dynamodb:Query',
+      'dynamodb:GetItem',
+      'dynamodb:BatchWrite*',
+      'dynamodb:PutItem',
+      'dynamodb:Delete*',
+    ],
+    resources: [props.mainTable.tableArn],
+  });
+
+  activitiesGetByOrcs.addToRolePolicy(dynamoDbPolicy);
+  activitiesPostByOrcs.addToRolePolicy(dynamoDbPolicy);
+  activitiesPutByOrcs.addToRolePolicy(dynamoDbPolicy);
+  activitiesDeleteByOrcs.addToRolePolicy(dynamoDbPolicy);
+
+  return {
+    activitiesGetByOrcs: activitiesGetByOrcs,
+    activitiesPostByOrcs: activitiesPostByOrcs,
+    activitiesPutByOrcs: activitiesPutByOrcs,
+    activitiesDeleteByOrcs: activitiesDeleteByOrcs,
+    activitiesResource: activitiesResource
+  };
+}
+
+module.exports = {
+  activitiesSetup
+};

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -1,0 +1,228 @@
+const { rulesFns } = require('/opt/validation-rules');
+
+const rf = new rulesFns();
+
+const SUB_ACTIVITY_TYPE_ENUMS = [
+  'campsite',
+  'walkin',
+  'rv',
+  'reservation',
+  'passport',
+  'vehicleParking',
+  'trailUse',
+  'shelterUse',
+  'saniUse',
+  'showerUse',
+  'elecUse',
+  'dockMooring',
+  'buoyMooring',
+  'frontcountry',
+  'backcountry',
+  'portionCircuit',
+  'fullCircuit',
+]
+const ACTIVITY_TYPE_ENUMS = [
+  'frontcountryCamp',
+  'backcountryCamp',
+  'groupCamp',
+  'dayuse',
+  'boating',
+  'cabinStay',
+  'canoe'
+];
+
+
+const ACTIVITY_API_PUT_CONFIG = {
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    orcs: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    displayName: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    description: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    schema: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ['activity']),
+        rf.expectAction(action, ['add']);
+      }
+    },
+    activityType: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS),
+        rf.expectAction(action, ['add']);
+      }
+    },
+    subActivityType: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS),
+        rf.expectAction(action, ['add']);
+      }
+    },
+    identifier: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    activityId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    geozone: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    facilities: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectArray(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    isVisible: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    },
+    searchTerms: {
+      rulesFn: ({ value, action }) => {
+        rf.expectArray(value, ['string']);
+        rf.expectAction(action, ['add']);
+      }
+    }
+  }
+}
+
+const ACTIVITY_API_UPDATE_CONFIG = {
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  fields: {
+    displayName: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    description: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    schema: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ['activity']),
+        rf.expectAction(action, ['set']);
+      }
+    },
+    activityType: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS),
+        rf.expectAction(action, ['set']);
+      }
+    },
+    subActivityType: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS),
+        rf.expectAction(action, ['set']);
+      }
+    },
+    identifier: {
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    activityId: {
+      rulesFn: ({ value, action }) => {
+        rf.expectInteger(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    geozone: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    facilities: {
+      rulesFn: ({ value, action }) => {
+        rf.expectArray(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    isVisible: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    searchTerms: {
+      rulesFn: ({ value, action }) => {
+        rf.expectArray(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    }
+  }
+}
+
+module.exports = {
+  ACTIVITY_API_PUT_CONFIG,
+  ACTIVITY_API_UPDATE_CONFIG
+}

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -2,6 +2,13 @@ const { rulesFns } = require('/opt/validation-rules');
 
 const rf = new rulesFns();
 
+ALLOWED_FILTERS = [
+  { name: "isVisible", type: "boolean" },
+  { name: "activityType", type: "list" },
+  { name: "subActivityType", type: "list" },
+  { name: "facilities", type: "list" }
+];
+
 const SUB_ACTIVITY_TYPE_ENUMS = [
   'campsite',
   'walkin',
@@ -224,5 +231,6 @@ const ACTIVITY_API_UPDATE_CONFIG = {
 
 module.exports = {
   ACTIVITY_API_PUT_CONFIG,
-  ACTIVITY_API_UPDATE_CONFIG
+  ACTIVITY_API_UPDATE_CONFIG,
+  ALLOWED_FILTERS
 }

--- a/lib/layers/dataUtils/activities/constants.js
+++ b/lib/layers/dataUtils/activities/constants.js
@@ -1,8 +1,0 @@
-ALLOWED_FILTERS = [
-  { name: "isVisible", type: "boolean" },
-  { name: "activityType", type: "list" },
-  { name: "subActivityType", type: "list" },
-  { name: "facilities", type: "list" }
-];
-
-module.exports = { ALLOWED_FILTERS };

--- a/lib/layers/dataUtils/activities/constants.js
+++ b/lib/layers/dataUtils/activities/constants.js
@@ -1,0 +1,8 @@
+ALLOWED_FILTERS = [
+  { name: "isVisible", type: "boolean" },
+  { name: "activityType", type: "list" },
+  { name: "subActivityType", type: "list" },
+  { name: "facilities", type: "list" }
+];
+
+module.exports = { ALLOWED_FILTERS };

--- a/lib/layers/dataUtils/activities/methods.js
+++ b/lib/layers/dataUtils/activities/methods.js
@@ -1,51 +1,212 @@
-const { TABLE_NAME, batchGetData, runQuery, getOne } = require('/opt/dynamodb');
-const { buildCompKeysFromSkField } = require('/opt/data-utils');
-const { Exception, logger } = require('/opt/base');
-const { getProductsByActivity } = require('/opt/products/methods');
+const { TABLE_NAME, runQuery, getOne, marshall } = require("/opt/dynamodb");
+const { Exception, logger } = require("/opt/base");
+const { ALLOWED_FILTERS } = require("/opt/activities/constants");
 
-async function getActivitiesByOrcs(orcs, params = null) {
-  logger.info('Get Activities');
+/**
+ * Adds any filter expressions if any filters were added to query.
+ *
+ * @param {Object} queryObj - The object query
+ * @param {Array} filters - Filter items that are passed from the query
+ *
+ * @returns {Object} the queryObj with any FilterExpressions added
+ *
+ */
+function addFilters(queryObj, filters) {
   try {
-    if (!orcs) {
-      throw 'ORCS is required';
-    }
+    ALLOWED_FILTERS.forEach((item) => {
+      if (item.name in filters) {
+        if (queryObj.FilterExpression) {
+          queryObj.FilterExpression += " AND ";
+        }
+        if (!queryObj.ExpressionAttributeNames) {
+          queryObj.ExpressionAttributeNames = {};
+        }
+        if (!queryObj.FilterExpression) {
+          queryObj.FilterExpression = "";
+        }
+
+        if (item.type == "list") {
+          queryObj.FilterExpression += `contains(#${item.name}, :${item.name})`;
+        } else {
+          queryObj.FilterExpression += `#${item.name} = :${item.name}`;
+        }
+
+        queryObj.ExpressionAttributeNames[`#${item.name}`] = item.name;
+        queryObj.ExpressionAttributeValues[`:${item.name}`] = marshall(
+          filters[item.name]
+        );
+      }
+    });
+    
+    return queryObj;
+  } catch (error) {
+    throw error;
+  }
+}
+
+/**
+ * Retrieves all activities matching an Orcs.
+ *
+ * @async
+ * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} [params] - Optional parameters for pagination control.
+ * @param {number} [params.limit] - Maximum number of items to return.
+ * @param {string} [params.lastEvaluatedKey] - Key to resume pagination from.
+ * @param {boolean} [params.paginated=true] - Whether to enable pagination.
+ *
+ * @returns {Promise<Object>} Query response containing:
+ *   - items: Array of activity objects
+ *   - lastEvaluatedKey: Key for pagination continuation
+ *   - count: Number of items returned
+ *
+ * @throws {Exception} With code 400 if database operation fails
+ *
+ */
+async function getActivitiesByOrcs(orcs, filters, params = null) {
+  logger.info("Get Activities by Orcs");
+  try {
     const limit = params?.limit || null;
     const lastEvaluatedKey = params?.lastEvaluatedKey || null;
     const paginated = params?.paginated || true;
-    const queryObj = {
+    let queryObj = {
       TableName: TABLE_NAME,
-      KeyConditionExpression: 'pk = :pk',
+      KeyConditionExpression: "pk = :pk",
       ExpressionAttributeValues: {
-        ':pk': { S: `activity::${orcs}` }
-      }
+        ":pk": { S: `activity::${orcs}` },
+      },
     };
+
+    if (Object.keys(filters).length > 0) {
+      queryObj = addFilters(queryObj, filters);
+    }
+
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Activities: ${res?.items?.length} found.`);
     return res;
   } catch (error) {
-    throw new Exception('Error getting activities', { code: 400, error: error });
+    throw new Exception("Error getting activities", {
+      code: 400,
+      error: error,
+    });
   }
 }
 
-async function getActivityById(orcs, type, id, fetchObj = null) {
-  logger.info('Get Activity By Type and ID');
+/**
+ * Retrieves activities matching the specified activity type.
+ *
+ * @async
+ * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} activityType - Type of activity to retrieve.
+ * @param {Object} [params] - Optional parameters for pagination control.
+ * @param {number} [params.limit] - Maximum number of items to return.
+ * @param {string} [params.lastEvaluatedKey] - Key to resume pagination from.
+ * @param {boolean} [params.paginated=true] - Whether to enable pagination.
+ *
+ * @returns {Promise<Object>} Query response containing:
+ *   - items: Array of activity objects
+ *   - lastEvaluatedKey: Key for pagination continuation
+ *   - count: Number of items returned
+ *
+ * @throws {Exception} With code 400 if database operation fails
+ */
+async function getActivitiesByActivityType(
+  orcs,
+  activityType,
+  filters,
+  params = null
+) {
+  logger.info("Get Activity by activity type");
   try {
-    let res = await getOne(`activity::${orcs}`, `${type}::${id}`);
-    if (fetchObj?.fetchProducts) {
-      const products = await getProductsByActivity(orcs, type, id);
-      res.products = products?.items || [];
+    const limit = params?.limit || null;
+    const lastEvaluatedKey = params?.lastEvaluatedKey || null;
+    const paginated = params?.paginated || true;
+    let queryObj = {
+      TableName: TABLE_NAME,
+      KeyConditionExpression: "pk = :pk AND begins_with(sk, :sk)",
+      ExpressionAttributeValues: {
+        ":pk": { S: `activity::${orcs}` },
+        ":sk": { S: `${activityType}::` },
+      },
+    };
+
+    if (Object.keys(filters).length > 0) {
+      queryObj = addFilters(queryObj, filters);
     }
-    if (fetchObj?.fetchFacilities && res.facilities) {
-      let keys = buildCompKeysFromSkField(res, `facility::${orcs}`, 'facilities');
-      res.facilities = await batchGetData(keys, TABLE_NAME);
-    }
+
+    const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
+    logger.info(`Activities: ${res?.items?.length} found.`);
     return res;
   } catch (error) {
-    throw new Exception('Error getting activity', { code: 400, error: error });
+    throw new Exception("Error getting activities", {
+      code: 400,
+      error: error,
+    });
+  }
+}
+
+/**
+ * Retrieves activities matching the specified activity type.
+ *
+ * @async
+ * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} activityType - Type of activity to retrieve.
+ * @param {Object} activityId - The ID of the activity to retrieve.
+ *
+ * @returns {Promise<Object>} Query response containing:
+ *   - items: activity object
+ *
+ * @throws {Exception} With code 400 if database operation fails
+ */
+async function getActivityByActivityId(orcs, activityType, activityId) {
+  logger.info("Get Activity By activity type and ID");
+  console.log('in here')
+  try {
+    let res = await getOne(
+      `activity::${orcs}`,
+      `${activityType}::${activityId}`
+    );
+    console.log('res?', res)
+    return res;
+
+  } catch (error) {
+    throw new Exception("Error getting activity", { code: 400, error: error });
+  }
+}
+
+/**
+ * Validates that the sort key is valid from the activityType and activityId if provided.
+ *
+ * @param {Object} activityType - Type of activity
+ * @param {Object} activityId- The ID of the activity
+ * @param {Object} sk- The sort key of the activity
+ *
+ * @returns {void}
+ *
+ * @throws {Exception} With code 400 if there's a mismatch between sk and activityType::activityId
+ */
+function validateSortKey(activityType, activityId, sk) {
+  if (!sk && !activityType && !activityId) {
+    throw new Exception("sk or activityType and activityId are required.", {
+      code: 400,
+    });
+  }
+
+  if (activityType && sk?.split("::")[0] !== activityType) {
+    throw new Exception("sk does not match activityType", {
+      code: 400,
+    });
+  }
+
+  if (activityId && sk?.split("::")[1] != activityId) {
+    throw new Exception("sk does not match activityId", {
+      code: 400,
+    });
   }
 }
 
 module.exports = {
   getActivitiesByOrcs,
-  getActivityById
+  getActivitiesByActivityType,
+  getActivityByActivityId,
+  validateSortKey,
 };

--- a/lib/layers/dataUtils/activities/methods.js
+++ b/lib/layers/dataUtils/activities/methods.js
@@ -1,6 +1,6 @@
 const { TABLE_NAME, runQuery, getOne, marshall } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
-const { ALLOWED_FILTERS } = require("/opt/activities/constants");
+const { ALLOWED_FILTERS } = require("/opt/activities/configs");
 
 /**
  * Adds any filter expressions if any filters were added to query.
@@ -17,12 +17,11 @@ function addFilters(queryObj, filters) {
       if (item.name in filters) {
         if (queryObj.FilterExpression) {
           queryObj.FilterExpression += " AND ";
+        } else if (!queryObj.FilterExpression) {
+          queryObj.FilterExpression = "";
         }
         if (!queryObj.ExpressionAttributeNames) {
           queryObj.ExpressionAttributeNames = {};
-        }
-        if (!queryObj.FilterExpression) {
-          queryObj.FilterExpression = "";
         }
 
         if (item.type == "list") {
@@ -174,6 +173,88 @@ async function getActivityByActivityId(orcs, activityType, activityId) {
 }
 
 /**
+ * Processes incoming requests by handling batch operations and individual items.
+ * Validates activityType and activityId parameters, falling back to body values if needed.
+ *
+ * @param {Object} orcs - ORCS number
+ * @param {string} activityType - Type of activity
+ * @param {string} activityId - ID of the activity
+ * @param {Object|Array} body - Request payload (single item or array of items)
+ * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ *
+ * @returns {Array} Array of processed update requests
+ */
+function parseRequest(orcs, activityType, activityId, body, requestType) {
+  let updateRequests = [];
+  // Check if the request is a batch request
+  if (Array.isArray(body)) {
+    for (let item of body) {
+      const { sk } = item;
+      updateRequests.push(
+        processItem(orcs, activityType, activityId, sk, item, requestType)
+      );
+    }
+  } else {
+    const { sk } = body;
+    updateRequests.push(
+      processItem(orcs, activityType, activityId, sk, body, requestType)
+    );
+  }
+
+  return updateRequests;
+}
+
+/**
+ * Processes individual items based on request type, creating appropriate key structures.
+ * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
+ *
+ * @param {Object} orcs - ORCS number
+ * @param {string} activityType - Type of activity
+ * @param {string} activityId - ID of the activity
+ * @param {string} [sk] - Optional sort key (defaults to ${activityType}::${activityId})
+ * @param {Object} item - Item data to process
+ * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ *
+ * @returns {Object} Processed item with key structure and data
+ */
+function processItem(orcs, activityType, activityId, sk, item, requestType) {  
+  activityType = activityType ?? item?.activityType;
+  activityId = activityId ?? item?.activityId;
+  
+  if (!sk) {
+    if (item.activityType && activityType != item.activityType) {
+      throw new Error(`activityType endpoint "${activityType}" doesn't match body's "${item.activityType}"`, { code: 400 });
+    }
+    if (item.activityId && activityId != item.activityId) {
+      throw new Error(`activityId endpoint "${activityId}" doesn't match body's "${item.activityId}"`, { code: 400 });
+    }
+  }
+    
+  const pk = `activity::${orcs}`;
+  sk = sk ? sk : `${activityType}::${activityId}`;
+  
+  validateSortKey(activityType, activityId, sk);
+
+  if (requestType == "PUT") {
+    // Remove items that can't be in a PUT request
+    delete item.pk;
+    delete item.sk;
+    delete item.activityType;
+    delete item.activityId;
+  } else if (requestType == "POST") {
+    // Create items for the POST request
+    item.pk = pk;
+    item.sk = sk;
+  }
+
+  return {
+    key: { pk: pk, sk: sk },
+    data: item,
+  };
+}
+
+
+/**
  * Validates that the sort key is valid from the activityType and activityId if provided.
  *
  * @param {Object} activityType - Type of activity
@@ -185,20 +266,20 @@ async function getActivityByActivityId(orcs, activityType, activityId) {
  * @throws {Exception} With code 400 if there's a mismatch between sk and activityType::activityId
  */
 function validateSortKey(activityType, activityId, sk) {
-  if (!sk && !activityType && !activityId) {
-    throw new Exception("sk or activityType and activityId are required.", {
+  if (!sk && (!activityType && !activityId)) {
+    throw new Exception("sk, activityType, and activityId are required.", {
       code: 400,
     });
   }
 
   if (activityType && sk?.split("::")[0] !== activityType) {
-    throw new Exception("sk does not match activityType", {
+    throw new Exception(`sk "${sk}" in body does not match activityType "${activityType}"`, {
       code: 400,
     });
   }
 
   if (activityId && sk?.split("::")[1] != activityId) {
-    throw new Exception("sk does not match activityId", {
+    throw new Exception(`sk "${sk}" in body does not match activityId "${activityId}"`, {
       code: 400,
     });
   }
@@ -208,5 +289,7 @@ module.exports = {
   getActivitiesByOrcs,
   getActivitiesByActivityType,
   getActivityByActivityId,
+  parseRequest,
+  processItem,
   validateSortKey,
 };

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -14,6 +14,7 @@ const { webSocketApiSetup } = require('./cdk/websockets');
 
 // HANDLER RESOURCES
 const { authorizerSetup } = require('./handlers/authorizer/resources');
+const { activitiesSetup } = require('./handlers/activities/resources');
 const { configSetup } = require('./handlers/config/resources');
 const { geozonesSetup } = require('./handlers/geozones/resources');
 const { protectedAreasSetup } = require('./handlers/protectedAreas/resources');
@@ -95,6 +96,18 @@ class ReserveRecCdkStack extends Stack {
 
 
     // LAMBDA FUNCTION HANDLERS & RESOURCES (ALPHABETIZED)
+
+    // Activities
+    const activitiesResources = activitiesSetup(this, {
+      env: props.env,
+      api: apigwResources.api,
+      layers: [
+        layerResources.baseLayer,
+        layerResources.awsUtilsLayer,
+        layerResources.dataUtilsLayer
+      ],
+      mainTable: dynamodbResources.mainTable,
+    });
 
     // Config
     const configResources = configSetup(this, {


### PR DESCRIPTION
### Ticket:
BRS-58

### Ticket URL:
#58 

### Description:
- First-pass at adding endpoints for Activities
- Add new `GET`, `POST`, `PUT`, and `DELETE` endpoints for `activities` by orcs
  - allow batch requests or single requests
  - use `queryParams` like `activityType=dayuse` or `activityId=1` to specify specific items in the partition
  - allow further filtering on `GET` requests using `ALLOWED_FILTERS`, such as by `facilities`, `subActivityType`, or `isVisible`
- Add new configuration for `activities` creation
- Add constants folder for `ALLOWED_FILTERS`
- Update Postman collection with new endpoints