### PR TITLE
PRDT-70-1 CRUD updates for geozones

### DIFF
--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -218,7 +218,7 @@ async function quickApiPutHandler(tableName, createList, config) {
         Object.keys(itemData).map((field) => {
           dataToValidate[field] = {
             value: itemData[field],
-            action: 'add'
+            action: DEFAULT_FIELD_ACTION
           };
         });
 

--- a/lib/layers/dataUtils/geozones/configs.js
+++ b/lib/layers/dataUtils/geozones/configs.js
@@ -2,7 +2,7 @@ const { rulesFns } = require('/opt/validation-rules');
 
 const rf = new rulesFns();
 
-const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston']
+const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston'];
 
 const ALLOWED_FILTERS = [
   { name: "isVisible", type: "boolean" },
@@ -19,126 +19,140 @@ const GEOZONE_API_PUT_CONFIG = {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     sk: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     gzCollectionId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     orcs: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     displayName: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     description: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     schema: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['geozone']),
-        rf.expectAction(action, ['add']);
+          rf.expectAction(action, ['set']);
       }
     },
     identifier: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     geozoneId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     location: {
       isMandatory: true,
-      rulesFn: ({value, action}) => {
+      rulesFn: ({ value, action }) => {
         rf.expectGeopoint(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     envelope: {
       isMandatory: true,
-      rulesFn: ({value, action}) => {
-        rf.expectGeoshape(value);
-        rf.expectAction(action, ['add']);
+      rulesFn: ({ value, action }) => {
+        rf.expectEnvelope(value);
+        rf.expectAction(action, ['set']);
       }
     },
     timezone: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, TIMEZONE_ENUMS);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     isVisible: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     minMapZoom: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     maxMapZoom: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     facilities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        value.map(v => rf.expectPrimaryKey(v));
+        rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        value.map(v => rf.expectPrimaryKey(v));
+        rf.expectAction(action, ['set']);
       }
     },
     imageUrl: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    searchTerms: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
       }
     }
   }
