### PR TITLE
adding Products GET and minor changes to facilitate data insertion

### DIFF
--- a/lib/handlers/products/_byPartition/GET/index.js
+++ b/lib/handlers/products/_byPartition/GET/index.js
@@ -1,0 +1,48 @@
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { getProducts } = require("/opt/products/methods");
+
+exports.handler = async (event, context) => {
+  logger.info("GET Products", event);
+
+  if (event?.httpMethod === "OPTIONS") {
+    return sendResponse(200, null, "Success", null, context);
+  }
+
+  const acCollectionId = event?.pathParameters?.acCollectionId || null;
+  const activityType = event?.pathParameters?.activityType || null;
+  const activityId = event?.pathParameters?.activityId || null;
+  const seasonId = event?.pathParameters?.seasonId || null;
+  const productId = event?.pathParameters?.productId || null;
+
+  const getPolicies = event?.queryStringParameters?.getPolicies || null;
+
+  if (!acCollectionId || !activityType || !activityId) {
+    throw new Exception("Activity Collection ID (acCollectionId), Activity Type and Activity ID are required", { code: 400 });
+  }
+
+  if (!seasonId && productId) {
+    throw new Exception("Season ID is required when product ID is provided", { code: 400 });
+  }
+
+  const products = await getProducts(
+    acCollectionId,
+    activityType,
+    activityId,
+    seasonId,
+    productId, {
+      getPolicies: getPolicies
+    }
+  );
+
+  try {
+    return sendResponse(200, products, "Success", null, context);
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/lib/handlers/products/resources.js
+++ b/lib/handlers/products/resources.js
@@ -1,0 +1,58 @@
+/**
+ * CDK resources for the products API.
+ */
+
+const lambda = require('aws-cdk-lib/aws-lambda');
+const apigateway = require('aws-cdk-lib/aws-apigateway');
+const iam = require('aws-cdk-lib/aws-iam');
+const { NodejsFunction } = require("aws-cdk-lib/aws-lambda-nodejs");
+
+function productsSetup(scope, props) {
+  console.log('products handlers setup...');
+
+  // /products resource
+  const productsResource = props.api.root.addResource('products');
+
+  // /products/{acCollectionId}/{activityType}/{activityId} resource. All belong to the partition so there is no ability to query any of them individually
+  const productsPartitionResource = productsResource.addResource('{acCollectionId}').addResource('{activityType}').addResource('{activityId}');
+
+  // GET /products/{acCollectionId}/{activityType}/{activityId} - Get all products for a given activity
+  const productsGetMethod = new NodejsFunction(scope, 'ProductsGetByPartition', {
+    code: lambda.Code.fromAsset('lib/handlers/products/_byPartition/GET'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  productsPartitionResource.addMethod('GET', new apigateway.LambdaIntegration(productsGetMethod));
+
+  // GET /products/{acCollectionId}/{activityType}/{activityId}/{seasonId} - Get all products for a given activity and season
+  const productsSeasonIdResource = productsPartitionResource.addResource('{seasonId}');
+  productsSeasonIdResource.addMethod('GET', new apigateway.LambdaIntegration(productsGetMethod));
+
+  // GET /products/{acCollectionId}/{activityType}/{activityId}/{seasonId}/{productId} - Get a single product by identifier
+  const productsProductIdResource = productsSeasonIdResource.addResource('{productId}');
+  productsProductIdResource.addMethod('GET', new apigateway.LambdaIntegration(productsGetMethod));
+
+  // Add DynamoDB query & getItem policies to the functions
+  const dynamoDbPolicy = new iam.PolicyStatement({
+    actions: [
+      'dynamodb:Query',
+      'dynamodb:GetItem',
+      'dynamodb:Scan',
+      'dynamodb:BatchGet*'
+    ],
+    resources: [props.mainTable.tableArn],
+  });
+
+  productsGetMethod.addToRolePolicy(dynamoDbPolicy);
+
+  return {
+    productsGetMethod: productsGetMethod,
+    productsResource: productsResource,
+  };
+}
+
+module.exports = {
+  productsSetup,
+};

--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -315,6 +315,7 @@ module.exports = {
   TABLE_NAME,
   USER_ID_PARTITION,
   batchGetData,
+  batchGetDataPromise,
   batchTransactData,
   batchWriteData,
   deleteItem,

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -119,7 +119,7 @@ const ACTIVITY_API_PUT_CONFIG = {
     },
     geozone: {
       rulesFn: ({ value, action }) => {
-        rf.expectType(value, ['string']);
+        rf.expectPrimaryKey(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -207,7 +207,7 @@ const ACTIVITY_API_UPDATE_CONFIG = {
     },
     geozone: {
       rulesFn: ({ value, action }) => {
-        rf.expectType(value, ['string']);
+        rf.expectPrimaryKey(value);
         rf.expectAction(action, ['set']);
       }
     },

--- a/lib/layers/dataUtils/products/methods.js
+++ b/lib/layers/dataUtils/products/methods.js
@@ -5,6 +5,65 @@ const { POLICY_TYPES } = require('/opt/policies/configs');
 const { PRODUCT_DAILY_PROPERTIES_CONFIG, PRODUCT_DEFAULT_PROPERTY_NAMES, PRODUCT_DEFAULT_SCHEDULE_RANGE } = require('/opt/products/configs');
 const { quickApiPutHandler } = require('/opt/data-utils');
 
+async function getProducts(acCollectionId, activityType, activityId, seasonId = null, productId = null, options = {}) {
+  logger.info('Get Product(s)');
+  try {
+    if (!acCollectionId || !activityType || !activityId) {
+      throw 'Activity Collection ID, Activity Type and Activity Id are required';
+    }
+    if (!seasonId && productId) {
+      throw 'Season ID is required if Product ID is provided';
+    }
+    const queryObj = {
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: {
+        ':pk': { S: `product::${acCollectionId}::${activityType}::${activityId}` },
+      },
+    };
+    if (seasonId) {
+      if (productId) {
+        queryObj.KeyConditionExpression += ' AND sk = :sk';
+        queryObj.ExpressionAttributeValues[':sk'] = { S: `${seasonId}::${productId}` };
+      } else {
+        queryObj.KeyConditionExpression += ' AND begins_with(sk, :sk)';
+        queryObj.ExpressionAttributeValues[':sk'] = { S: `${seasonId}` };
+      }
+    }
+    let res = await runQuery(queryObj);
+    // If we want to also get the relevant policies, we will do a parallelized batch get
+    // for each of the policies in the product.
+    // Each product can have multiple policies, so we do a batch get where everything is fired off at once.
+    if (options?.getPolicies && res?.items?.length) {
+      let promises = [];
+      res.items?.map((item => {
+        promises.push(new Promise((resolve, reject) => {
+          let policies = {
+            bookingPolicy: [item?.bookingPolicy],
+            changePolicy: [item?.changePolicy],
+            partyPolicy: [item?.partyPolicy],
+          };
+          try {
+            parallelizedBatchGetData(policies, TABLE_NAME).then(results => {
+              for (const result of results) {
+                item[result.key] = result.data;
+              }
+              resolve();
+            });
+          } catch (error) {
+            reject(error);
+          }
+        }));
+      }));
+      await Promise.all(promises);
+    }
+    logger.info(`Products: ${res?.items?.length} found.`);
+    return res;
+  } catch (error) {
+    throw new Exception('Error getting products', { code: 400, error: error });
+  }
+}
+
 async function getProductsByActivity(orcs, activityType, activityId) {
   logger.info('Get Products By Activity', orcs, activityType, activityId);
   try {
@@ -244,6 +303,7 @@ async function deleteOldProducts(productsToDelete) {
 
 module.exports = {
   buildSchedule,
+  getProducts,
   getProductsByActivity,
   getProductById,
 };

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -18,6 +18,7 @@ const { activitiesSetup } = require('./handlers/activities/resources');
 const { configSetup } = require('./handlers/config/resources');
 const { facilitiesSetup } = require('./handlers/facilities/resources');
 const { geozonesSetup } = require('./handlers/geozones/resources');
+const { productsSetup } = require('./handlers/products/resources');
 const { protectedAreasSetup } = require('./handlers/protectedAreas/resources');
 const { searchSetup } = require('./handlers/search/resources');
 const { streamSetup } = require('./handlers/dynamoStream/resources');
@@ -134,6 +135,18 @@ class ReserveRecCdkStack extends Stack {
 
     // Geozone
     const geozonesResources = geozonesSetup(this, {
+      env: props.env,
+      api: apigwResources.api,
+      layers: [
+        layerResources.baseLayer,
+        layerResources.awsUtilsLayer,
+        layerResources.dataUtilsLayer
+      ],
+      mainTable: dynamodbResources.mainTable,
+    });
+
+    // Products
+    const productsResources = productsSetup(this, {
       env: props.env,
       api: apigwResources.api,
       layers: [


### PR DESCRIPTION
Relates to #69 and #70.

Adding `GET Products` endpoint. Subject to change based on the outcome of the scheduling data model changes.

```
GET products/acCollectionId/activityType/activityId/seasonId/productId
```

If queryParams `getPolicies=true` is passed in, the internal policies within the product are queried and populated by Dynamodb `BatchGET`. 