### PR TITLE
PRDT-70-5 Adding  permissions to facilities

### DIFF
--- a/lib/handlers/facilities/resources.js
+++ b/lib/handlers/facilities/resources.js
@@ -63,6 +63,7 @@ function facilitiesSetup(scope, props) {
       'dynamodb:BatchWrite*',
       'dynamodb:PutItem',
       'dynamodb:Delete*',
+      'dynamodb:Update*'
     ],
     resources: [props.mainTable.tableArn],
   });


### PR DESCRIPTION
Facilities resources missing the `dynamodb:Update*` permissions.