-}
+};
 
 const GEOZONE_API_UPDATE_CONFIG = {
   failOnError: true,
@@ -160,7 +174,7 @@ const GEOZONE_API_UPDATE_CONFIG = {
     schema: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['geozone']),
-        rf.expectAction(action, ['set']);
+          rf.expectAction(action, ['set']);
       }
     },
     identifier: {
@@ -170,14 +184,14 @@ const GEOZONE_API_UPDATE_CONFIG = {
       }
     },
     location: {
-      rulesFn: ({value, action}) => {
+      rulesFn: ({ value, action }) => {
         rf.expectGeopoint(value);
         rf.expectAction(action, ['set']);
       }
     },
     envelope: {
-      rulesFn: ({value, action}) => {
-        rf.expectGeoshape(value);
+      rulesFn: ({ value, action }) => {
+        rf.expectEnvelope(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -208,12 +222,14 @@ const GEOZONE_API_UPDATE_CONFIG = {
     facilities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
+        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
+        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
@@ -222,12 +238,24 @@ const GEOZONE_API_UPDATE_CONFIG = {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    searchTerms: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
     }
   }
-}
+};
 
 module.exports = {
   ALLOWED_FILTERS,
   GEOZONE_API_PUT_CONFIG,
   GEOZONE_API_UPDATE_CONFIG
-}
+};

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -28,13 +28,13 @@ class rulesFns {
    * @param {string[]} type - An array of expected types as strings that the array contains.
    * @throws {Exception} Throws an exception if the value is not an array and if any of the values does not match the expected type.
    */
-  expectArray(value, type) {
+  expectArray(value, type = null) {
     if (!Array.isArray(value)) {
       throw new Exception(`Invalid value: expected ${JSON.stringify(value)} to be an array`, { code: 400 });
     }
-    if (!value.every(item => type.includes(typeof item))) {
+    if (type && !value.every(item => type.includes(typeof item))) {
       const actualTypes = value.map(i => typeof i);
-      throw new Exception(`Invalid types in array: expected items to be one of: [${type}], but got: [${actualTypes}]`,{ code: 400 });
+      throw new Exception(`Invalid types in array: expected items to be one of: [${type}], but got: [${actualTypes}]`, { code: 400 });
     }
   }
 
@@ -228,8 +228,8 @@ class rulesFns {
    * @throws {Exception} Throws an exception if the type is not 'Point' or if the coordinates are not a valid array with two elements.
    */
   expectGeopoint(value) {
-    if (!value?.type || value?.type !== 'Point') {
-      throw new Exception(`Invalid geopoint type: Expected 'type' to be 'Point'`, { code: 400 });
+    if (!value?.type || value?.type !== 'point') {
+      throw new Exception(`Invalid geopoint type: Expected 'type' to be 'point'`, { code: 400 });
     }
     const coords = value?.coordinates;
     if (!Array.isArray(coords) || coords.length !== 2) {
@@ -244,31 +244,26 @@ class rulesFns {
    *
    * @param {Object} value - The value to be validated.
    * @param {string} value.type - The type of the GeoJSON object, expected to be 'Envelope'.
-   * @param {Array} value.coordinates - The coordinates of the GeoJSON shape, expected to be an array of arrays with at least two elements of the format [longitude, latitude]. 
+   * @param {Array} value.coordinates - The coordinates of the GeoJSON shape, expected to be an array of arrays with at least two elements of the format [longitude, latitude].
    * @throws {Exception} Throws an exception if the type is not 'Envelope' or if the coordinates are not a valid array or arrays with at least two elements.
    */
   expectGeoshape(value) {
     // Type validation
-    if (!value?.type || (value.type !== 'Envelope' && value.type !== 'Polygon')) {
-      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'Envelope'`, { code: 400 });
+    if (!value?.type || (value.type !== 'envelope' && value.type !== 'Polygon')) {
+      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'envelope'`, { code: 400 });
     }
 
     // Coordinates validation
     const coords = value.coordinates;
-    
+
     // Check if coordinates exists and is an array
     if (!Array.isArray(coords)) {
       throw new Exception('Invalid geoshape: Coordinates must exist and be an array', { code: 400 });
     }
 
-    // Check if we have exactly one inner array
-    if (coords.length !== 1 || !Array.isArray(coords[0])) {
-      throw new Exception('Invalid geoshape: Coordinates must contain exactly one array of points', { code: 400 });
-    }
-
     // Get the array of points
     const points = coords[0];
-    
+
     // Ensure we have at least two points
     if (!Array.isArray(points) || points.length < 2) {
       throw new Exception('Invalid geoshape point coordinates: Expected coordinates to be an array with at least two elements', { code: 400 });
@@ -277,9 +272,47 @@ class rulesFns {
     // Validate each point
     for (let i = 0; i < points.length; i++) {
       const point = points[i];
-    
+
       this.expectLongitude(point[0]);
       this.expectLatitude(point[1]);
+    }
+  }
+
+  expectEnvelope(value) {
+    // Type validation
+    if (!value?.type || value.type !== 'envelope') {
+      throw new Exception(`Invalid envelope type: Expected 'type' to be 'envelope'`, { code: 400 });
+    }
+
+    // Coordinates validation
+    const coords = value.coordinates;
+
+    // Check if coordinates exists and is an array
+    if (!Array.isArray(coords)) {
+      throw new Exception('Invalid envelope: Coordinates must exist and be an array', { code: 400 });
+    }
+
+    // Ensure we have at least two points
+    if (!Array.isArray(coords) || coords.length !== 2) {
+      throw new Exception('Invalid envelope point coordinates: Expected coordinates to be an array with at least two elements', { code: 400 });
+    }
+
+    // Validate each point
+    for (let i = 0; i < coords.length; i++) {
+      const point = coords[i];
+      this.expectLongitude(point[0]);
+      this.expectLatitude(point[1]);
+    }
+  }
+
+  expectPrimaryKey(value) {
+    // Expect the only properties to be 'pk' and 'sk'
+    const keys = Object.keys(value);
+    if (keys.length !== 2 || !keys.includes('pk') || !keys.includes('sk')) {
+      throw new Exception(`Invalid primary key: Expected { pk: <string>, sk: <string> }`, { code: 400 });
+    }
+    for (const key in value) {
+      this.expectType(value[key], ['string']);
     }
   }
 }


### PR DESCRIPTION
Relates to #70, #69 

Minor updates to the Geozone CRUD ops to support minor changes to the data model that have been made recently.

Listing the minor changes below:

- Changing the default `quickApiPutHandler` dynamodb operation to 'set' (was 'add). Both functions are fundamentally equivalent except 'add' is typically used when an existing value must be considered, which will never be the case for this function (use `quickApiUpdateHandler` in that situation).
- Adding a `expectPrimaryKey` config function for checking whether or not a property is structured as a dynamodb primary key. Due to the desire to move away from ORCS as the backbone for the data model, we must now list the whole primary key (pk + sk) when cross linking datapoints. We can no longer infer the primary key from other properties.
- Adding an `expectEnvelope` config function for checking envelopes as they have a slightly different geojson structure than polygons/geoshapes.
- Added some geozone properties not yet reflected in the data model but necessary to add. Updating the data model to follow.

Once this change is in, geozones can be migrated from the excel sheet into the database. Other datatypes to follow.