### PR TITLE
PRDT-70-3 updating facilities CRUD ops

### DIFF
--- a/docs/postman/BCParks PRDT Reservation System.postman_collection.json
+++ b/docs/postman/BCParks PRDT Reservation System.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "397e9c9e-d85f-49d9-993a-128fddd15ad8",
+		"_postman_id": "9ad99818-ce00-4a69-92b2-6aaa63ba2e1b",
 		"name": "BCParks PRDT Reservation System",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-d5314b6f-3178-44eb-9a6f-e3111e217cf5?action=share&source=collection_link&creator=14509064",
-		"_exporter_id": "43291325"
+		"_exporter_id": "14509064",
+		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-9ad99818-ce00-4a69-92b2-6aaa63ba2e1b?action=share&source=collection_link&creator=14509064"
 	},
 	"item": [
 		{
@@ -1018,10 +1018,10 @@
 			"name": "Facilities",
 			"item": [
 				{
-					"name": "Facility by ORCS",
+					"name": "Facility by Facility Collection Id",
 					"item": [
 						{
-							"name": "Batch Post Facilities by ORCS",
+							"name": "Batch Post Facilities by Facility Collection Id",
 							"event": [
 								{
 									"listen": "test",
@@ -1053,7 +1053,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"facility::997\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::997\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Musacheak Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1061,18 +1061,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs",
+									"raw": "{{base_url}}/facilities/:fcCollectionId",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "997"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1080,7 +1080,7 @@
 							"response": []
 						},
 						{
-							"name": "Batch Put Facilities by ORCS",
+							"name": "Batch Put Facilities by Facility Collection Id",
 							"event": [
 								{
 									"listen": "test",
@@ -1109,18 +1109,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs",
+									"raw": "{{base_url}}/facilities/:fcCollectionId",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "997"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1128,7 +1128,7 @@
 							"response": []
 						},
 						{
-							"name": "Get Facility by ORCS",
+							"name": "Get Facility by Facility Collection Id",
 							"event": [
 								{
 									"listen": "test",
@@ -1162,18 +1162,18 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs",
+									"raw": "{{base_url}}/facilities/:fcCollectionId",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "997"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1220,7 +1220,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"facility::998\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::998\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::998\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"fcCollectionId\": \"bcparks_998\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1228,13 +1228,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1244,8 +1244,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "998"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1282,13 +1282,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1298,8 +1298,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "998"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1341,13 +1341,13 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1357,8 +1357,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "998"
+											"key": "fcCollectionId",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1405,7 +1405,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"pk\": \"facility::999\",\r\n  \"sk\": \"parking::1\",\r\n  \"orcs\": 999,\r\n  \"displayName\": \"Cheakamus Main Parking Lot\",\r\n  \"description\": \"Where you park your car\",\r\n  \"schema\": \"facility\",\r\n  \"facilityType\": \"parking\",\r\n  \"address\": \"8675 Road St.\",\r\n  \"identifier\": 1 ,\r\n  \"facilityId\": 1,\r\n  \"geozone\": \"geozone::bcparks::7#3\",\r\n  \"activities\": [\"dayuse::1\"],\r\n  \"isVisible\": true,\r\n  \"timezone\": \"America/Vancouver\",\r\n  \"location\": {\r\n    \"type\": \"Point\",\r\n    \"coordinates\": [\r\n        89,\r\n        -89\r\n    ]\r\n  },\r\n  \"minMapZoom\": 123,\r\n  \"maxMapZoom\": 456,\r\n  \"showOnMap\": true,\r\n  \"imageUrl\": \"www.example.com\",\r\n  \"searchTerms\": [\"Cheakamus\", \"Parking\", \"Dayuse parking\"]\r\n}",
+									"raw": "{\r\n  \"pk\": \"facility::bcparks_999\",\r\n  \"sk\": \"parking::1\",\r\n  \"orcs\": 999,\r\n  \"displayName\": \"Cheakamus Main Parking Lot\",\r\n  \"description\": \"Where you park your car\",\r\n  \"schema\": \"facility\",\r\n  \"facilityType\": \"parking\",\r\n  \"address\": \"8675 Road St.\",\r\n  \"fcCollectionId\": \"bcparks_999\",\r\n  \"identifier\": 1 ,\r\n  \"facilityId\": 1,\r\n  \"geozone\": \"geozone::bcparks::7#3\",\r\n  \"activities\": [\"dayuse::1\"],\r\n  \"isVisible\": true,\r\n  \"timezone\": \"America/Vancouver\",\r\n  \"location\": {\r\n    \"type\": \"point\",\r\n    \"coordinates\": [\r\n        89,\r\n        -89\r\n    ]\r\n  },\r\n  \"minMapZoom\": 123,\r\n  \"maxMapZoom\": 456,\r\n  \"showOnMap\": true,\r\n  \"imageUrl\": \"www.example.com\",\r\n  \"searchTerms\": [\"Cheakamus\", \"Parking\", \"Dayuse parking\"]\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1413,13 +1413,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking&facilityId=1",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking&facilityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1433,8 +1433,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "fcCollectionId",
+											"value": "bcparks_999"
 										}
 									]
 								}
@@ -1471,13 +1471,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking&facilityId=1",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking&facilityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1491,8 +1491,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "fcCollectionId",
+											"value": "bcparks_999"
 										}
 									]
 								}
@@ -1526,13 +1526,13 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking&facilityId=1",
+									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking&facilityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":fcCollectionId"
 									],
 									"query": [
 										{
@@ -1546,8 +1546,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "fcCollectionId",
+											"value": "bcparks_999"
 										}
 									]
 								}
@@ -1622,13 +1622,13 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/facilities/:orcs?facilityType=parking&facilityId=1",
+									"raw": "{{base_url}}/facilities/:facCollectionId?facilityType=parking&facilityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":orcs"
+										":facCollectionId"
 									],
 									"query": [
 										{
@@ -1642,8 +1642,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "facCollectionId",
+											"value": "bcparks_999"
 										}
 									]
 								}
@@ -2559,16 +2559,14 @@
 		},
 		{
 			"name": "Search",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
 			"request": {
-				"method": "GET",
+				"method": "POST",
 				"header": [
 					{
 						"key": "x-api-key",
 						"value": "{{x-api-key}}",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					}
 				],
 				"body": {
@@ -2581,7 +2579,7 @@
 					}
 				},
 				"url": {
-					"raw": "{{base_url}}/search?limit=20&type=opDate&startDate=2024-11-06&endDate=2024-11-08&category=permit",
+					"raw": "{{base_url}}/search",
 					"host": [
 						"{{base_url}}"
 					],
@@ -2600,13 +2598,9 @@
 							"disabled": true
 						},
 						{
-							"key": "text",
-							"value": "date",
-							"disabled": true
-						},
-						{
 							"key": "limit",
-							"value": "20"
+							"value": "20",
+							"disabled": true
 						},
 						{
 							"key": "status",
@@ -2620,19 +2614,23 @@
 						},
 						{
 							"key": "type",
-							"value": "opDate"
+							"value": "opDate",
+							"disabled": true
 						},
 						{
 							"key": "startDate",
-							"value": "2024-11-06"
+							"value": "2024-11-06",
+							"disabled": true
 						},
 						{
 							"key": "endDate",
-							"value": "2024-11-08"
+							"value": "2024-11-08",
+							"disabled": true
 						},
 						{
 							"key": "category",
-							"value": "permit"
+							"value": "permit",
+							"disabled": true
 						}
 					]
 				}
