### PR TITLE
PRDT-89: Auto Increment on Post Requests

### DIFF
--- a/docs/postman/BCParks PRDT Reservation System.postman_collection.json
+++ b/docs/postman/BCParks PRDT Reservation System.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "9ad99818-ce00-4a69-92b2-6aaa63ba2e1b",
+		"_postman_id": "f850ea3e-8c59-486f-8bb3-944053c1a72b",
 		"name": "BCParks PRDT Reservation System",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14509064",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-9ad99818-ce00-4a69-92b2-6aaa63ba2e1b?action=share&source=collection_link&creator=14509064"
+		"_exporter_id": "43291325"
 	},
 	"item": [
 		{
@@ -48,7 +47,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"displayName\": \"Cheakamus 4\",\r\n        \"gzCollectionId\": \"7\",\r\n        \"orcs\": 7,\r\n        \"identifier\": 4,\r\n        \"schema\": \"geozone\",\r\n        \"geozoneId\": 4,\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                89,\r\n                -89\r\n            ]\r\n        },\r\n        \"envelope\": {\r\n            \"type\": \"Envelope\",\r\n            \"coordinates\": [\r\n                [\r\n                    [\r\n                        89.123,\r\n                        -89.123\r\n                    ],\r\n                    [\r\n                        89.122,\r\n                        -88.122\r\n                    ]\r\n                ]\r\n            ]\r\n        },\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"isVisible\": true,\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"facilities\": [\r\n            \"parking::1\",\r\n            \"parking::2\"\r\n        ],\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"geozone::bcparks::7\",\r\n        \"sk\": \"5\",\r\n        \"displayName\": \"Cheakamus 5\",\r\n        \"gzCollectionId\": \"7\",\r\n        \"orcs\": 7,\r\n        \"identifier\": 5,\r\n        \"schema\": \"geozone\",\r\n        \"geozoneId\": 5,\r\n        \"location\": {\r\n            \"type\": \"Point\",\r\n            \"coordinates\": [\r\n                88,\r\n                -88\r\n            ]\r\n        },\r\n        \"envelope\": {\r\n            \"type\": \"Envelope\",\r\n            \"coordinates\": [\r\n                [\r\n                    [\r\n                        88.123,\r\n                        -88.123\r\n                    ],\r\n                    [\r\n                        88.122,\r\n                        -88.122\r\n                    ]\r\n                ]\r\n            ]\r\n        },\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"isVisible\": true,\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"facilities\": [\r\n            \"parking::1\",\r\n            \"parking::2\"\r\n        ],\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"displayName\": \"Cheakamus 4\",\r\n        \"gzCollectionId\": \"7\",\r\n        \"orcs\": 7,\r\n        \"schema\": \"geozone\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89,\r\n                -89\r\n            ]\r\n        },\r\n        \"envelope\": {\r\n            \"type\": \"envelope\",\r\n            \"coordinates\": [\r\n                [\r\n                    89.123,\r\n                    -89.123\r\n                ],\r\n                [\r\n                    89.122,\r\n                    -88.122\r\n                ]\r\n            ]\r\n        },\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"isVisible\": true,\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"facilities\": [\r\n            \"parking::1\",\r\n            \"parking::1\"\r\n        ],\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ]\r\n    },\r\n    {\r\n        \"displayName\": \"Cheakamus 5\",\r\n        \"gzCollectionId\": \"7\",\r\n        \"orcs\": 7,\r\n        \"schema\": \"geozone\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                88,\r\n                -88\r\n            ]\r\n        },\r\n        \"envelope\": {\r\n            \"type\": \"envelope\",\r\n            \"coordinates\": [\r\n                [\r\n                    88.123,\r\n                    -88.123\r\n                ],\r\n                [\r\n                    88.122,\r\n                    -88.122\r\n                ]\r\n            ]\r\n        },\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"isVisible\": true,\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"facilities\": [\r\n            \"parking::1\",\r\n            \"parking::1\"\r\n        ],\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ]\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -67,7 +66,7 @@
 									"variable": [
 										{
 											"key": "gzcollectionid",
-											"value": "bcparks::7"
+											"value": "bcparks_7"
 										}
 									]
 								}
@@ -96,7 +95,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"displayName\": \"New Cheakamus 4\",\r\n        \"geozoneId\": \"4\"\r\n    },\r\n    {\r\n        \"displayName\": \"New Cheakamus 5\",\r\n        \"activities\": [\r\n            \"boating::5\"\r\n        ],\r\n        \"sk\": \"5\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"displayName\": \"New Cheakamus 1\",\r\n        \"geozoneId\": \"1\"\r\n    },\r\n    {\r\n        \"displayName\": \"New Cheakamus 2\",\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ],\r\n        \"geozoneId\": \"2\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -115,7 +114,7 @@
 									"variable": [
 										{
 											"key": "gzcollectionid",
-											"value": "bcparks::7"
+											"value": "bcparks_7"
 										}
 									]
 								}
@@ -181,71 +180,6 @@
 					"name": "Geozone by Collection Geozone ID",
 					"item": [
 						{
-							"name": "Post Geozone by Collection Geozone ID",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"// Test for response body properties",
-											"pm.test(\"Response body has data, msg, and context\", function () {",
-											"    pm.response.to.have.jsonBody(\"data\");",
-											"    pm.response.to.have.jsonBody(\"msg\");",
-											"    pm.response.to.have.jsonBody(\"context\");",
-											"});",
-											"",
-											"// Test for response body data field value",
-											"pm.test(\"Data field value is true\", function () {",
-											"    pm.expect(pm.response.json().data).to.equal(true);",
-											"});"
-										],
-										"type": "text/javascript",
-										"packages": {}
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\r\n    \"displayName\": \"New New Cheakamus\",\r\n    \"gzCollectionId\": \"7\",\r\n    \"orcs\": 7,\r\n    \"identifier\": 3,\r\n    \"schema\": \"geozone\",\r\n    \"geozoneId\": 3,\r\n    \"location\": {\r\n        \"type\": \"Point\",\r\n        \"coordinates\": [\r\n            89,\r\n            -89\r\n        ]\r\n    },\r\n    \"envelope\": {\r\n        \"type\": \"Envelope\",\r\n        \"coordinates\": [\r\n            [\r\n                [\r\n                    89.123,\r\n                    -89.123\r\n                ],\r\n                [\r\n                    89.122,\r\n                    -88.122\r\n                ]\r\n            ]\r\n        ]\r\n    },\r\n    \"timezone\": \"America/Vancouver\",\r\n    \"isVisible\": true,\r\n    \"minMapZoom\": 123,\r\n    \"maxMapZoom\": 456,\r\n    \"facilities\": [\r\n        \"parking::1\",\r\n        \"parking::2\"\r\n    ],\r\n    \"activities\": [\r\n        \"dayuse::1\"\r\n    ]\r\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{base_url}}/geozones/:gzcollectionid?geozoneId=3",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"geozones",
-										":gzcollectionid"
-									],
-									"query": [
-										{
-											"key": "geozoneId",
-											"value": "3"
-										}
-									],
-									"variable": [
-										{
-											"key": "gzcollectionid",
-											"value": "bcparks::7"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Put Geozone by Collection Geozone ID",
 							"event": [
 								{
@@ -267,7 +201,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"sk\": \"3\",\r\n    \"displayName\": \"Newer Cheakamus\"\r\n}",
+									"raw": "{\r\n    \"displayName\": \"Newer Cheakamus\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -275,7 +209,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/geozones/:gzcollectionid?geozoneId=3",
+									"raw": "{{base_url}}/geozones/:gzcollectionid?geozoneId=1",
 									"host": [
 										"{{base_url}}"
 									],
@@ -286,13 +220,13 @@
 									"query": [
 										{
 											"key": "geozoneId",
-											"value": "3"
+											"value": "1"
 										}
 									],
 									"variable": [
 										{
 											"key": "gzcollectionid",
-											"value": "bcparks::7"
+											"value": "bcparks_7"
 										}
 									]
 								}
@@ -407,7 +341,7 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/geozones/:gzcollectionid?geozoneId=3",
+									"raw": "{{base_url}}/geozones/:gzcollectionid?geozoneId=1",
 									"host": [
 										"{{base_url}}"
 									],
@@ -418,13 +352,13 @@
 									"query": [
 										{
 											"key": "geozoneId",
-											"value": "3"
+											"value": "1"
 										}
 									],
 									"variable": [
 										{
 											"key": "gzcollectionid",
-											"value": "bcparks::7"
+											"value": "bcparks_7"
 										}
 									]
 								}
@@ -1053,7 +987,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::997\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Musacheak\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"structure\",\r\n        \"facilitySubType\": \"parkingLot\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n         \"activities\": [\r\n            \"dayuse::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Musacheak\"\r\n    },\r\n    {\r\n        \"orcs\": 997,\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"displayName\": \"Musacheak Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"structure\",\r\n        \"facilitySubType\": \"parkingLot\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"geozone\": \"geozone::bcparks::997#3\",\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Musacheak\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1061,17 +995,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId",
+									"raw": "{{base_url}}/facilities/:fccollectionid",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
+											"key": "fccollectionid",
 											"value": "bcparks_997"
 										}
 									]
