### PR TITLE
PRDT-70-2: Adding `dynamodb:Update*` role to geozone PUT

### DIFF
--- a/lib/handlers/dynamoStream/index.js
+++ b/lib/handlers/dynamoStream/index.js
@@ -4,6 +4,15 @@ const { OPENSEARCH_MAIN_INDEX, bulkWriteDocuments, OPENSEARCH_DOMAIN_NAME } = re
 const API_STAGE = process.env.API_STAGE;
 const WEBSOCKET_URL = process.env.WEBSOCKET_URL;
 
+// These are the schemas that we want to transfer to OpenSearch
+const schemasTransferrable = [
+  'protectedArea',
+  'geozone',
+  'facility',
+  'activity',
+  'product'
+];
+
 exports.handler = async function (event, context) {
   logger.info('Stream Handler');
   logger.debug(JSON.stringify(event));
@@ -21,10 +30,19 @@ exports.handler = async function (event, context) {
       const creationTime = createDate.toISOString();
 
       const gsipk = record.dynamodb.Keys.pk;
+      const schema = record.dynamodb.Keys.schema;
 
       // If pk === USER_ID_PARTITION then skip
       if (gsipk.S === USER_ID_PARTITION) {
         // TODO: Push data into either a new index and add some sort of record to the audit table.
+        continue;
+      }
+
+      // If the schema is not in the list of schemas to transfer, skip
+      // We only care about publicly searchable data for now.
+      // TODO: This also skips the audit step, so we still need to add a record to the audit table
+      if (!schemasTransferrable.includes(schema)) {
+        logger.debug(`Skipping schema ${newImage} - not in list of schemas to transfer`);
         continue;
       }
 
@@ -57,7 +75,10 @@ exports.handler = async function (event, context) {
           };
           doc['id'] = openSearchId;
 
-          upsertDocs.push(doc);
+          upsertDocs.push({
+            doc: doc,
+            doc_as_upsert: true,
+          });
           logger.debug(JSON.stringify(doc));
         } break;
         case 'REMOVE': {

--- a/lib/handlers/geozones/resources.js
+++ b/lib/handlers/geozones/resources.js
@@ -24,7 +24,7 @@ function geozonesSetup(scope, props) {
     layers: props.layers,
   });
   geozonesGzCollectionIdResource.addMethod('GET', new apigateway.LambdaIntegration(geozonesGetByGzCollectionId));
-  
+
   // POST /geozones/{gzcollectionid}
   const geozonesPostByGzCollectionId = new NodejsFunction(scope, 'GeozonesPostByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/POST'),
@@ -34,7 +34,7 @@ function geozonesSetup(scope, props) {
     layers: props.layers,
   });
   geozonesGzCollectionIdResource.addMethod('POST', new apigateway.LambdaIntegration(geozonesPostByGzCollectionId));
-  
+
   // PUT /geozones/{gzcollectionid}
   const geozonesPutByGzCollectionId = new NodejsFunction(scope, 'GeozonesPutByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/PUT'),
@@ -44,7 +44,7 @@ function geozonesSetup(scope, props) {
     layers: props.layers,
   });
   geozonesGzCollectionIdResource.addMethod('PUT', new apigateway.LambdaIntegration(geozonesPutByGzCollectionId));
-  
+
   // DELETE /geozones/{gzcollectionid}
   const geozonesDeleteByGzCollectionId = new NodejsFunction(scope, 'GeozonesDeleteByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/DELETE'),
@@ -63,6 +63,7 @@ function geozonesSetup(scope, props) {
       'dynamodb:BatchWrite*',
       'dynamodb:PutItem',
       'dynamodb:Delete*',
+      'dynamodb:Update*'
     ],
     resources: [props.mainTable.tableArn],
   });


### PR DESCRIPTION
Relates to #69, #70

The `dynamodb:Update*` policy action is necessary to perform DynamoDB's UpdateItem command (used in all PUTs). Note: We will have to update the permissions of the other put functions at a later time. 

Also included in this PR: restricting the datatypes that are forwarded to OpenSearch. If an incoming image has a schema that is not included in the `schemasTransferrable` list, it will not be forwarded to OpenSearch (or the audit log, or websockets, for now. This will have to be modified later).