@@ -2722,6 +2720,11 @@
 		"type": "oauth2",
 		"oauth2": [
 			{
+				"key": "useBrowser",
+				"value": false,
+				"type": "boolean"
+			},
+			{
 				"key": "clientId",
 				"value": "{{cognito_client_id}}",
 				"type": "string"
@@ -2735,11 +2738,6 @@
 				"key": "accessTokenUrl",
 				"value": "{{cognito_auth_url}}/oauth2/token",
 				"type": "string"
-			},
-			{
-				"key": "useBrowser",
-				"value": true,
-				"type": "boolean"
 			},
 			{
 				"key": "grant_type",

--- a/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
@@ -3,17 +3,17 @@ const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
 const { validateSortKey } = require("/opt/facilities/methods");
 
 /**
- * @api {delete} /facilities/{orcs}/ DELETE
+ * @api {delete} /facilities/{fcCollectionId}/ DELETE
  * Delete Facilities
  */
 exports.handler = async (event, context) => {
   logger.info("DELETE Facilities", event);
   try {
-    const orcs = event?.pathParameters?.orcs;
+    const fcCollectionId = event?.pathParameters?.fcCollectionId;
     const body = JSON.parse(event?.body);
 
-    if (!orcs) {
-      throw new Exception("ORCS is required", { code: 400 });
+    if (!fcCollectionId) {
+      throw new Exception("Facility Collection Id (fcCollectionId) is required", { code: 400 });
     }
 
     if (body) {
@@ -26,9 +26,9 @@ exports.handler = async (event, context) => {
     if (!facilityType && !facilityId) {
       throw new Exception("facilityType and facilityId are required", { code: 400 });
     }
-    
-    const deleteItem = createDeleteCommand(orcs, facilityType, facilityId)
-    
+
+    const deleteItem = createDeleteCommand(fcCollectionId, facilityType, facilityId)
+
     // Use batchTransactData to delete the database item
     const res = await batchTransactData([deleteItem]);
     return sendResponse(200, res, "Success", null, context);
@@ -43,7 +43,7 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(orcs, facilityType, facilityId, sk = undefined) {
+function createDeleteCommand(fcCollectionId, facilityType, facilityId, sk = undefined) {
   // Use sk if provided in a batch request, otherwise there won't be an sk
   // so use the pathParams to create sk
   const sortKey = sk || `${facilityType}::${facilityId}`;
@@ -52,7 +52,7 @@ function createDeleteCommand(orcs, facilityType, facilityId, sk = undefined) {
     data: {
       TableName: TABLE_NAME,
       Key: marshall({
-        pk: `facility::${orcs}`,
+        pk: `facility::${fcCollectionId}`,
         sk: sortKey,
       }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",

--- a/lib/handlers/facilities/_fcCollectionId/GET/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/GET/index.js
@@ -1,5 +1,5 @@
 const {
-  getFacilitiesByOrcs,
+  getFacilitiesByFcCollectionId,
   getFacilitiesByFacilityType,
   getFacilityByFacilityId,
 } = require("/opt/facilities/methods");
@@ -7,7 +7,7 @@ const { Exception, logger, sendResponse } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/facilities/configs");
 
 /**
- * @api {get} /facilities/{orcs} GET
+ * @api {get} /facilities/{fcCollectionId} GET
  * Fetch Facilities
  */
 exports.handler = async (event, context) => {
@@ -18,10 +18,10 @@ exports.handler = async (event, context) => {
   }
 
   try {
-    const orcs = event?.pathParameters?.orcs;
+    const fcCollectionId = event?.pathParameters?.fcCollectionId;
 
-    if (!orcs) {
-      throw new Exception("ORCS is required", { code: 400 });
+    if (!fcCollectionId) {
+      throw new Exception("Facility Collection ID (fcCollectionId) is required", { code: 400 });
     }
 
     // Grab the facilityType or facilityId if provided
@@ -44,12 +44,12 @@ exports.handler = async (event, context) => {
     });
 
     if (facilityType && facilityId) {
-      res = await getFacilityByFacilityId(orcs, facilityType, facilityId);
+      res = await getFacilityByFacilityId(fcCollectionId, facilityType, facilityId);
     }
 
     if (facilityType && !facilityId) {
       res = await getFacilitiesByFacilityType(
-        orcs,
+        fcCollectionId,
         facilityType,
         filters,
         event?.queryStringParameters || null
@@ -57,8 +57,8 @@ exports.handler = async (event, context) => {
     }
 
     if (!facilityType && !facilityId) {
-      res = await getFacilitiesByOrcs(
-        orcs,
+      res = await getFacilitiesByFcCollectionId(
+        fcCollectionId,
         filters,
         event?.queryStringParameters || null
       );

--- a/lib/handlers/facilities/_fcCollectionId/POST/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/POST/index.js
@@ -5,15 +5,15 @@ const { parseRequest } = require("/opt/facilities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
- * @api {post} /facilities/{orcs} POST
+ * @api {post} /facilities/{fcCollectionId} POST
  * Create Facilities
  */
 exports.handler = async (event, context) => {
   logger.info("POST Facilities", event);
   try {
-    const orcs = String(event?.pathParameters?.orcs);
-    if (!orcs) {
-      throw new Exception("ORCS is required", { code: 400 });
+    const fcCollectionId = String(event?.pathParameters?.fcCollectionId);
+    if (!fcCollectionId) {
+      throw new Exception("Facility Collection ID (fcCollectionId) is required", { code: 400 });
     }
 
     const body = JSON.parse(event?.body);
@@ -23,8 +23,8 @@ exports.handler = async (event, context) => {
 
     // Grab the facilityType or facilityId if provided
     const { facilityType, facilityId } = event?.queryStringParameters || {};
-    
-    let postRequests = parseRequest(orcs, facilityType, facilityId, body, "POST");
+
+    let postRequests = parseRequest(fcCollectionId, facilityType, facilityId, body, "POST");
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(
@@ -32,6 +32,8 @@ exports.handler = async (event, context) => {
       postRequests,
       FACILITY_API_PUT_CONFIG
     );
+
+    console.log('putItems:', putItems);
 
     // Use batchTransactData to put the database
     const res = await batchTransactData(putItems);

--- a/lib/handlers/facilities/_fcCollectionId/PUT/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/PUT/index.js
@@ -5,17 +5,17 @@ const { parseRequest } = require("/opt/facilities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
- * @api {put} /facilities/{orcs} PUT
+ * @api {put} /facilities/{fcCollectionId} PUT
  * Update Facilities
  */
 exports.handler = async (event, context) => {
   logger.info("PUT Facilities", event);
   try {
-    const orcs = event?.pathParameters?.orcs;
+    const fcCollectionId = event?.pathParameters?.fcCollectionId;
     const body = JSON.parse(event?.body);
 
-    if (!orcs) {
-      throw new Exception("ORCS is required", { code: 400 });
+    if (!fcCollectionId) {
+      throw new Exception("Facility Collection Id (fcCollectionId) is required", { code: 400 });
     }
 
     if (!body) {
@@ -25,7 +25,7 @@ exports.handler = async (event, context) => {
     // Grab the facilityType or facilityId if provided
     const { facilityType, facilityId } = event?.queryStringParameters || {};
 
-    let updateRequests = parseRequest(orcs, facilityType, facilityId, body, "PUT");
+    let updateRequests = parseRequest(fcCollectionId, facilityType, facilityId, body, "PUT");
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(

--- a/lib/handlers/facilities/resources.js
+++ b/lib/handlers/facilities/resources.js
@@ -12,48 +12,48 @@ function facilitiesSetup(scope, props) {
   // /facilities resource
   const facilitiesResource = props.api.root.addResource('facilities');
 
-  // /facilities/{orcs}/ resource
-  const facilitiesOrcsResource = facilitiesResource.addResource('{orcs}');
+  // /facilities/{fcCollectionId}/ resource
+  const fcCollectionIdResource = facilitiesResource.addResource('{fcCollectionId}');
 
-  // GET /facilities/{orcs}
-  const facilitiesGetByOrcs = new NodejsFunction(scope, 'FacilitiesGetByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/facilities/_orcs/GET'),
+  // GET /facilities/{fcCollectionId}
+  const facilitiesGetByFcCollectionId = new NodejsFunction(scope, 'FacilitiesGetByFcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/facilities/_fcCollectionId/GET'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  facilitiesOrcsResource.addMethod('GET', new apigateway.LambdaIntegration(facilitiesGetByOrcs));
-  
-  // POST /facilities/{orcs}
-  const facilitiesPostByOrcs = new NodejsFunction(scope, 'FacilitiesPostByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/facilities/_orcs/POST'),
+  fcCollectionIdResource.addMethod('GET', new apigateway.LambdaIntegration(facilitiesGetByFcCollectionId));
+
+  // POST /facilities/{fcCollectionId}
+  const facilitiesPostByFcCollectionId = new NodejsFunction(scope, 'FacilitiesPostByFcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/facilities/_fcCollectionId/POST'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  facilitiesOrcsResource.addMethod('POST', new apigateway.LambdaIntegration(facilitiesPostByOrcs));
-  
-  // PUT /facilities/{orcs}
-  const facilitiesPutByOrcs = new NodejsFunction(scope, 'FacilitiesPutByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/facilities/_orcs/PUT'),
+  fcCollectionIdResource.addMethod('POST', new apigateway.LambdaIntegration(facilitiesPostByFcCollectionId));
+
+  // PUT /facilities/{fcCollectionId}
+  const facilitiesPutByFcCollectionId = new NodejsFunction(scope, 'FacilitiesPutByFcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/facilities/_fcCollectionId/PUT'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  facilitiesOrcsResource.addMethod('PUT', new apigateway.LambdaIntegration(facilitiesPutByOrcs));
-  
-  // DELETE /facilities/{orcs}
-  const facilitiesDeleteByOrcs = new NodejsFunction(scope, 'FacilitiesDeleteByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/facilities/_orcs/DELETE'),
+  fcCollectionIdResource.addMethod('PUT', new apigateway.LambdaIntegration(facilitiesPutByFcCollectionId));
+
+  // DELETE /facilities/{fcCollectionId}
+  const facilitiesDeleteByFcCollectionId = new NodejsFunction(scope, 'FacilitiesDeleteByFcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/facilities/_fcCollectionId/DELETE'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  facilitiesOrcsResource.addMethod('DELETE', new apigateway.LambdaIntegration(facilitiesDeleteByOrcs));
+  fcCollectionIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(facilitiesDeleteByFcCollectionId));
 
   // Add DynamoDB query & getItem policies to the functions
   const dynamoDbPolicy = new iam.PolicyStatement({
@@ -67,16 +67,16 @@ function facilitiesSetup(scope, props) {
     resources: [props.mainTable.tableArn],
   });
 
-  facilitiesGetByOrcs.addToRolePolicy(dynamoDbPolicy);
-  facilitiesPostByOrcs.addToRolePolicy(dynamoDbPolicy);
-  facilitiesPutByOrcs.addToRolePolicy(dynamoDbPolicy);
-  facilitiesDeleteByOrcs.addToRolePolicy(dynamoDbPolicy);
+  facilitiesGetByFcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  facilitiesPostByFcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  facilitiesPutByFcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  facilitiesDeleteByFcCollectionId.addToRolePolicy(dynamoDbPolicy);
 
   return {
-    facilitiesGetByOrcs: facilitiesGetByOrcs,
-    facilitiesPostByOrcs: facilitiesPostByOrcs,
-    facilitiesPutByOrcs: facilitiesPutByOrcs,
-    facilitiesDeleteByOrcs: facilitiesDeleteByOrcs,
+    facilitiesGetByFcCollectionId: facilitiesGetByFcCollectionId,
+    facilitiesPostByFcCollectionId: facilitiesPostByFcCollectionId,
+    facilitiesPutByFcCollectionId: facilitiesPutByFcCollectionId,
+    facilitiesDeleteByFcCollectionId: facilitiesDeleteByFcCollectionId,
     facilitiesResource: facilitiesResource
   };
 }

--- a/lib/handlers/tooling/protectedAreas/syncFromDataRegister/index.js
+++ b/lib/handlers/tooling/protectedAreas/syncFromDataRegister/index.js
@@ -72,16 +72,16 @@ async function syncData(protectedAreas, fieldsToSync, forceUpdate = false) {
       updateList.push(await createPutPAItem(protectedArea, fieldsToSync, now));
       created++;
       continue;
-    }
+    } else {
+      // If the item exists but one of the syncing fields has changed, update the item in the database
+      const shouldUpdate = fieldsToSync.some(field => {
+        return protectedArea?.[field] !== existingItem?.[field];
+      });
 
-    // If the item exists but one of the syncing fields has changed, update the item in the database
-    const shouldUpdate = fieldsToSync.some(field => {
-      return protectedArea?.[field] !== existingItem?.[field];
-    });
-
-    if (shouldUpdate || forceUpdate) {
-      updateList.push(await createUpdatePAItem(protectedArea, fieldsToSync, now));
-      updated++;
+      if (shouldUpdate || forceUpdate) {
+        updateList.push(await createUpdatePAItem(protectedArea, fieldsToSync, now));
+        updated++;
+      }
     }
   }
   logger.info(`Updating ${updateList.length} protected areas.`);
@@ -105,7 +105,9 @@ async function createPutPAItem(protectedArea, fieldsToSync, timestamp) {
     imageUrl: 'https://picsum.photos/500',
     version: 1,
     creationDate: timestamp,
-    lastUpdated: timestamp
+    lastUpdated: timestamp,
+    searchTerms: '',
+    adminNotes: ''
   };
   for (const field of fieldsToSync) {
     item[field] = protectedArea[field];
@@ -139,7 +141,7 @@ function createUpdatePAItem(protectedArea, fieldsToSync, timestamp) {
       TableName: TABLE_NAME,
       Key: {
         pk: { S: 'protectedArea' },
-        sk: { S: `${protectedArea.pk}::properties` }
+        sk: { S: `${protectedArea.pk}` }
       },
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,

--- a/lib/layers/dataUtils/facilities/configs.js
+++ b/lib/layers/dataUtils/facilities/configs.js
@@ -20,136 +20,149 @@ const FACILITY_API_PUT_CONFIG = {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     sk: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    fcCollectionId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
       }
     },
     orcs: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     displayName: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     description: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     schema: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['facility']),
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     facilityType: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, FACILITY_TYPE_ENUMS),
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    facilitySubType: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
       }
     },
     location: {
       isMandatory: true,
       rulesFn: ({value, action}) => {
         rf.expectGeopoint(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     address: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     identifier: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     facilityId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     geozone: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     activities: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     isVisible: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     timezone: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, TIMEZONE_ENUMS);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     minMapZoom: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     maxMapZoom: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     showOnMap: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     imageUrl: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     searchTerms: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     }
   }
@@ -172,9 +185,9 @@ const FACILITY_API_UPDATE_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    schema: {
+    facilitySubType: {
       rulesFn: ({ value, action }) => {
-        rf.expectValueInList(value, ['facility']),
+        rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
     },

--- a/lib/layers/dataUtils/facilities/methods.js
+++ b/lib/layers/dataUtils/facilities/methods.js
@@ -37,7 +37,7 @@ function addFilters(queryObj, filters) {
         );
       }
     });
-    
+
     return queryObj;
   } catch (error) {
     throw error;
@@ -45,10 +45,10 @@ function addFilters(queryObj, filters) {
 }
 
 /**
- * Retrieves all facilities matching an ORCS.
+ * Retrieves all facilities matching a facility collection id.
  *
  * @async
- * @param {Object} orcs - The ORCS of the facility.
+ * @param {Object} fcCollectionId - The fcCollectionId of the facility.
  * @param {Object} [params] - Optional parameters for pagination control.
  * @param {number} [params.limit] - Maximum number of items to return.
  * @param {string} [params.lastEvaluatedKey] - Key to resume pagination from.
@@ -62,8 +62,8 @@ function addFilters(queryObj, filters) {
  * @throws {Exception} With code 400 if database operation fails
  *
  */
-async function getFacilitiesByOrcs(orcs, filters, params = null) {
-  logger.info("Get Facilities by ORCS");
+async function getFacilitiesByFcCollectionId(fcCollectionId, filters, params = null) {
+  logger.info("Get Facilities by Facility Collection ID");
   try {
     const limit = params?.limit || null;
     const lastEvaluatedKey = params?.lastEvaluatedKey || null;
@@ -72,7 +72,7 @@ async function getFacilitiesByOrcs(orcs, filters, params = null) {
       TableName: TABLE_NAME,
       KeyConditionExpression: "pk = :pk",
       ExpressionAttributeValues: {
-        ":pk": { S: `facility::${orcs}` },
+        ":pk": { S: `facility::${fcCollectionId}` },
       },
     };
 
@@ -95,7 +95,7 @@ async function getFacilitiesByOrcs(orcs, filters, params = null) {
  * Retrieves facilities matching the specified Facility Type.
  *
  * @async
- * @param {Object} orcs - The ORCS of the facility.
+ * @param {Object} fcCollectionId - The facility collection ID of the facility.
  * @param {Object} facilityType - Type of facility to retrieve.
  * @param {Object} [params] - Optional parameters for pagination control.
  * @param {number} [params.limit] - Maximum number of items to return.
@@ -110,7 +110,7 @@ async function getFacilitiesByOrcs(orcs, filters, params = null) {
  * @throws {Exception} With code 400 if database operation fails
  */
 async function getFacilitiesByFacilityType(
-  orcs,
+  fcCollectionId,
   facilityType,
   filters,
   params = null
@@ -124,7 +124,7 @@ async function getFacilitiesByFacilityType(
       TableName: TABLE_NAME,
       KeyConditionExpression: "pk = :pk AND begins_with(sk, :sk)",
       ExpressionAttributeValues: {
-        ":pk": { S: `facility::${orcs}` },
+        ":pk": { S: `facility::${fcCollectionId}` },
         ":sk": { S: `${facilityType}::` },
       },
     };
@@ -148,7 +148,7 @@ async function getFacilitiesByFacilityType(
  * Retrieves facilities matching the specified Facility ID.
  *
  * @async
- * @param {Object} orcs - The ORCS number.
+ * @param {Object} fcCollectionId - The facility collection ID number.
  * @param {Object} facilityType - Type of facility.
  * @param {Object} facilityId - The ID of the facility.
  *
@@ -157,11 +157,11 @@ async function getFacilitiesByFacilityType(
  *
  * @throws {Exception} With code 400 if database operation fails
  */
-async function getFacilityByFacilityId(orcs, facilityType, facilityId) {
+async function getFacilityByFacilityId(fcCollectionId, facilityType, facilityId) {
   logger.info("Get Facility By Facility Type and ID");
   try {
     let res = await getOne(
-      `facility::${orcs}`,
+      `facility::${fcCollectionId}`,
       `${facilityType}::${facilityId}`
     );
     return res;
@@ -174,7 +174,7 @@ async function getFacilityByFacilityId(orcs, facilityType, facilityId) {
  * Processes incoming requests by handling batch operations and individual items.
  * Validates facilityType and facilityId parameters, falling back to body values if needed.
  *
- * @param {Object} orcs - ORCS number
+ * @param {Object} fcCollectionId - Facility Collection ID number
  * @param {string} facilityType - Type of facility
  * @param {string} facilityId - ID of the facility
  * @param {Object|Array} body - Request payload (single item or array of items)
@@ -182,20 +182,20 @@ async function getFacilityByFacilityId(orcs, facilityType, facilityId) {
  *
  * @returns {Array} Array of processed update requests
  */
-function parseRequest(orcs, facilityType, facilityId, body, requestType) {
+function parseRequest(fcCollectionId, facilityType, facilityId, body, requestType) {
   let updateRequests = [];
   // Check if the request is a batch request
   if (Array.isArray(body)) {
     for (let item of body) {
       const { sk } = item;
       updateRequests.push(
-        processItem(orcs, facilityType, facilityId, sk, item, requestType)
+        processItem(fcCollectionId, facilityType, facilityId, sk, item, requestType)
       );
     }
   } else {
     const { sk } = body;
     updateRequests.push(
-      processItem(orcs, facilityType, facilityId, sk, body, requestType)
+      processItem(fcCollectionId, facilityType, facilityId, sk, body, requestType)
     );
   }
 
@@ -206,7 +206,7 @@ function parseRequest(orcs, facilityType, facilityId, body, requestType) {
  * Processes individual items based on request type, creating appropriate key structures.
  * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
  *
- * @param {Object} orcs - ORCS number
+ * @param {Object} fcCollectionId - Facility Collection ID number
  * @param {string} facilityType - Type of facility
  * @param {string} facilityId - ID of the facility
  * @param {string} [sk] - Optional sort key (defaults to ${facilityType}::${facilityId})
@@ -215,10 +215,10 @@ function parseRequest(orcs, facilityType, facilityId, body, requestType) {
  *
  * @returns {Object} Processed item with key structure and data
  */
-function processItem(orcs, facilityType, facilityId, sk, item, requestType) {  
+function processItem(fcCollectionId, facilityType, facilityId, sk, item, requestType) {
   facilityType = facilityType ?? item?.facilityType;
   facilityId = facilityId ?? item?.facilityId;
-  
+
   if (!sk) {
     if (item.facilityType && facilityType != item.facilityType) {
       throw new Error(`facilityType endpoint "${facilityType}" doesn't match body's "${item.facilityType}"`, { code: 400 });
@@ -227,10 +227,10 @@ function processItem(orcs, facilityType, facilityId, sk, item, requestType) {
       throw new Error(`facilityId endpoint "${facilityId}" doesn't match body's "${item.facilityId}"`, { code: 400 });
     }
   }
-    
-  const pk = `facility::${orcs}`;
+
+  const pk = `facility::${fcCollectionId}`;
   sk = sk ? sk : `${facilityType}::${facilityId}`;
-  
+
   validateSortKey(facilityType, facilityId, sk);
 
   if (requestType == "PUT") {
@@ -284,7 +284,7 @@ function validateSortKey(facilityType, facilityId, sk) {
 }
 
 module.exports = {
-  getFacilitiesByOrcs,
+  getFacilitiesByFcCollectionId,
   getFacilitiesByFacilityType,
   getFacilityByFacilityId,
   parseRequest,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "sam local start-api -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json --warm-containers LAZY --skip-pull-image 2>&1 | tr '\r' '\n'",
     "build": "cdk synth",
     "start-full": "yarn build && yarn start",
-    "invoke-lambda": "sam local invoke $1 --event lib/handlers/events/event.json -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json",
+    "invoke-lambda": "sam local invoke $1 --no-event -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json",
+    "invoke-lambda-event": "sam local invoke $1 --event lib/handlers/events/event.json -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json",
     "invoke-lambda-full": "yarn build && yarn invoke-lambda $1",
     "watch": "tsc -w",
     "test": "jest",
@@ -28,6 +29,7 @@
     "@opensearch-project/opensearch": "^3.2.0",
     "aws-cdk-lib": "2.173.2",
     "aws-sdk": "^2.1692.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.0",
+    "xlsx": "^0.18.5"
   }
 }


### PR DESCRIPTION
Relates to #69, #70.

Some minor updates to facilities CRUD ops to facilitate the insertion of data into the system:

- Updating the default `quickApiPutHandler` action to 'set' (See https://github.com/bcgov/reserve-rec-api/pull/80).
- Changed the structure of facility pks to include 'Facility Collection ID (`fcCollectionId`) in replacement of ORCS. This is done so we can decouple facilities from strictly belonging to ORCS in the future. The default collection of facilities for bcparks is `bcparks_<orcs>`. Fundamentally this does not change how the code currently works but the variable naming was updated to show `fcCollectionId` instead of `orcs`.
- Added some facility properties not yet reflected in the data model but necessary to add. Updating the model to follow.

Once this change is in, facilities can be migrated from the excel sheet into the database. Other datatypes to follow. 