### PR TITLE
PRDT-70-7 updates to activity CRUD ops

### DIFF
--- a/lib/handlers/activities/_acCollectionId/DELETE/index.js
+++ b/lib/handlers/activities/_acCollectionId/DELETE/index.js
@@ -1,19 +1,18 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
-const { validateSortKey } = require("/opt/activities/methods");
 
 /**
- * @api {delete} /activities/{orcs}/ DELETE
+ * @api {delete} /activities/{acCollectionId}/ DELETE
  * Delete Activities
  */
 exports.handler = async (event, context) => {
   logger.info("DELETE Activities", event);
   try {
-    const orcs = event?.pathParameters?.orcs;
+    const acCollectionId = event?.pathParameters?.acCollectionId;
     const body = JSON.parse(event?.body);
 
-    if (!orcs) {
-      throw new Exception("orcs is required", { code: 400 });
+    if (!acCollectionId) {
+      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
     }
 
     if (body) {
@@ -26,9 +25,9 @@ exports.handler = async (event, context) => {
     if (!activityType && !activityId) {
       throw new Exception("activityType and activityId are required", { code: 400 });
     }
-    
-    const deleteItem = createDeleteCommand(orcs, activityType, activityId)
-    
+
+    const deleteItem = createDeleteCommand(acCollectionId, activityType, activityId)
+
     // Use batchTransactData to delete the database item
     const res = await batchTransactData([deleteItem]);
     return sendResponse(200, res, "Success", null, context);
@@ -43,7 +42,7 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(orcs, activityType, activityId) {
+function createDeleteCommand(acCollectionId, activityType, activityId) {
   // Use sk if provided in a batch request, otherwise there won't be an sk
   // so use the pathParams to create sk
   const sortKey = `${activityType}::${activityId}`;
@@ -52,7 +51,7 @@ function createDeleteCommand(orcs, activityType, activityId) {
     data: {
       TableName: TABLE_NAME,
       Key: marshall({
-        pk: `activity::${orcs}`,
+        pk: `activity::${acCollectionId}`,
         sk: sortKey,
       }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",

--- a/lib/handlers/activities/_acCollectionId/GET/index.js
+++ b/lib/handlers/activities/_acCollectionId/GET/index.js
@@ -1,5 +1,5 @@
 const {
-  getActivitiesByOrcs,
+  getActivitiesByAcCollectionId,
   getActivitiesByActivityType,
   getActivityByActivityId,
 } = require("/opt/activities/methods");
@@ -7,7 +7,7 @@ const { Exception, logger, sendResponse } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/activities/configs");
 
 /**
- * @api {get} /activities/{orcs} GET
+ * @api {get} /activities/{acCollectionId} GET
  * Fetch Activities
  */
 exports.handler = async (event, context) => {
@@ -18,9 +18,9 @@ exports.handler = async (event, context) => {
   }
 
   try {
-    const orcs = event?.pathParameters?.orcs;
-    if (!orcs) {
-      throw new Exception("ORCS is required", { code: 400 });
+    const acCollectionId = event?.pathParameters?.acCollectionId;
+    if (!acCollectionId) {
+      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
     }
 
     const { activityType, activityId, ...queryParams } =
@@ -42,12 +42,12 @@ exports.handler = async (event, context) => {
     });
 
     if (activityType && activityId) {
-      res = await getActivityByActivityId(orcs, activityType, activityId);
+      res = await getActivityByActivityId(acCollectionId, activityType, activityId);
     }
 
     if (activityType && !activityId) {
       res = await getActivitiesByActivityType(
-        orcs,
+        acCollectionId,
         activityType,
         filters,
         event?.queryStringParameters || null
@@ -55,8 +55,8 @@ exports.handler = async (event, context) => {
     }
 
     if (!activityType && !activityId) {
-      res = await getActivitiesByOrcs(
-        orcs,
+      res = await getActivitiesByAcCollectionId(
+        acCollectionId,
         filters,
         event?.queryStringParameters || null
       );

--- a/lib/handlers/activities/_acCollectionId/POST/index.js
+++ b/lib/handlers/activities/_acCollectionId/POST/index.js
@@ -5,15 +5,15 @@ const { parseRequest } = require("/opt/activities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
- * @api {post} /activities/{orcs} POST
+ * @api {post} /activities/{acCollectionId} POST
  * Create Activities
  */
 exports.handler = async (event, context) => {
   logger.info("POST Activities", event);
   try {
-    const orcs = String(event?.pathParameters?.orcs);
-    if (!orcs) {
-      throw new Exception("Orcs is required", { code: 400 });
+    const acCollectionId = String(event?.pathParameters?.acCollectionId);
+    if (!acCollectionId) {
+      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
     }
 
     const body = JSON.parse(event?.body);
@@ -22,7 +22,7 @@ exports.handler = async (event, context) => {
     }
 
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let postRequests = parseRequest(orcs, activityType, activityId, body, "POST");
+    let postRequests = parseRequest(acCollectionId, activityType, activityId, body, "POST");
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(

--- a/lib/handlers/activities/_acCollectionId/PUT/index.js
+++ b/lib/handlers/activities/_acCollectionId/PUT/index.js
@@ -5,24 +5,24 @@ const { parseRequest } = require("/opt/activities/methods");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 /**
- * @api {put} /activities/{orcs} PUT
+ * @api {put} /activities/{acCollectionId} PUT
  * Update Activities
  */
 exports.handler = async (event, context) => {
   logger.info("PUT Activities", event);
   try {
-    const orcs = event?.pathParameters?.orcs;
-    if (!orcs) {
-      throw new Exception("Orcs is required", { code: 400 });
+    const acCollectionId = event?.pathParameters?.acCollectionId;
+    if (!acCollectionId) {
+      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
     }
-    
+
     const body = JSON.parse(event?.body);
     if (!body) {
       throw new Exception("Body is required", { code: 400 });
     }
 
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let updateRequests = parseRequest(orcs, activityType, activityId, body, "PUT");
+    let updateRequests = parseRequest(acCollectionId, activityType, activityId, body, "PUT");
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(
@@ -46,13 +46,13 @@ exports.handler = async (event, context) => {
   }
 };
 
-function processItem(orcs, activityType, activityId, sk, item) {
+function processItem(acCollectionId, activityType, activityId, sk, item) {
   validateSortKey(activityType, activityId, sk);
-  return createPutCommand(orcs, activityType, activityId, sk, item);
+  return createPutCommand(acCollectionId, activityType, activityId, sk, item);
 }
 
-function createPutCommand(orcs, activityType, activityId, sk, item) {
-  const pk = `activity::${orcs}`;
+function createPutCommand(acCollectionId, activityType, activityId, sk, item) {
+  const pk = `activity::${acCollectionId}`;
   sk = sk ? sk : `${activityType}::${activityId}`;
 
   // Remove pk, sk, activityType, and activityId as these can't be updated

--- a/lib/handlers/activities/resources.js
+++ b/lib/handlers/activities/resources.js
@@ -12,48 +12,48 @@ function activitiesSetup(scope, props) {
   // /activities resource
   const activitiesResource = props.api.root.addResource('activities');
 
-  // /activities/{orcs}/ resource
-  const activitiesOrcsResource = activitiesResource.addResource('{orcs}');
+  // /activities/{acCollectionId}/ resource
+  const activitiesCollectionIdResource = activitiesResource.addResource('{acCollectionId}');
 
-  // GET /activities/{orcs}
-  const activitiesGetByOrcs = new NodejsFunction(scope, 'ActivitiesGetByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/GET'),
+  // GET /activities/{acCollectionId}
+  const activitiesGetByAcCollectionId = new NodejsFunction(scope, 'ActivitiesGetByAcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/GET'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesOrcsResource.addMethod('GET', new apigateway.LambdaIntegration(activitiesGetByOrcs));
-  
-  // POST /activities/{orcs}
-  const activitiesPostByOrcs = new NodejsFunction(scope, 'ActivitiesPostByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/POST'),
+  activitiesCollectionIdResource.addMethod('GET', new apigateway.LambdaIntegration(activitiesGetByAcCollectionId));
+
+  // POST /activities/{acCollectionId}
+  const activitiesPostByAcCollectionId = new NodejsFunction(scope, 'ActivitiesPostByAcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/POST'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesOrcsResource.addMethod('POST', new apigateway.LambdaIntegration(activitiesPostByOrcs));
-  
-  // PUT /activities/{orcs}
-  const activitiesPutByOrcs = new NodejsFunction(scope, 'ActivitiesPutByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/PUT'),
+  activitiesCollectionIdResource.addMethod('POST', new apigateway.LambdaIntegration(activitiesPostByAcCollectionId));
+
+  // PUT /activities/{acCollectionId}
+  const activitiesPutByAcCollectionId = new NodejsFunction(scope, 'ActivitiesPutByAcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/PUT'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesOrcsResource.addMethod('PUT', new apigateway.LambdaIntegration(activitiesPutByOrcs));
-  
-  // DELETE /activities/{orcs}
-  const activitiesDeleteByOrcs = new NodejsFunction(scope, 'ActivitiesDeleteByOrcs', {
-    code: lambda.Code.fromAsset('lib/handlers/activities/_orcs/DELETE'),
+  activitiesCollectionIdResource.addMethod('PUT', new apigateway.LambdaIntegration(activitiesPutByAcCollectionId));
+
+  // DELETE /activities/{acCollectionId}
+  const activitiesDeleteByAcCollectionId = new NodejsFunction(scope, 'ActivitiesDeleteByAcCollectionId', {
+    code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/DELETE'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesOrcsResource.addMethod('DELETE', new apigateway.LambdaIntegration(activitiesDeleteByOrcs));
+  activitiesCollectionIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(activitiesDeleteByAcCollectionId));
 
   // Add DynamoDB query & getItem policies to the functions
   const dynamoDbPolicy = new iam.PolicyStatement({
@@ -63,20 +63,21 @@ function activitiesSetup(scope, props) {
       'dynamodb:BatchWrite*',
       'dynamodb:PutItem',
       'dynamodb:Delete*',
+      'dynamodb:Update*',
     ],
     resources: [props.mainTable.tableArn],
   });
 
-  activitiesGetByOrcs.addToRolePolicy(dynamoDbPolicy);
-  activitiesPostByOrcs.addToRolePolicy(dynamoDbPolicy);
-  activitiesPutByOrcs.addToRolePolicy(dynamoDbPolicy);
-  activitiesDeleteByOrcs.addToRolePolicy(dynamoDbPolicy);
+  activitiesGetByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  activitiesPostByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  activitiesPutByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  activitiesDeleteByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
 
   return {
-    activitiesGetByOrcs: activitiesGetByOrcs,
-    activitiesPostByOrcs: activitiesPostByOrcs,
-    activitiesPutByOrcs: activitiesPutByOrcs,
-    activitiesDeleteByOrcs: activitiesDeleteByOrcs,
+    activitiesGetByAcCollectionId: activitiesGetByAcCollectionId,
+    activitiesPostByAcCollectionId: activitiesPostByAcCollectionId,
+    activitiesPutByAcCollectionId: activitiesPutByAcCollectionId,
+    activitiesDeleteByAcCollectionId: activitiesDeleteByAcCollectionId,
     activitiesResource: activitiesResource
   };
 }

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -27,7 +27,7 @@ const SUB_ACTIVITY_TYPE_ENUMS = [
   'backcountry',
   'portionCircuit',
   'fullCircuit',
-]
+];
 const ACTIVITY_TYPE_ENUMS = [
   'frontcountryCamp',
   'backcountryCamp',
@@ -48,106 +48,115 @@ const ACTIVITY_API_PUT_CONFIG = {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     sk: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     orcs: {
-      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    acCollectionId: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
       }
     },
     displayName: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     description: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     schema: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['activity']),
-        rf.expectAction(action, ['add']);
+          rf.expectAction(action, ['set']);
       }
     },
     activityType: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS),
-        rf.expectAction(action, ['add']);
+          rf.expectAction(action, ['set']);
       }
     },
-    subActivityType: {
-      isMandatory: true,
+    activitySubType: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS),
-        rf.expectAction(action, ['add']);
+          rf.expectAction(action, ['set']);
       }
     },
     identifier: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     activityId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectInteger(value);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     geozone: {
-      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     facilities: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     isVisible: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     imageUrl: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectAction(action, ['set']);
       }
     },
     searchTerms: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
-        rf.expectAction(action, ['add']);
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
       }
     }
   }
-}
+};
 
 const ACTIVITY_API_UPDATE_CONFIG = {
   failOnError: true,
@@ -169,19 +178,19 @@ const ACTIVITY_API_UPDATE_CONFIG = {
     schema: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['activity']),
-        rf.expectAction(action, ['set']);
+          rf.expectAction(action, ['set']);
       }
     },
     activityType: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS),
-        rf.expectAction(action, ['set']);
+          rf.expectAction(action, ['set']);
       }
     },
-    subActivityType: {
+    activitySubType: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS),
-        rf.expectAction(action, ['set']);
+          rf.expectAction(action, ['set']);
       }
     },
     identifier: {
@@ -222,15 +231,21 @@ const ACTIVITY_API_UPDATE_CONFIG = {
     },
     searchTerms: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
     }
   }
-}
+};
 
 module.exports = {
   ACTIVITY_API_PUT_CONFIG,
   ACTIVITY_API_UPDATE_CONFIG,
   ALLOWED_FILTERS
-}
+};

--- a/lib/layers/dataUtils/activities/methods.js
+++ b/lib/layers/dataUtils/activities/methods.js
@@ -36,7 +36,7 @@ function addFilters(queryObj, filters) {
         );
       }
     });
-    
+
     return queryObj;
   } catch (error) {
     throw error;
@@ -44,10 +44,10 @@ function addFilters(queryObj, filters) {
 }
 
 /**
- * Retrieves all activities matching an Orcs.
+ * Retrieves all activities matching an Activity Collection ID.
  *
  * @async
- * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} acCollectionId - The Activity Collection ID of the activity.
  * @param {Object} [params] - Optional parameters for pagination control.
  * @param {number} [params.limit] - Maximum number of items to return.
  * @param {string} [params.lastEvaluatedKey] - Key to resume pagination from.
@@ -61,8 +61,8 @@ function addFilters(queryObj, filters) {
  * @throws {Exception} With code 400 if database operation fails
  *
  */
-async function getActivitiesByOrcs(orcs, filters, params = null) {
-  logger.info("Get Activities by Orcs");
+async function getActivitiesByAcCollectionId(acCollectionId, filters, params = null) {
+  logger.info("Get Activities by Activity Collection ID");
   try {
     const limit = params?.limit || null;
     const lastEvaluatedKey = params?.lastEvaluatedKey || null;
@@ -71,7 +71,7 @@ async function getActivitiesByOrcs(orcs, filters, params = null) {
       TableName: TABLE_NAME,
       KeyConditionExpression: "pk = :pk",
       ExpressionAttributeValues: {
-        ":pk": { S: `activity::${orcs}` },
+        ":pk": { S: `activity::${acCollectionId}` },
       },
     };
 
@@ -94,7 +94,7 @@ async function getActivitiesByOrcs(orcs, filters, params = null) {
  * Retrieves activities matching the specified activity type.
  *
  * @async
- * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} acCollectionId - The Activity Collection Id of the activity.
  * @param {Object} activityType - Type of activity to retrieve.
  * @param {Object} [params] - Optional parameters for pagination control.
  * @param {number} [params.limit] - Maximum number of items to return.
@@ -109,7 +109,7 @@ async function getActivitiesByOrcs(orcs, filters, params = null) {
  * @throws {Exception} With code 400 if database operation fails
  */
 async function getActivitiesByActivityType(
-  orcs,
+  acCollectionId,
   activityType,
   filters,
   params = null
@@ -123,7 +123,7 @@ async function getActivitiesByActivityType(
       TableName: TABLE_NAME,
       KeyConditionExpression: "pk = :pk AND begins_with(sk, :sk)",
       ExpressionAttributeValues: {
-        ":pk": { S: `activity::${orcs}` },
+        ":pk": { S: `activity::${acCollectionId}` },
         ":sk": { S: `${activityType}::` },
       },
     };
@@ -147,7 +147,7 @@ async function getActivitiesByActivityType(
  * Retrieves activities matching the specified activity type.
  *
  * @async
- * @param {Object} orcs - The Orcs of the activity.
+ * @param {Object} acCollectionId - The Activity Collection ID of the activity.
  * @param {Object} activityType - Type of activity to retrieve.
  * @param {Object} activityId - The ID of the activity to retrieve.
  *
@@ -156,12 +156,12 @@ async function getActivitiesByActivityType(
  *
  * @throws {Exception} With code 400 if database operation fails
  */
-async function getActivityByActivityId(orcs, activityType, activityId) {
+async function getActivityByActivityId(acCollectionId, activityType, activityId) {
   logger.info("Get Activity By activity type and ID");
   console.log('in here')
   try {
     let res = await getOne(
-      `activity::${orcs}`,
+      `activity::${acCollectionId}`,
       `${activityType}::${activityId}`
     );
     console.log('res?', res)
@@ -176,7 +176,7 @@ async function getActivityByActivityId(orcs, activityType, activityId) {
  * Processes incoming requests by handling batch operations and individual items.
  * Validates activityType and activityId parameters, falling back to body values if needed.
  *
- * @param {Object} orcs - ORCS number
+ * @param {Object} acCollectionId - Activity Collection ID number
  * @param {string} activityType - Type of activity
  * @param {string} activityId - ID of the activity
  * @param {Object|Array} body - Request payload (single item or array of items)
@@ -184,20 +184,20 @@ async function getActivityByActivityId(orcs, activityType, activityId) {
  *
  * @returns {Array} Array of processed update requests
  */
-function parseRequest(orcs, activityType, activityId, body, requestType) {
+function parseRequest(acCollectionId, activityType, activityId, body, requestType) {
   let updateRequests = [];
   // Check if the request is a batch request
   if (Array.isArray(body)) {
     for (let item of body) {
       const { sk } = item;
       updateRequests.push(
-        processItem(orcs, activityType, activityId, sk, item, requestType)
+        processItem(acCollectionId, activityType, activityId, sk, item, requestType)
       );
     }
   } else {
     const { sk } = body;
     updateRequests.push(
-      processItem(orcs, activityType, activityId, sk, body, requestType)
+      processItem(acCollectionId, activityType, activityId, sk, body, requestType)
     );
   }
 
@@ -208,7 +208,7 @@ function parseRequest(orcs, activityType, activityId, body, requestType) {
  * Processes individual items based on request type, creating appropriate key structures.
  * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
  *
- * @param {Object} orcs - ORCS number
+ * @param {Object} acCollectionId - Activity Collection ID number
  * @param {string} activityType - Type of activity
  * @param {string} activityId - ID of the activity
  * @param {string} [sk] - Optional sort key (defaults to ${activityType}::${activityId})
@@ -217,10 +217,10 @@ function parseRequest(orcs, activityType, activityId, body, requestType) {
  *
  * @returns {Object} Processed item with key structure and data
  */
-function processItem(orcs, activityType, activityId, sk, item, requestType) {  
+function processItem(acCollectionId, activityType, activityId, sk, item, requestType) {
   activityType = activityType ?? item?.activityType;
   activityId = activityId ?? item?.activityId;
-  
+
   if (!sk) {
     if (item.activityType && activityType != item.activityType) {
       throw new Error(`activityType endpoint "${activityType}" doesn't match body's "${item.activityType}"`, { code: 400 });
@@ -229,10 +229,10 @@ function processItem(orcs, activityType, activityId, sk, item, requestType) {
       throw new Error(`activityId endpoint "${activityId}" doesn't match body's "${item.activityId}"`, { code: 400 });
     }
   }
-    
-  const pk = `activity::${orcs}`;
+
+  const pk = `activity::${acCollectionId}`;
   sk = sk ? sk : `${activityType}::${activityId}`;
-  
+
   validateSortKey(activityType, activityId, sk);
 
   if (requestType == "PUT") {
@@ -286,7 +286,7 @@ function validateSortKey(activityType, activityId, sk) {
 }
 
 module.exports = {
-  getActivitiesByOrcs,
+  getActivitiesByAcCollectionId,
   getActivitiesByActivityType,
   getActivityByActivityId,
   parseRequest,


### PR DESCRIPTION
Relates to #69 and #70

Some minor updates to activities CRUD ops to facilitate the insertion of data into the system:


- Updating the default quickApiPutHandler action to 'set' (See https://github.com/bcgov/reserve-rec-api/pull/80).
- Changed the structure of activity pks to include 'Activity Collection ID (acCollectionId) in replacement of ORCS. This is analogous to the change made to facilities and is done so we can decouple activities from strictly belonging to ORCS in the future. The default collection of activities for bcparks is bcparks_<orcs>. Fundamentally this does not change how the code currently works but the variable naming was updated to show acCollectionId instead of orcs.
- Added some activity properties not yet reflected in the data model but necessary to add. Updating the model to follow.

Once this change is in, activities can be migrated from the excel sheet into the database. Other datatypes to follow.