@@ -1101,7 +1035,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"displayName\": \"New Musacheak Side Parking Lot\",\r\n        \"facilityType\": \"parking\",\r\n        \"facilityId\": 1\r\n    },\r\n    {\r\n        \"displayName\": \"New Musacheak Overflow Parking Lot\",\r\n        \"sk\": \"parking::2\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"displayName\": \"New Musacheak Side Parking Lot\",\r\n        \"facilityType\": \"structure\",\r\n        \"facilityId\": 1\r\n    },\r\n    {\r\n        \"displayName\": \"New Musacheak Overflow Parking Lot\",\r\n        \"facilityType\": \"structure\",\r\n        \"facilityId\": 2\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1109,17 +1043,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId",
+									"raw": "{{base_url}}/facilities/:fccollectionid",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
+											"key": "fccollectionid",
 											"value": "bcparks_997"
 										}
 									]
@@ -1220,7 +1154,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"facility::bcparks_997\",\r\n        \"sk\": \"parking::1\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"fcCollectionId\": \"bcparks_997\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 1,\r\n        \"facilityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Side parking\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"facility::998\",\r\n        \"sk\": \"parking::2\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Cheakamus Overflow Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"fcCollectionId\": \"bcparks_998\",\r\n        \"schema\": \"facility\",\r\n        \"facilityType\": \"parking\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"identifier\": 2,\r\n        \"facilityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::998\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.123,\r\n                -89.123\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Parking\",\r\n            \"Overflow parking\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"orcs\": 998,\r\n        \"fcCollectionId\": \"bcparks_998\",\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilitySubType\": \"parkingLot\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Musacheak\"\r\n    },\r\n    {\r\n        \"orcs\": 998,\r\n        \"fcCollectionId\": \"bcparks_998\",\r\n        \"displayName\": \"Musacheak Side Parking Lot\",\r\n        \"description\": \"Where you park your car\",\r\n        \"schema\": \"facility\",\r\n        \"facilitySubType\": \"parkingLot\",\r\n        \"address\": \"8675 Road St.\",\r\n        \"geozone\": \"geozone::bcparks::998#3\",\r\n        \"activities\": [\r\n            \"dayuse::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"timezone\": \"America/Vancouver\",\r\n        \"location\": {\r\n            \"type\": \"point\",\r\n            \"coordinates\": [\r\n                89.234,\r\n                -89.234\r\n            ]\r\n        },\r\n        \"minMapZoom\": 123,\r\n        \"maxMapZoom\": 456,\r\n        \"showOnMap\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Musacheak\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1228,24 +1162,24 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fccollectionid?facilityType=structure",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"query": [
 										{
 											"key": "facilityType",
-											"value": "parking"
+											"value": "structure"
 										}
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
-											"value": "bcparks_997"
+											"key": "fccollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1274,7 +1208,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"displayName\": \"New Cheakamus Side Parking Lot\",\r\n        \"facilityId\": 1\r\n    },\r\n    {\r\n        \"displayName\": \"New Cheakamus Overflow Parking Lot\",\r\n        \"sk\": \"parking::2\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"displayName\": \"New Cheakamus Side Parking Lot\",\r\n        \"facilityId\": 1\r\n    },\r\n    {\r\n        \"displayName\": \"New Cheakamus Overflow Parking Lot\",\r\n        \"facilityId\": 2\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1282,24 +1216,24 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fccollectionid?facilityType=structure",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"query": [
 										{
 											"key": "facilityType",
-											"value": "parking"
+											"value": "structure"
 										}
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
-											"value": "bcparks_997"
+											"key": "fccollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1341,24 +1275,24 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking",
+									"raw": "{{base_url}}/facilities/:fccollectionid?facilityType=structure",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"query": [
 										{
 											"key": "facilityType",
-											"value": "parking"
+											"value": "structure"
 										}
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
-											"value": "bcparks_997"
+											"key": "fccollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1370,77 +1304,6 @@
 				{
 					"name": "Facility by Facility ID",
 					"item": [
-						{
-							"name": "Post Facility by Facility ID",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"// Test for status code",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"// Test for response body properties",
-											"pm.test(\"Response body has data, msg, and context\", function () {",
-											"    pm.response.to.have.jsonBody(\"data\");",
-											"    pm.response.to.have.jsonBody(\"msg\");",
-											"    pm.response.to.have.jsonBody(\"context\");",
-											"});",
-											"",
-											"// Test for response body data field value",
-											"pm.test(\"Data field value is true\", function () {",
-											"    pm.expect(pm.response.json().data).to.equal(true);",
-											"});",
-											""
-										],
-										"type": "text/javascript",
-										"packages": {}
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\r\n  \"pk\": \"facility::bcparks_999\",\r\n  \"sk\": \"parking::1\",\r\n  \"orcs\": 999,\r\n  \"displayName\": \"Cheakamus Main Parking Lot\",\r\n  \"description\": \"Where you park your car\",\r\n  \"schema\": \"facility\",\r\n  \"facilityType\": \"parking\",\r\n  \"address\": \"8675 Road St.\",\r\n  \"fcCollectionId\": \"bcparks_999\",\r\n  \"identifier\": 1 ,\r\n  \"facilityId\": 1,\r\n  \"geozone\": \"geozone::bcparks::7#3\",\r\n  \"activities\": [\"dayuse::1\"],\r\n  \"isVisible\": true,\r\n  \"timezone\": \"America/Vancouver\",\r\n  \"location\": {\r\n    \"type\": \"point\",\r\n    \"coordinates\": [\r\n        89,\r\n        -89\r\n    ]\r\n  },\r\n  \"minMapZoom\": 123,\r\n  \"maxMapZoom\": 456,\r\n  \"showOnMap\": true,\r\n  \"imageUrl\": \"www.example.com\",\r\n  \"searchTerms\": [\"Cheakamus\", \"Parking\", \"Dayuse parking\"]\r\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking&facilityId=1",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"facilities",
-										":fcCollectionId"
-									],
-									"query": [
-										{
-											"key": "facilityType",
-											"value": "parking"
-										},
-										{
-											"key": "facilityId",
-											"value": "1"
-										}
-									],
-									"variable": [
-										{
-											"key": "fcCollectionId",
-											"value": "bcparks_999"
-										}
-									]
-								}
-							},
-							"response": []
-						},
 						{
 							"name": "Put Facility by Facility ID",
 							"event": [
@@ -1463,7 +1326,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"sk\": \"parking::1\",\r\n    \"displayName\": \"New Name for Cheakamus Main Parking Lot\"\r\n}",
+									"raw": "{\r\n    \"displayName\": \"New Name for Cheakamus Main Parking Lot\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1471,18 +1334,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/facilities/:fcCollectionId?facilityType=parking&facilityId=1",
+									"raw": "{{base_url}}/facilities/:fccollectionid?facilityType=structure&facilityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"facilities",
-										":fcCollectionId"
+										":fccollectionid"
 									],
 									"query": [
 										{
 											"key": "facilityType",
-											"value": "parking"
+											"value": "structure"
 										},
 										{
 											"key": "facilityId",
@@ -1491,8 +1354,8 @@
 									],
 									"variable": [
 										{
-											"key": "fcCollectionId",
-											"value": "bcparks_999"
+											"key": "fccollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1547,7 +1410,7 @@
 									"variable": [
 										{
 											"key": "fcCollectionId",
-											"value": "bcparks_999"
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1643,7 +1506,7 @@
 									"variable": [
 										{
 											"key": "facCollectionId",
-											"value": "bcparks_999"
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -1875,10 +1738,10 @@
 			"name": "Activities",
 			"item": [
 				{
-					"name": "Activity by ORCS",
+					"name": "Activity by Activity Collection ID",
 					"item": [
 						{
-							"name": "Batch Post Activities by ORCS",
+							"name": "Batch Post Activities Activity Collection ID",
 							"event": [
 								{
 									"listen": "test",
@@ -1912,7 +1775,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::997#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::997\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::997#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"activitySubType\": \"vehicleParking\",\r\n        \"geozone\": \"geozone::bcparks::997#1\",\r\n        \"facilities\": [\r\n            \"structure::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Cheakamus\"\r\n    },\r\n    {\r\n        \"orcs\": 997,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"activitySubType\": \"vehicleParking\",\r\n        \"geozone\": \"geozone::bcparks::997#2\",\r\n        \"facilities\": [\r\n            \"structure::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Cheakamus\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1931,7 +1794,7 @@
 									"variable": [
 										{
 											"key": "orcs",
-											"value": "997"
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1939,7 +1802,7 @@
 							"response": []
 						},
 						{
-							"name": "Batch Put Activities by ORCS",
+							"name": "Batch Put Activities Activity Collection ID",
 							"event": [
 								{
 									"listen": "test",
@@ -1960,7 +1823,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Hiking trail renamed\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed here too\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"activityId\": \"1\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"activityType\": \"dayuse\",\r\n        \"displayName\": \"Hiking trail renamed here too\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1968,18 +1831,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs",
+									"raw": "{{base_url}}/activities/:accollectionid",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "997"
+											"key": "accollectionid",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -1987,7 +1850,7 @@
 							"response": []
 						},
 						{
-							"name": "Get Activity by ORCS",
+							"name": "Get Activity Activity Collection ID",
 							"event": [
 								{
 									"listen": "test",
@@ -2021,18 +1884,18 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs",
+									"raw": "{{base_url}}/activities/:accollectionid",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "997"
+											"key": "accollectionid",
+											"value": "bcparks_997"
 										}
 									]
 								}
@@ -2079,7 +1942,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"pk\": \"activity::998\",\r\n        \"sk\": \"dayuse::1\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 1,\r\n        \"activityId\": 1,\r\n        \"geozone\": \"geozone::bcparks::998#1\",\r\n        \"facilities\": [\r\n            \"parking::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    },\r\n    {\r\n        \"pk\": \"activity::998\",\r\n        \"sk\": \"dayuse::2\",\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail north side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"subActivityType\": \"vehicleParking\",\r\n        \"identifier\": 2,\r\n        \"activityId\": 2,\r\n        \"geozone\": \"geozone::bcparks::998#2\",\r\n        \"facilities\": [\r\n            \"parking::2\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": [\r\n            \"Cheakamus\",\r\n            \"Activity\",\r\n            \"Dayuse\"\r\n        ]\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"activitySubType\": \"vehicleParking\",\r\n        \"geozone\": \"geozone::bcparks::998#1\",\r\n        \"facilities\": [\r\n            \"structure::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Cheakamus\"\r\n    },\r\n    {\r\n        \"orcs\": 998,\r\n        \"displayName\": \"Dayuse Spot 2 at Cheakamus\",\r\n        \"description\": \"Hiking trail south side\",\r\n        \"schema\": \"activity\",\r\n        \"activityType\": \"dayuse\",\r\n        \"activitySubType\": \"vehicleParking\",\r\n        \"geozone\": \"geozone::bcparks::998#1\",\r\n        \"facilities\": [\r\n            \"structure::1\"\r\n        ],\r\n        \"isVisible\": true,\r\n        \"imageUrl\": \"www.example.com\",\r\n        \"searchTerms\": \"Cheakamus\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2087,13 +1950,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
+									"raw": "{{base_url}}/activities/:accollectionid?activityType=dayuse",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"query": [
 										{
@@ -2103,8 +1966,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "998"
+											"key": "accollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -2133,7 +1996,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "[\r\n    {\r\n        \"sk\": \"dayuse::1\",\r\n        \"displayName\": \"Dayuse Spot 1 New Name Here\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n    }\r\n]",
+									"raw": "[\r\n    {\r\n        \"activityId\": \"1\",\r\n        \"displayName\": \"Dayuse Spot 1 New Name Here\"\r\n    },\r\n    {\r\n        \"activityId\": \"2\",\r\n        \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n    }\r\n]",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2141,13 +2004,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse",
+									"raw": "{{base_url}}/activities/:accollectionid?activityType=dayuse",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"query": [
 										{
@@ -2157,8 +2020,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "998"
+											"key": "accollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -2230,77 +2093,6 @@
 					"name": "Activity by Activity ID",
 					"item": [
 						{
-							"name": "Post Activity by Activity ID",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"// Test for status code",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"// Test for response body properties",
-											"pm.test(\"Response body has data, msg, and context\", function () {",
-											"    pm.response.to.have.jsonBody(\"data\");",
-											"    pm.response.to.have.jsonBody(\"msg\");",
-											"    pm.response.to.have.jsonBody(\"context\");",
-											"});",
-											"",
-											"// Test for response body data field value",
-											"pm.test(\"Data field value is true\", function () {",
-											"    pm.expect(pm.response.json().data).to.equal(true);",
-											"});",
-											""
-										],
-										"type": "text/javascript",
-										"packages": {}
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\r\n    \"orcs\": 999,\r\n    \"displayName\": \"Dayuse Spot 1 at Cheakamus\",\r\n    \"description\": \"Hiking trail north side\",\r\n    \"schema\": \"activity\",\r\n    \"activityType\": \"dayuse\",\r\n    \"subActivityType\": \"vehicleParking\",\r\n    \"identifier\": 1,\r\n    \"activityId\": 1,\r\n    \"geozone\": \"geozone::bcparks::999#1\",\r\n    \"facilities\": [\r\n        \"parking::1\"\r\n    ],\r\n    \"isVisible\": true,\r\n    \"imageUrl\": \"www.example.com\",\r\n    \"searchTerms\": [\r\n        \"Cheakamus\",\r\n        \"Activity\",\r\n        \"Dayuse\"\r\n    ]\r\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"activities",
-										":orcs"
-									],
-									"query": [
-										{
-											"key": "activityType",
-											"value": "dayuse"
-										},
-										{
-											"key": "activityId",
-											"value": "1"
-										}
-									],
-									"variable": [
-										{
-											"key": "orcs",
-											"value": "999"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Put Activity by Activity ID",
 							"event": [
 								{
@@ -2322,7 +2114,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"sk\": \"dayuse::1\",\r\n    \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n}",
+									"raw": "{\r\n    \"displayName\": \"Dayuse Spot 2 New Name Here\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2330,13 +2122,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:accollectionid?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"query": [
 										{
@@ -2350,8 +2142,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "accollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -2385,13 +2177,13 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/activities/:orcs?activityType=dayuse&activityId=1",
+									"raw": "{{base_url}}/activities/:accollectionid?activityType=dayuse&activityId=1",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"activities",
-										":orcs"
+										":accollectionid"
 									],
 									"query": [
 										{
@@ -2405,8 +2197,8 @@
 									],
 									"variable": [
 										{
-											"key": "orcs",
-											"value": "999"
+											"key": "accollectionid",
+											"value": "bcparks_998"
 										}
 									]
 								}
@@ -2502,7 +2294,7 @@
 									"variable": [
 										{
 											"key": "orcs",
-											"value": "999"
+											"value": "bcparks_998"
 										}
 									]
 								}

--- a/lib/handlers/activities/_acCollectionId/POST/index.js
+++ b/lib/handlers/activities/_acCollectionId/POST/index.js
@@ -13,7 +13,7 @@ exports.handler = async (event, context) => {
   try {
     const acCollectionId = String(event?.pathParameters?.acCollectionId);
     if (!acCollectionId) {
-      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
+      throw new Exception("acCollectionId is required", { code: 400 });
     }
 
     const body = JSON.parse(event?.body);
@@ -22,7 +22,7 @@ exports.handler = async (event, context) => {
     }
 
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let postRequests = parseRequest(acCollectionId, activityType, activityId, body, "POST");
+    let postRequests = await parseRequest(acCollectionId, body, "POST", activityType, activityId);
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(

--- a/lib/handlers/activities/_acCollectionId/PUT/index.js
+++ b/lib/handlers/activities/_acCollectionId/PUT/index.js
@@ -22,7 +22,7 @@ exports.handler = async (event, context) => {
     }
 
     const { activityType, activityId } = event?.queryStringParameters || {};
-    let updateRequests = parseRequest(acCollectionId, activityType, activityId, body, "PUT");
+    let updateRequests = await parseRequest(acCollectionId, body, "PUT", activityType, activityId);
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(
@@ -46,9 +46,8 @@ exports.handler = async (event, context) => {
   }
 };
 
-function processItem(acCollectionId, activityType, activityId, sk, item) {
-  validateSortKey(activityType, activityId, sk);
-  return createPutCommand(acCollectionId, activityType, activityId, sk, item);
+function processItem(orcs, activityType, activityId, sk, item) {
+  return createPutCommand(orcs, activityType, activityId, sk, item);
 }
 
 function createPutCommand(acCollectionId, activityType, activityId, sk, item) {

--- a/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
@@ -1,6 +1,5 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
-const { validateSortKey } = require("/opt/facilities/methods");
 
 /**
  * @api {delete} /facilities/{fcCollectionId}/ DELETE

--- a/lib/handlers/facilities/_fcCollectionId/POST/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/POST/index.js
@@ -23,8 +23,7 @@ exports.handler = async (event, context) => {
 
     // Grab the facilityType or facilityId if provided
     const { facilityType, facilityId } = event?.queryStringParameters || {};
-
-    let postRequests = parseRequest(fcCollectionId, facilityType, facilityId, body, "POST");
+    let postRequests = await parseRequest(fcCollectionId, body, "POST", facilityType, facilityId);
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(

--- a/lib/handlers/facilities/_fcCollectionId/PUT/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/PUT/index.js
@@ -25,7 +25,7 @@ exports.handler = async (event, context) => {
     // Grab the facilityType or facilityId if provided
     const { facilityType, facilityId } = event?.queryStringParameters || {};
 
-    let updateRequests = parseRequest(fcCollectionId, facilityType, facilityId, body, "PUT");
+    let updateRequests = await parseRequest(fcCollectionId, body, "PUT", facilityType, facilityId);
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(

--- a/lib/handlers/geozones/_gzCollectionId/DELETE/index.js
+++ b/lib/handlers/geozones/_gzCollectionId/DELETE/index.js
@@ -1,6 +1,5 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
-const { validateSortKey } = require("/opt/geozones/methods");
 
 /**
  * @api {delete} /geozones/{gzCollectionId}/ DELETE
@@ -9,7 +8,7 @@ const { validateSortKey } = require("/opt/geozones/methods");
 exports.handler = async (event, context) => {
   logger.info("DELETE Geozones", event);
   try {
-    const gzCollectionId = event?.pathParameters?.gzcollectionid;
+    const gzCollectionId = event?.pathParameters?.gzCollectionId;
     if (!gzCollectionId) {
       throw new Exception("gzCollectionId is required", { code: 400 });
     }

--- a/lib/handlers/geozones/_gzCollectionId/GET/index.js
+++ b/lib/handlers/geozones/_gzCollectionId/GET/index.js
@@ -6,7 +6,7 @@ const { Exception, logger, sendResponse } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/geozones/configs");
 
 /**
- * @api {get} /geozones/{gzcollectionid} GET
+ * @api {get} /geozones/{gzCollectionId} GET
  * Fetch geozones
  */
 exports.handler = async (event, context) => {
@@ -17,7 +17,7 @@ exports.handler = async (event, context) => {
   }
 
   try {
-    const gzCollectionId = event?.pathParameters?.gzcollectionid;
+    const gzCollectionId = event?.pathParameters?.gzCollectionId;
 
     if (!gzCollectionId) {
       throw new Exception("gzCollectionId is required", { code: 400 });

--- a/lib/handlers/geozones/_gzCollectionId/POST/index.js
+++ b/lib/handlers/geozones/_gzCollectionId/POST/index.js
@@ -11,7 +11,7 @@ const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 exports.handler = async (event, context) => {
   logger.info("POST Geozones", event);
   try {
-    const gzCollectionId = String(event?.pathParameters?.gzcollectionid);
+    const gzCollectionId = String(event?.pathParameters?.gzCollectionId);
 
     if (!gzCollectionId) {
       throw new Exception("gzCollectionId is required", { code: 400 });
@@ -22,9 +22,8 @@ exports.handler = async (event, context) => {
       throw new Exception("Body is required", { code: 400 });
     }
 
-    // Grab the geozoneId if provided
-    const { geozoneId } = event?.queryStringParameters || {};
-    let postRequests = parseRequest(gzCollectionId, geozoneId, body, "POST");
+    // Create the geozoneId / identifier
+    let postRequests = await parseRequest(gzCollectionId, body, "POST");
 
     // Use quickApiPutHandler to create the put items
     const putItems = await quickApiPutHandler(

--- a/lib/handlers/geozones/_gzCollectionId/PUT/index.js
+++ b/lib/handlers/geozones/_gzCollectionId/PUT/index.js
@@ -11,7 +11,7 @@ const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 exports.handler = async (event, context) => {
   logger.info("PUT Geozones", event);
   try {
-    const gzCollectionId = event?.pathParameters?.gzcollectionid;
+    const gzCollectionId = event?.pathParameters?.gzCollectionId;
     if (!gzCollectionId) {
       throw new Exception("gzCollectionId is required", { code: 400 });
     }
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
 
     // Grab the geozoneId if provided
     const { geozoneId } = event?.queryStringParameters || {};
-    let updateRequests = parseRequest(gzCollectionId, geozoneId, body, "PUT");
+    let updateRequests = await parseRequest(gzCollectionId, body, "PUT", geozoneId);
 
     // Use quickApiPutHandler to create the put items
     const updateItems = await quickApiUpdateHandler(

--- a/lib/handlers/geozones/resources.js
+++ b/lib/handlers/geozones/resources.js
@@ -12,10 +12,10 @@ function geozonesSetup(scope, props) {
   // /geozones resource
   const geozonesResource = props.api.root.addResource('geozones');
 
-  // /geozones/{gzcollectionid}/ resource
-  const geozonesGzCollectionIdResource = geozonesResource.addResource('{gzcollectionid}');
+  // /geozones/{gzCollectionId}/ resource
+  const geozonesGzCollectionIdResource = geozonesResource.addResource('{gzCollectionId}');
 
-  // GET /geozones/{gzcollectionid}
+  // GET /geozones/{gzCollectionId}
   const geozonesGetByGzCollectionId = new NodejsFunction(scope, 'GeozonesGetByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/GET'),
     handler: 'index.handler',
@@ -25,7 +25,7 @@ function geozonesSetup(scope, props) {
   });
   geozonesGzCollectionIdResource.addMethod('GET', new apigateway.LambdaIntegration(geozonesGetByGzCollectionId));
 
-  // POST /geozones/{gzcollectionid}
+  // POST /geozones/{gzCollectionId}
   const geozonesPostByGzCollectionId = new NodejsFunction(scope, 'GeozonesPostByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/POST'),
     handler: 'index.handler',
@@ -35,7 +35,7 @@ function geozonesSetup(scope, props) {
   });
   geozonesGzCollectionIdResource.addMethod('POST', new apigateway.LambdaIntegration(geozonesPostByGzCollectionId));
 
-  // PUT /geozones/{gzcollectionid}
+  // PUT /geozones/{gzCollectionId}
   const geozonesPutByGzCollectionId = new NodejsFunction(scope, 'GeozonesPutByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/PUT'),
     handler: 'index.handler',
@@ -45,7 +45,7 @@ function geozonesSetup(scope, props) {
   });
   geozonesGzCollectionIdResource.addMethod('PUT', new apigateway.LambdaIntegration(geozonesPutByGzCollectionId));
 
-  // DELETE /geozones/{gzcollectionid}
+  // DELETE /geozones/{gzCollectionId}
   const geozonesDeleteByGzCollectionId = new NodejsFunction(scope, 'GeozonesDeleteByGzCollectionId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/DELETE'),
     handler: 'index.handler',

--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -1,4 +1,4 @@
-const { BatchGetItemCommand, DynamoDB, DynamoDBClient, PutItemCommand, QueryCommand, GetItemCommand, DeleteItemCommand, TransactWriteItemsCommand } = require('@aws-sdk/client-dynamodb');
+const { BatchGetItemCommand, DynamoDB, DynamoDBClient, PutItemCommand, QueryCommand, GetItemCommand, DeleteItemCommand, UpdateItemCommand, TransactWriteItemsCommand } = require('@aws-sdk/client-dynamodb');
 const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
 const { logger } = require('/opt/base');
 
@@ -34,6 +34,37 @@ async function getOne(pk, sk) {
     return unmarshall(item.Item);
   }
   return null;
+}
+
+/**
+ * Increments a counter value in DynamoDB; creates item counter if it doesn't exist.
+ * @param {string} counterSchema - The schema identifier (e.g. "geozone")
+ * @param {string} skCollection - The sort key for the counter item (e.g. "bcparks", "user", "dayuse", etc.)
+ * @returns {Promise<number|undefined>} The updated counter value, or undefined if an error occurs.
+ */
+async function incrementItem (counterSchema, skCollection) {
+  // DynamoDB command to update record with incremented counter
+  const increment = {
+    TableName: TABLE_NAME,
+    Key: {
+      pk: { S: `counter::${counterSchema}` },
+      sk: { S: skCollection },
+    },
+    UpdateExpression: "ADD counterValue :counterValue",
+    ExpressionAttributeValues: { 
+      ":counterValue": { N: 1 }
+    },
+    ReturnValues: "ALL_NEW",
+  };
+
+  logger.debug("Incrementing counter", increment);
+  try {
+    const res = await dynamodb.send(new UpdateItemCommand(increment));
+    const item = unmarshall(res?.Attributes)
+    return item.counterValue;
+  } catch (error) {
+    logger.error("Error with increment: ", error)
+  }
 }
 
 
@@ -321,6 +352,7 @@ module.exports = {
   dynamodb,
   dynamodbClient,
   getOne,
+  incrementItem,
   marshall,
   parallelizedBatchGetData,
   putItem,

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -87,20 +87,20 @@ const ACTIVITY_API_PUT_CONFIG = {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['activity']),
-          rf.expectAction(action, ['set']);
+        rf.expectAction(action, ['set']);
       }
     },
     activityType: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS),
-          rf.expectAction(action, ['set']);
+        rf.expectAction(action, ['set']);
       }
     },
     activitySubType: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS),
-          rf.expectAction(action, ['set']);
+        rf.expectAction(action, ['set']);
       }
     },
     identifier: {

--- a/lib/layers/dataUtils/activities/methods.js
+++ b/lib/layers/dataUtils/activities/methods.js
@@ -1,4 +1,4 @@
-const { TABLE_NAME, runQuery, getOne, marshall } = require("/opt/dynamodb");
+const { TABLE_NAME, runQuery, getOne, marshall, incrementItem } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/activities/configs");
 
@@ -158,7 +158,6 @@ async function getActivitiesByActivityType(
  */
 async function getActivityByActivityId(acCollectionId, activityType, activityId) {
   logger.info("Get Activity By activity type and ID");
-  console.log('in here')
   try {
     let res = await getOne(
       `activity::${acCollectionId}`,
@@ -177,27 +176,25 @@ async function getActivityByActivityId(acCollectionId, activityType, activityId)
  * Validates activityType and activityId parameters, falling back to body values if needed.
  *
  * @param {Object} acCollectionId - Activity Collection ID number
- * @param {string} activityType - Type of activity
- * @param {string} activityId - ID of the activity
  * @param {Object|Array} body - Request payload (single item or array of items)
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} activityType - Type of activity
+ * @param {string} [activityId] - Optional ID of the activity
  *
  * @returns {Array} Array of processed update requests
  */
-function parseRequest(acCollectionId, activityType, activityId, body, requestType) {
+async function parseRequest(acCollectionId, body, requestType, activityType, activityId = null) {
   let updateRequests = [];
   // Check if the request is a batch request
   if (Array.isArray(body)) {
     for (let item of body) {
-      const { sk } = item;
       updateRequests.push(
-        processItem(acCollectionId, activityType, activityId, sk, item, requestType)
+        await processItem(acCollectionId, item, requestType, activityType, activityId)
       );
     }
   } else {
-    const { sk } = body;
     updateRequests.push(
-      processItem(acCollectionId, activityType, activityId, sk, body, requestType)
+      await processItem(acCollectionId, body, requestType, activityType, activityId)
     );
   }
 
@@ -209,42 +206,68 @@ function parseRequest(acCollectionId, activityType, activityId, body, requestTyp
  * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
  *
  * @param {Object} acCollectionId - Activity Collection ID number
- * @param {string} activityType - Type of activity
- * @param {string} activityId - ID of the activity
- * @param {string} [sk] - Optional sort key (defaults to ${activityType}::${activityId})
  * @param {Object} item - Item data to process
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} activityType - Type of activity
+ * @param {string} [activityId] - Optional ID of the activity
  *
  * @returns {Object} Processed item with key structure and data
  */
-function processItem(acCollectionId, activityType, activityId, sk, item, requestType) {
-  activityType = activityType ?? item?.activityType;
-  activityId = activityId ?? item?.activityId;
+async function processItem(
+  acCollectionId,
+  item,
+  requestType,
+  activityType,
+  activityId = null
+) {
+  const pk = `activity::${acCollectionId}`;
+  let sk = null
 
-  if (!sk) {
-    if (item.activityType && activityType != item.activityType) {
-      throw new Error(`activityType endpoint "${activityType}" doesn't match body's "${item.activityType}"`, { code: 400 });
-    }
-    if (item.activityId && activityId != item.activityId) {
-      throw new Error(`activityId endpoint "${activityId}" doesn't match body's "${item.activityId}"`, { code: 400 });
-    }
+  // You should have a activityType in queryParams or the item
+  if (!activityType && !item.activityType) {
+    throw new Error(`activityType is not specified in one of the requests.`, { code: 400 });
   }
 
-  const pk = `activity::${acCollectionId}`;
-  sk = sk ? sk : `${activityType}::${activityId}`;
-
-  validateSortKey(activityType, activityId, sk);
+  // activityType should be taken from queryParams, but can be taken from item if it's a bulk update
+  activityType = activityType ?? item?.activityType;
 
   if (requestType == "PUT") {
+    // Throw an error if activityId is not passed in
+    if (!activityId && !item.activityId) {
+      throw new Error(`activityId is not specified in one of the requests.`, { code: 400 });
+    }
+
+    // activityId should be taken from queryParams, but can be taken from item if it's a bulk update
+    activityId = activityId ?? item?.activityId;
+    sk = `${activityType}::${activityId}`;
+    
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;
     delete item.activityType;
     delete item.activityId;
   } else if (requestType == "POST") {
-    // Create items for the POST request
+    // Throw an error if activityId is passed in POST request, as we only allow auto increment for POST requests
+    if (activityId || item.activityId) {
+      throw new Error(
+        "Can't specify activityId in POST request; must be null to allow auto increment",
+        { code: 400 }
+      );
+    }
+
+    // If it's a POST request, we need to increment the identifier
+    // or we need to create the counter if it doesn't already exist. incrementItem does either.
+    // Pass in the item.schema and the acCollectionId with the activityType, e.g. "bcparks_7::dayuse"
+    const identifier = await incrementItem(item.schema, `${acCollectionId}::${activityType}`);
+
+    // Create the sk from the activityType and the identifier
+    sk = `${activityType}::${String(identifier)}`;
+
     item.pk = pk;
     item.sk = sk;
+    item.activityType = activityType;
+    item.activityId = identifier;
+    item.identifier = identifier;
   }
 
   return {
@@ -253,43 +276,10 @@ function processItem(acCollectionId, activityType, activityId, sk, item, request
   };
 }
 
-
-/**
- * Validates that the sort key is valid from the activityType and activityId if provided.
- *
- * @param {Object} activityType - Type of activity
- * @param {Object} activityId- The ID of the activity
- * @param {Object} sk- The sort key of the activity
- *
- * @returns {void}
- *
- * @throws {Exception} With code 400 if there's a mismatch between sk and activityType::activityId
- */
-function validateSortKey(activityType, activityId, sk) {
-  if (!sk && (!activityType && !activityId)) {
-    throw new Exception("sk, activityType, and activityId are required.", {
-      code: 400,
-    });
-  }
-
-  if (activityType && sk?.split("::")[0] !== activityType) {
-    throw new Exception(`sk "${sk}" in body does not match activityType "${activityType}"`, {
-      code: 400,
-    });
-  }
-
-  if (activityId && sk?.split("::")[1] != activityId) {
-    throw new Exception(`sk "${sk}" in body does not match activityId "${activityId}"`, {
-      code: 400,
-    });
-  }
-}
-
 module.exports = {
   getActivitiesByAcCollectionId,
   getActivitiesByActivityType,
   getActivityByActivityId,
   parseRequest,
-  processItem,
-  validateSortKey,
+  processItem
 };

--- a/lib/layers/dataUtils/facilities/configs.js
+++ b/lib/layers/dataUtils/facilities/configs.js
@@ -120,8 +120,7 @@ const FACILITY_API_PUT_CONFIG = {
     activities: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['object']);
-        value.map(v => rf.expectPrimaryKey(v));
+        rf.expectArray(value, ['string']);
         rf.expectAction(action, ['set']);
     }
   },
@@ -231,8 +230,7 @@ const FACILITY_API_UPDATE_CONFIG = {
     },
     activities: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['object']);
-        value.map(v => rf.expectPrimaryKey(v));
+        rf.expectArray(value, ['string']);
         rf.expectAction(action, ['set']);
       }
     },

--- a/lib/layers/dataUtils/facilities/methods.js
+++ b/lib/layers/dataUtils/facilities/methods.js
@@ -1,4 +1,4 @@
-const { TABLE_NAME, runQuery, getOne, marshall } = require("/opt/dynamodb");
+const { TABLE_NAME, runQuery, getOne, marshall, incrementItem } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/facilities/configs");
 
@@ -175,27 +175,25 @@ async function getFacilityByFacilityId(fcCollectionId, facilityType, facilityId)
  * Validates facilityType and facilityId parameters, falling back to body values if needed.
  *
  * @param {Object} fcCollectionId - Facility Collection ID number
- * @param {string} facilityType - Type of facility
- * @param {string} facilityId - ID of the facility
  * @param {Object|Array} body - Request payload (single item or array of items)
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} facilityType - Type of facility
+ * @param {string} [facilityId] - Optional ID of the facility
  *
  * @returns {Array} Array of processed update requests
  */
-function parseRequest(fcCollectionId, facilityType, facilityId, body, requestType) {
+async function parseRequest(fcCollectionId, body, requestType, facilityType, facilityId = null) {
   let updateRequests = [];
   // Check if the request is a batch request
   if (Array.isArray(body)) {
     for (let item of body) {
-      const { sk } = item;
       updateRequests.push(
-        processItem(fcCollectionId, facilityType, facilityId, sk, item, requestType)
+        await processItem(fcCollectionId, item, requestType, facilityType, facilityId)
       );
     }
   } else {
-    const { sk } = body;
     updateRequests.push(
-      processItem(fcCollectionId, facilityType, facilityId, sk, body, requestType)
+      await processItem(fcCollectionId, body, requestType, facilityType, facilityId)
     );
   }
 
@@ -207,42 +205,68 @@ function parseRequest(fcCollectionId, facilityType, facilityId, body, requestTyp
  * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
  *
  * @param {Object} fcCollectionId - Facility Collection ID number
- * @param {string} facilityType - Type of facility
- * @param {string} facilityId - ID of the facility
- * @param {string} [sk] - Optional sort key (defaults to ${facilityType}::${facilityId})
  * @param {Object} item - Item data to process
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} facilityType - Type of facility
+ * @param {string} [facilityId] - Optional ID of the facility
  *
  * @returns {Object} Processed item with key structure and data
  */
-function processItem(fcCollectionId, facilityType, facilityId, sk, item, requestType) {
-  facilityType = facilityType ?? item?.facilityType;
-  facilityId = facilityId ?? item?.facilityId;
+async function processItem(
+  fcCollectionId,
+  item,
+  requestType,
+  facilityType,
+  facilityId = null
+) {
+  const pk = `facility::${fcCollectionId}`;
+  let sk = null
 
-  if (!sk) {
-    if (item.facilityType && facilityType != item.facilityType) {
-      throw new Error(`facilityType endpoint "${facilityType}" doesn't match body's "${item.facilityType}"`, { code: 400 });
-    }
-    if (item.facilityId && facilityId != item.facilityId) {
-      throw new Error(`facilityId endpoint "${facilityId}" doesn't match body's "${item.facilityId}"`, { code: 400 });
-    }
+  // You should have a facilityType in queryParams or the item
+  if (!facilityType && !item.facilityType) {
+    throw new Error(`facilityType is not specified in one of the requests.`, { code: 400 });
   }
 
-  const pk = `facility::${fcCollectionId}`;
-  sk = sk ? sk : `${facilityType}::${facilityId}`;
-
-  validateSortKey(facilityType, facilityId, sk);
+  // facilityType should be taken from queryParams, but can be taken from item if it's a bulk update
+  facilityType = facilityType ?? item?.facilityType;
 
   if (requestType == "PUT") {
+    // Throw an error if facilityId is not passed in
+    if (!facilityId && !item.facilityId) {
+      throw new Error(`facilityId is not specified in one of the requests.`, { code: 400 });
+    }
+
+    // facilityId should be taken from queryParams, but can be taken from item if it's a bulk update
+    facilityId = facilityId ?? item?.facilityId;
+    sk = `${facilityType}::${facilityId}`;
+    
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;
     delete item.facilityType;
     delete item.facilityId;
   } else if (requestType == "POST") {
-    // Create items for the POST request
+    // Throw an error if facilityId is passed in POST request, as we only allow auto increment for POST requests
+    if (facilityId || item.facilityId) {
+      throw new Error(
+        "Can't specify facilityId in POST request; must be null to allow auto increment",
+        { code: 400 }
+      );
+    }
+
+    // If it's a POST request, we need to increment the identifier
+    // or we need to create the counter if it doesn't already exist. incrementItem does either.
+    // Pass in the item.schema and the fcCollectionId with the facilityType, e.g. "bcparks_7::structure"
+    const identifier = await incrementItem(item.schema, `${fcCollectionId}::${facilityType}`);
+
+    // Create the sk from the facilityType and the identifier
+    sk = `${facilityType}::${String(identifier)}`;
+
     item.pk = pk;
     item.sk = sk;
+    item.facilityType = facilityType;
+    item.facilityId = identifier;
+    item.identifier = identifier;
   }
 
   return {
@@ -251,43 +275,10 @@ function processItem(fcCollectionId, facilityType, facilityId, sk, item, request
   };
 }
 
-
-/**
- * Validates that the sort key is valid from the facilityType and facilityId if provided.
- *
- * @param {Object} facilityType - Type of facility
- * @param {Object} facilityId- The ID of the facility
- * @param {Object} sk- The sort key of the facility
- *
- * @returns {void}
- *
- * @throws {Exception} With code 400 if there's a mismatch between sk and facilityType::facilityId
- */
-function validateSortKey(facilityType, facilityId, sk) {
-  if (!sk && (!facilityType && !facilityId)) {
-    throw new Exception("sk, facilityType, and facilityId are required.", {
-      code: 400,
-    });
-  }
-
-  if (facilityType && sk?.split("::")[0] !== facilityType) {
-    throw new Exception(`sk "${sk}" in body does not match facilityType "${facilityType}"`, {
-      code: 400,
-    });
-  }
-
-  if (facilityId && sk?.split("::")[1] != facilityId) {
-    throw new Exception(`sk "${sk}" in body does not match facilityId "${facilityId}"`, {
-      code: 400,
-    });
-  }
-}
-
 module.exports = {
   getFacilitiesByFcCollectionId,
   getFacilitiesByFacilityType,
   getFacilityByFacilityId,
   parseRequest,
-  processItem,
-  validateSortKey,
+  processItem
 };

--- a/lib/layers/dataUtils/geozones/configs.js
+++ b/lib/layers/dataUtils/geozones/configs.js
@@ -122,14 +122,12 @@ const GEOZONE_API_PUT_CONFIG = {
     facilities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
@@ -222,14 +220,12 @@ const GEOZONE_API_UPDATE_CONFIG = {
     facilities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
-        value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },

--- a/lib/layers/dataUtils/geozones/methods.js
+++ b/lib/layers/dataUtils/geozones/methods.js
@@ -1,4 +1,9 @@
-const { TABLE_NAME, runQuery, getOne, marshall } = require("/opt/dynamodb");
+const {
+  TABLE_NAME,
+  runQuery,
+  marshall,
+  incrementItem
+} = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/geozones/configs");
 
@@ -17,7 +22,8 @@ function addFilters(queryObj, filters) {
       if (item.name in filters) {
         if (queryObj.FilterExpression) {
           queryObj.FilterExpression += " AND ";
-        } if (!queryObj.FilterExpression) {
+        }
+        if (!queryObj.FilterExpression) {
           queryObj.FilterExpression = "";
         }
         if (!queryObj.ExpressionAttributeNames) {
@@ -98,6 +104,7 @@ async function getGeozonesByGzCollectionId(
  * @async
  * @param {Object} gzCollectionId - The GzCollectionId of the geozone.
  * @param {Object} geozoneId - The geozone to retrieve.
+ * @param {Object} filters - Allowed filters for the item.
  * @param {Object} [params] - Optional parameters for pagination control.
  * @param {number} [params.limit] - Maximum number of items to return.
  * @param {string} [params.lastEvaluatedKey] - Key to resume pagination from.
@@ -145,29 +152,26 @@ async function getGeozonesByGeozoneId(
 
 /**
  * Processes incoming requests by handling batch operations and individual items.
- * Validates geozoneId parameter, falling back to body values if needed.
  *
  * @param {Object} gzCollectionId - gzCollectionId (e.g. bcparks::1)
- * @param {string} geozoneId - ID of the geozone
  * @param {Object|Array} body - Request payload (single item or array of items)
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} [geozoneId] - Optional ID of the geozone (for "PUT" requests)
  *
  * @returns {Array} Array of processed update requests
  */
-function parseRequest(gzCollectionId, geozoneId, body, requestType) {
+async function parseRequest(gzCollectionId, body, requestType, geozoneId = null) {
   let updateRequests = [];
   // Check if the request is a batch request
   if (Array.isArray(body)) {
     for (let item of body) {
-      const { sk } = item;
       updateRequests.push(
-        processItem(gzCollectionId, geozoneId, sk, item, requestType)
+        await processItem(gzCollectionId, item, requestType, geozoneId)
       );
     }
   } else {
-    const { sk } = body;
     updateRequests.push(
-      processItem(gzCollectionId, geozoneId, sk, body, requestType)
+      await processItem(gzCollectionId, body, requestType, geozoneId)
     );
   }
 
@@ -179,36 +183,58 @@ function parseRequest(gzCollectionId, geozoneId, body, requestType) {
  * Handles PUT and POST requests differently, managing primary and sort keys accordingly.
  *
  * @param {Object} gzCollectionId - gzCollectionId (e.g. bcparks::1)
- * @param {string} geozoneId - ID of the geozone
- * @param {string} [sk] - Optional sort key (defaults to ${geozoneId})
  * @param {Object} item - Item data to process
  * @param {string} requestType - Type of HTTP request ("PUT" or "POST")
+ * @param {string} [geozoneId] - Optional ID of the geozone
  *
  * @returns {Object} Processed item with key structure and data
  */
-function processItem(gzCollectionId, geozoneId, sk, item, requestType) {  
-  geozoneId = geozoneId ?? item?.geozoneId;
-  
-  if (!sk) {
-    if (item.geozoneId && geozoneId != item.geozoneId) {
-      throw new Error(`geozoneId endpoint "${geozoneId}" doesn't match body's "${item.geozoneId}"`, { code: 400 });
-    }
-  }
-    
+async function processItem(
+  gzCollectionId,
+  item,
+  requestType,
+  geozoneId = null
+) {
   const pk = `geozone::${gzCollectionId}`;
-  sk = sk ? sk : `${geozoneId}`;
-  
-  validateSortKey(geozoneId, sk);
+  let sk = null
 
   if (requestType == "PUT") {
+    // Throw an error if geozoneId is not passed in
+    if (!geozoneId && !item.geozoneId) {
+      throw new Error(`geozoneId is not specified in one of the requests.`, { code: 400 });
+    }
+
+    // geozoneId should be taken from queryParams, but can be taken from item if it's a bulk update
+    geozoneId = geozoneId ?? item?.geozoneId;
+    sk = geozoneId;
+    
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;
     delete item.geozoneId;
   } else if (requestType == "POST") {
-    // Create items for the POST request
+    // Throw an error if geozoneId is passed in POST request, as we only allow auto increment for POST requests
+    if (geozoneId || item.geozoneId) {
+      throw new Error(
+        "Can't specify geozoneId in POST request; must be null to allow auto increment",
+        { code: 400 }
+      );
+    }
+
+    // If it's a POST request, we need to increment the identifier
+    // or we need to create the counter if it doesn't already exist. incrementItem does either.
+    // Pass in the item.schema (geozone) and the skCollection, which is everything before "::" or "_" or "#"
+    // break, e.g. "bcparks_7" or a user's sub "a81bc81b-dead-4e5d-abff-90865d1e13b1#123"
+    const skCollection = gzCollectionId.split(/::|_|#/)[0];
+    const identifier = await incrementItem(item.schema, skCollection);
+
+    // Create the sk from the identifier
+    sk = String(identifier);
+
     item.pk = pk;
     item.sk = sk;
+    item.geozoneId = identifier;
+    item.identifier = identifier;
   }
 
   return {
@@ -217,34 +243,8 @@ function processItem(gzCollectionId, geozoneId, sk, item, requestType) {
   };
 }
 
-
-/**
- * Validates that the sort key is valid from the geozoneId if provided.
- *
- * @param {Object} geozoneId- The ID of the geozone
- * @param {Object} sk- The sort key of the geozone
- *
- * @returns {void}
- *
- * @throws {Exception} With code 400 if there's a mismatch between sk and geozoneType::geozoneId
- */
-function validateSortKey(geozoneId, sk) {
-  if (!sk && !geozoneId) {
-    throw new Exception("sk and geozoneId are required.", {
-      code: 400,
-    });
-  }
-
-  if (geozoneId && sk != geozoneId) {
-    throw new Exception("sk does not match geozoneId", {
-      code: 400,
-    });
-  }
-}
-
 module.exports = {
   getGeozonesByGzCollectionId,
   getGeozonesByGeozoneId,
-  parseRequest,
-  validateSortKey,
+  parseRequest
 };


### PR DESCRIPTION
### Ticket:
BRS-89

### Ticket URL:
#89 

### Description:
Refactor activity request handling, update validation logic, and add counter support

- Update to Geozone
  - `resource.js`
    - update `pathParameters` to be camelCase (applies to GET, POST, PUT, and DELETE)
  - POST
    - requests are now `async` to allow increment transaction with Dynamo
    - remove `geozoneId` as this now auto increments and the user cannot specify in POST request
  - PUT
    - requests are now `async` as increment transactions are within same method
  - DELETE
    - Remove unused `validateSortKey` import.
  - `method.js`
    - Rework functions to allow for `null` IDs (for auto increment)
    - Remove `validateSortKey` function. Make it more strict to build sk, and do not allow `sk` to be passed in as an item (must be created from `geozoneId`).
    - ActivityID is optional, as it might only be supplied in body of request and not as a `queryParams`
    - `parseRequest` and `processItem` now async for `incrementItem` function
    - Throw `error` if activityType not provided
    - Throw `error` if user attempts to provide `activityId` as these are auto incremented now
  
- Update to Facilities
  - POST
    - requests are now `async` to allow increment transaction with Dynamo
  - PUT
    - requests are now `async` as increment transactions are within same method
  - `method.js`
    - Rework functions to allow for `null` IDs (for auto increment)
    - Remove `validateSortKey` function. Make it more strict to build sk, and do not allow `sk` to be passed in as an item (must be created from `facilityType` and `facilityId`
    - `parseRequest` and `processItem` now async for `incrementItem` function
    - Throw `error` if facilityType not provided
    - Throw `error` if user attempts to provide `activityId` as these are auto incremented now
  - DELETE
    - Remove unused `validateSortKey` import

- Update to Activities
  - POST
    - requests are now `async` to allow increment transaction with Dynamo
  - PUT
    - requests are now `async` as increment transactions are within same method
  - `method.js`
    - Rework functions to allow for `null` IDs (for auto increment)
    - Remove `validateSortKey` function. Make it more strict to build sk, and do not allow `sk` to be passed in as an item (must be created from `activityType` and `activityId`
    - ActivityID is optional, as it might only be supplied in body of request and not as a `queryParams`
    - `parseRequest` and `processItem` now async for `incrementItem` function
    - Throw `error` if activityType not provided
    - Throw `error` if user attempts to provide `activityId` as these are auto incremented now

- Created `incrementItem` function to increment a counter value in DynamoDB, which will also create an item counter if it doesn't already exist in Dynamo.
  - Counter in dynamo, such as:
  ```
  pk: counter::facility
  sk: bcparks_997::structure
  counterValue: 1
  ```
 
- Several `config.js` fixes
- Updates to Postman endpoints following changes