### PR TITLE
changing default mainIndex mappings

### DIFF
--- a/lib/handlers/tooling/opensearch/createMainIndex/index.js
+++ b/lib/handlers/tooling/opensearch/createMainIndex/index.js
@@ -22,6 +22,31 @@ const mainIndexMappingOptions = {
     // envelope
     envelope: {
       type: 'geo_shape'
+    },
+    // geozone
+    geozone: {
+      type: 'object'
+    },
+    // facility
+    facilities: {
+      type: 'object'
+    },
+    // activity
+    activities: {
+      type: 'object'
+    },
+    // policies
+    bookingPolicy: {
+      type: 'object'
+    },
+    changePolicy: {
+      type: 'object'
+    },
+    partyPolicy: {
+      type: 'object'
+    },
+    feePolicy: {
+      type: 'object'
     }
   }
 };


### PR DESCRIPTION
Adding geozone, facilities, activities, and policies as `object` field mapping types by default in opensearch