### PR TITLE
PRDT-98 Adding Bookings POST/GET

### DIFF
--- a/lib/cdk/dynamodb.js
+++ b/lib/cdk/dynamodb.js
@@ -20,6 +20,13 @@ function dynamodbSetup(scope, props) {
     removalPolicy: RemovalPolicy.RETAIN
   });
 
+  // Add gsi1pk (UUID) as a GSI
+  mainTable.addGlobalSecondaryIndex({
+    indexName: 'globalId-index',
+    partitionKey: { name: 'globalId', type: dynamodb.AttributeType.STRING },
+    projectionType: dynamodb.ProjectionType.ALL,
+  });
+
   // Audit Table
   const auditTable = new dynamodb.Table(scope, 'AuditTable', {
     tableName: props.env.AUDIT_TABLE_NAME,
@@ -70,7 +77,7 @@ function dynamodbSetup(scope, props) {
     description: 'PubSub Table',
     exportName: 'PubSubTableName',
   });
-  
+
   new CfnOutput(scope, 'CounterTableName', {
     value: counterTable.tableName,
     description: 'Counter Table',

--- a/lib/handlers/activities/resources.js
+++ b/lib/handlers/activities/resources.js
@@ -78,7 +78,8 @@ function activitiesSetup(scope, props) {
     activitiesPostByAcCollectionId: activitiesPostByAcCollectionId,
     activitiesPutByAcCollectionId: activitiesPutByAcCollectionId,
     activitiesDeleteByAcCollectionId: activitiesDeleteByAcCollectionId,
-    activitiesResource: activitiesResource
+    activitiesResource: activitiesResource,
+    activitiesCollectionIdResource: activitiesCollectionIdResource,
   };
 }
 

--- a/lib/handlers/bookings/GET/index.js
+++ b/lib/handlers/bookings/GET/index.js
@@ -1,0 +1,48 @@
+// Get booking
+
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { getBookingByBookingId, getBookingsByActivityDetails } = require("/opt/bookings/methods");
+
+exports.handler = async (event, context) => {
+  logger.info("Bookings GET:", event);
+
+  // Allow CORS
+  if (event.httpMethod === 'OPTIONS') {
+    return sendResponse(200, {}, 'Success', null, context);
+  }
+
+  try {
+    // Get relevant data from the event
+    // Search by ID
+    const bookingId = event?.pathParameters?.bookingId || event?.queryStringParameters?.bookingId;
+    const acCollectionId = event?.pathParameters?.acCollectionId || event?.queryStringParameters?.acCollectionId;
+    const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId;
+    const startDate = event?.pathParameters?.startDate || event?.queryStringParameters?.startDate;
+    const endDate = event?.pathParameters?.endDate || event?.queryStringParameters?.endDate || null;
+
+    if (bookingId) {
+      // Get booking by bookingId
+      const booking = await getBookingByBookingId(bookingId);
+      return sendResponse(200, booking, "Success", null, context);
+    }
+
+    if (!acCollectionId || !activityType || !activityId || !startDate) {
+      throw new Exception("Booking ID (bookingId) OR Activity Collection ID (acCollectionId), Activity Type (activityType), Activity ID (activityId) and Start Date (startDate) are required", { code: 400 });
+    }
+
+    const bookings = await getBookingsByActivityDetails(acCollectionId, activityType, activityId, startDate, endDate);
+
+    return sendResponse(200, bookings, "Success", null, context);
+
+  } catch (error) {
+    logger.error("Error in bookings GET:", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.msg || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/lib/handlers/bookings/POST/index.js
+++ b/lib/handlers/bookings/POST/index.js
@@ -1,0 +1,55 @@
+// Create new booking
+const { Exception, logger, sendResponse } = require("/opt/base");
+const { createBooking } = require("/opt/bookings/methods");
+const { BOOKING_PUT_CONFIG } = require("/opt/bookings/configs");
+const { quickApiPutHandler } = require("/opt/data-utils");
+const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+
+exports.handler = async (event, context) => {
+  logger.info("Bookings POST:", event);
+
+  try {
+    // Get relevant data from the event
+
+    const body = JSON.parse(event?.body);
+    if (!body) {
+      throw new Exception("Body is required", { code: 400 });
+    }
+
+    const acCollectionId = event?.pathParameters?.acCollectionId || event?.queryStringParameters?.acCollectionId || body?.acCollectionId;
+    const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType || body?.activityType;
+    const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId || body?.activityId;
+    const startDate = event?.pathParameters?.startDate || event?.queryStringParameters?.startDate || body?.startDate;
+
+
+    if (!acCollectionId || !activityType || !activityId || !startDate) {
+      throw new Exception("Activity Collection ID (acCollectionId), Activity Type (activityType), Activity ID (activityId) and Start Date (startDate) are required", { code: 400 });
+    }
+
+    let postRequests = await createBooking(acCollectionId, activityType, activityId, startDate, body);
+
+    const putItems = await quickApiPutHandler(
+      TABLE_NAME,
+      postRequests,
+      BOOKING_PUT_CONFIG
+    );
+
+    const res = await batchTransactData(putItems);
+
+    const response = {
+      res: res,
+      booking: postRequests,
+    }
+
+    return sendResponse(200, response, "Success", null, context);
+
+  } catch (error) {
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+}

--- a/lib/handlers/bookings/resources.js
+++ b/lib/handlers/bookings/resources.js
@@ -1,0 +1,87 @@
+/**
+ * CDK resources for the bookings API.
+ *
+ * Note: Pursuant of completing an E2E proof of concept, a planned step has been skipped:
+ *
+ * Bookings generally were planned to be made against a specific Product datatype, such that policies and date
+ * restrictions could be applied. For the E2E, only backcountry registration offerings are being considered, which
+ * are unlimited in quanity and typically offered year-round. Because of this, it is assumed that no verification of
+ * the Product type is required, and therefore bookings can be made against the Activity datatype.
+ *
+ * This assumtion is not a requirement of the system, but rather a design decision made to simplify the E2E proof of
+ * concept. It will need to be revised in the future to handle the more complex case of verifying the bookings.
+ */
+
+const lambda = require('aws-cdk-lib/aws-lambda');
+const apigateway = require('aws-cdk-lib/aws-apigateway');
+const iam = require('aws-cdk-lib/aws-iam');
+const { NodejsFunction } = require("aws-cdk-lib/aws-lambda-nodejs");
+
+function bookingsSetup(scope, props) {
+  console.log('Bookings handlers setup...');
+
+  // /bookings resource
+  const bookingsResource = props.api.root.addResource('bookings');
+
+  // /bookings/{bookingId} resource (specific booking)
+  const bookingsByBookingIdResource = bookingsResource.addResource('{bookingId}');
+
+  // /bookings by activity resource (extends from /activities/{acCollectionId}/{activityType}/{activityId}/{startDate}/bookings)
+  const bookingsByActivityResource = props.activitiesResources.activitiesCollectionIdResource
+    .addResource('{activityType}')
+    .addResource('{activityId}')
+    .addResource('{startDate}')
+    .addResource('bookings');
+
+  // GET /bookings
+  const bookingsGet = new NodejsFunction(scope, 'BookingsGet', {
+    code: lambda.Code.fromAsset('lib/handlers/bookings/GET'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+  bookingsResource.addMethod('GET', new apigateway.LambdaIntegration(bookingsGet));
+  bookingsByBookingIdResource.addMethod('GET', new apigateway.LambdaIntegration(bookingsGet));
+  bookingsByActivityResource.addMethod('GET', new apigateway.LambdaIntegration(bookingsGet));
+
+  // POST /bookings
+  const bookingsPost = new NodejsFunction(scope, 'BookingsPost', {
+    code: lambda.Code.fromAsset('lib/handlers/bookings/POST'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+  });
+
+  bookingsResource.addMethod('POST', new apigateway.LambdaIntegration(bookingsPost));
+  bookingsByActivityResource.addMethod('POST', new apigateway.LambdaIntegration(bookingsPost));
+
+  const dynamodbPolicy = new iam.PolicyStatement({
+    actions: [
+      'dynamodb:BatchGetItem',
+      'dynamodb:BatchWriteItem',
+      'dynamodb:PutItem',
+      'dynamodb:GetItem',
+      'dynamodb:Query',
+      'dynamodb:Scan',
+      'dynamodb:UpdateItem',
+    ],
+    resources: [props.env.TABLE_NAME],
+  });
+  bookingsGet.addToRolePolicy(dynamodbPolicy);
+  bookingsPost.addToRolePolicy(dynamodbPolicy);
+
+  return {
+    bookingsResource: bookingsResource,
+    bookingsByBookingIdResource: bookingsByBookingIdResource,
+    bookingsByActivityResource: bookingsByActivityResource,
+    bookingsGet: bookingsGet,
+    bookingsPost: bookingsPost,
+  };
+
+}
+
+module.exports = {
+  bookingsSetup,
+};

--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -3,6 +3,7 @@ const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
 const { logger } = require('/opt/base');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'reserve-rec';
+const GLOBALID_INDEX_NAME = 'globalId-index';
 const AUDIT_TABLE_NAME = process.env.AUDIT_TABLE_NAME || 'Audit';
 const PUBSUB_TABLE_NAME = process.env.PUBSUB_TABLE_NAME || 'reserve-rec-pubsub';
 const COUNTER_TABLE_NAME = process.env.COUNTER_TABLE_NAME || 'reserve-rec-counter'
@@ -24,10 +25,10 @@ const dynamodb = new DynamoDB(options);
 const dynamodbClient = new DynamoDBClient(options);
 
 // simple way to return a single Item by primary key.
-async function getOne(pk, sk) {
+async function getOne(pk, sk, tableName = TABLE_NAME) {
   logger.info(`getItem: { pk: ${pk}, sk: ${sk} }`);
   const params = {
-    TableName: TABLE_NAME,
+    TableName: tableName,
     Key: marshall({ pk, sk }),
   };
   let item = await dynamodbClient.send(new GetItemCommand(params));
@@ -43,7 +44,7 @@ async function getOne(pk, sk) {
  * @param {string} pk - The schema identifier (e.g. "geozone::bcparks_7")
  * @param {Array} collectionType - An optional array of collection types for
  *                                 the counter item (e.g. "structure", "dayuse")
- * 
+ *
  * @returns {integer} The next logical ID for the counter value.
  */
 async function incrementCounter(pk, collectionType = []) {
@@ -150,11 +151,11 @@ async function incrementCounter(pk, collectionType = []) {
 /**
  * Reset's an item's counter in counter table. Queries the existing items using
  *  the pk and partial sk, maps and finds what the next logical ID should be.
- * 
+ *
  * @param {string} pk - pk of the item
  * @param {string} sk - concatenated string with sk's collection types, without
  *                      their identifier, e.g. "structure" or "foo::bar" etc.
- * 
+ *
  * @returns {void} Resets the counter value, throws error otherwise.
  */
 async function resetCounter(pk, skType) {
@@ -204,6 +205,29 @@ async function resetCounter(pk, skType) {
     logger.error("Error with resetCounter: ", error)
   }
 }
+async function getOneByGlobalId(globalId, globalIdAttributeName = 'globalId', tableName = TABLE_NAME, indexName = GLOBALID_INDEX_NAME) {
+  logger.info(`getItem by index: { ${globalIdAttributeName}: ${globalId}, indexName: ${indexName} }`);
+
+  // GetItem operation is not supported on GSIs, so we need to use Query instead.
+  const params = {
+    TableName: tableName,
+    IndexName: indexName,
+    KeyConditionExpression: '#globalId = :globalId',
+    ExpressionAttributeValues: {
+      ':globalId': marshall(globalId),
+    },
+    ExpressionAttributeNames: {
+      '#globalId': globalIdAttributeName,
+    }
+  };
+
+  let item = await runQuery(params);
+  if (item?.items?.[0]) {
+    return item.items[0];
+  }
+  return null;
+}
+
 
 async function runQuery(query, limit = null, lastEvaluatedKey = null, paginated = true) {
   let data = [];
@@ -477,6 +501,7 @@ async function batchTransactData(data, action = 'Put') {
 module.exports = {
   AUDIT_TABLE_NAME,
   AWS_REGION,
+  GLOBALID_INDEX_NAME,
   PUBSUB_TABLE_NAME,
   PutItemCommand,
   QueryCommand,
@@ -491,6 +516,7 @@ module.exports = {
   dynamodbClient,
   getOne,
   incrementCounter,
+  getOneByGlobalId,
   marshall,
   parallelizedBatchGetData,
   putItem,

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -1,4 +1,5 @@
 const { rulesFns } = require('/opt/validation-rules');
+const { ACTIVITY_TYPE_ENUMS, SUB_ACTIVITY_TYPE_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
 
@@ -8,36 +9,6 @@ ALLOWED_FILTERS = [
   { name: "subActivityType", type: "list" },
   { name: "facilities", type: "list" }
 ];
-
-const SUB_ACTIVITY_TYPE_ENUMS = [
-  'campsite',
-  'walkin',
-  'rv',
-  'reservation',
-  'passport',
-  'vehicleParking',
-  'trailUse',
-  'shelterUse',
-  'saniUse',
-  'showerUse',
-  'elecUse',
-  'dockMooring',
-  'buoyMooring',
-  'frontcountry',
-  'backcountry',
-  'portionCircuit',
-  'fullCircuit',
-];
-const ACTIVITY_TYPE_ENUMS = [
-  'frontcountryCamp',
-  'backcountryCamp',
-  'groupCamp',
-  'dayuse',
-  'boating',
-  'cabinStay',
-  'canoe'
-];
-
 
 const ACTIVITY_API_PUT_CONFIG = {
   failOnError: true,

--- a/lib/layers/dataUtils/bookings/configs.js
+++ b/lib/layers/dataUtils/bookings/configs.js
@@ -1,0 +1,338 @@
+const { rulesFns } = require('/opt/validation-rules');
+const { ACTIVITY_TYPE_ENUMS, BOOKING_STATUS_ENUMS, SUB_ACTIVITY_TYPE_ENUMS, TIMEZONE_ENUMS, PARTY_AGE_CATEGORY_ENUMS, RATE_CLASS_ENUMS } = require('/opt/data-constants');
+
+const rf = new rulesFns();
+
+const BOOKING_PUT_CONFIG = {
+  failOnError: true,
+  autoTimeStamp: true,
+  autoVersion: true,
+  allowOverwrite: false,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    schema: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ['booking']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    globalId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    bookingId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    startDate: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectISODateObjFormat(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    endDate: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectISODateObjFormat(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    timezone: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, TIMEZONE_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    bookedAt: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectISODateTimeObjFormat(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    user: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    acCollectionId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    activityType: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, ACTIVITY_TYPE_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    activitySubType: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, SUB_ACTIVITY_TYPE_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    activityId: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string', 'number']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    displayName: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    description: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    partyInformation: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['object']);
+        rf.expectAction(action, ['set']);
+      },
+      fields: {
+        adult: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectInteger(value);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        child: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectInteger(value);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        senior: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectInteger(value);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        youth: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectInteger(value);
+            rf.expectAction(action, ['set']);
+          }
+        }
+      }
+    },
+    rateClass: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, RATE_CLASS_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    namedOccupant: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['object']);
+        rf.expectAction(action, ['set']);
+      },
+      fields: {
+        firstName: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        lastName: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        age: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectInteger(value);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        contactInfo: {
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['object']);
+            rf.expectObjectToHaveMinNumberOfProperties(value, ['email', 'phone'], 1);
+            rf.expectAction(action, ['set']);
+          },
+          fields: {
+            email: {
+              rulesFn: ({ value, action }) => {
+                rf.expectEmailFormat(value);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            phone: {
+              rulesFn: ({ value, action }) => {
+                rf.expect10DigitPhoneFormat(value);
+                rf.expectAction(action, ['set']);
+              }
+            }
+          }
+        }
+      }
+    },
+    vehicleInformation: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['object']);
+        rf.expectAction(action, ['set']);
+      },
+      fields: {
+        licensePlate: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        licensePlateRegistrationRegion: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        vehicleMake: {
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        vehicleModel: {
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        vehicleColour: {
+          rulesFn: ({ value, action }) => {
+            rf.expectType(value, ['string']);
+            rf.expectAction(action, ['set']);
+          }
+        }
+      }
+    },
+    equipmentInformation: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    feeInformation: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['object']);
+        rf.expectAction(action, ['set']);
+      },
+      fields: {
+        registrationFees: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectMoneyFormat(value, ['number']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        transactionFees: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectMoneyFormat(value, ['number']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        tax: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectMoneyFormat(value, ['number']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+        total: {
+          isMandatory: true,
+          rulesFn: ({ value, action }) => {
+            rf.expectMoneyFormat(value, ['number']);
+            rf.expectAction(action, ['set']);
+          }
+        },
+      }
+    },
+    bookingStatus: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, BOOKING_STATUS_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    entryPoint: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    exitPoint: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    location: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectGeopoint(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    }
+  }
+};
+
+module.exports = {
+  BOOKING_PUT_CONFIG
+};

--- a/lib/layers/dataUtils/bookings/methods.js
+++ b/lib/layers/dataUtils/bookings/methods.js
@@ -1,0 +1,107 @@
+const crypto = require("crypto");
+const { getOneByGlobalId, marshall, runQuery, TABLE_NAME } = require("/opt/dynamodb");
+const { Exception, logger } = require("/opt/base");
+const { getActivityByActivityId } = require("/opt/activities/methods");
+
+async function getBookingByBookingId(bookingId) {
+  logger.debug("Getting booking by bookingId:", bookingId);
+  try {
+    return await getOneByGlobalId(bookingId);
+  } catch (error) {
+    throw new Exception("Error getting booking by bookingId", {
+      code: 400,
+      error: error,
+    });
+  }
+}
+
+async function getBookingsByActivityDetails(acCollectionId, activityType, activityId, startDate = null, endDate = null) {
+  logger.debug("Getting bookings by activity details:", acCollectionId, activityType, activityId, startDate, endDate);
+  try {
+    let query = {
+      TableName: TABLE_NAME,
+      KeyConditionExpression: "pk = :pk",
+      ExpressionAttributeValues: {
+        ":pk": marshall(`booking::${acCollectionId}::${activityType}::${activityId}`),
+      },
+    };
+
+    if (startDate) {
+      if (endDate) {
+        // If both startDate and endDate are provided, get everything in between
+        // We can use >= for startDate on the sk since it begins with the startDate - this is better for scalability.
+        query.KeyConditionExpression += " AND sk >= :startDate";
+        query['FilterExpression'] = "endDate <= :endDate";
+        query.ExpressionAttributeValues[":startDate"] = marshall(startDate);
+        query.ExpressionAttributeValues[":endDate"] = marshall(endDate);
+      } else {
+        // If only startDate is provided, use begins_with to only get booking that start on the startDate
+        query.KeyConditionExpression += " AND begins_with(sk, :startDate)";
+        query.ExpressionAttributeValues[":startDate"] = marshall(startDate);
+      }
+    }
+
+    logger.debug("Querying bookings:", query);
+    const result = await runQuery(query);
+    logger.debug("Bookings result:", result);
+    return result;
+
+  } catch (error) {
+    throw new Exception("Error getting bookings by activity details", {
+      code: 400,
+      error: error,
+    });
+  }
+}
+
+async function createBooking(acCollectionId, activityType, activityId, startDate, body) {
+  logger.debug("Creating booking:", acCollectionId, activityType, activityId, startDate, body);
+  try {
+
+    // Confirm that activity exists
+    const activity = await getActivityByActivityId(acCollectionId, activityType, activityId);
+
+    if (!activity) {
+      throw new Exception(`Activity not found (CollectionID: ${acCollectionId}, Type: ${activityType}, ID: ${activityId}`, { code: 404 });
+    }
+
+    // Create unique bookingId
+    const globalId = crypto.randomUUID();
+
+    // Create booking request
+    let bookingRequest = {
+      ...body,
+      pk: `booking::${acCollectionId}::${activityType}::${activityId}`,
+      sk: `${startDate}::${globalId}`,
+      schema: "booking",
+      globalId: globalId,
+      bookingId: globalId,
+      activityType: activityType,
+      activityId: activityId,
+      acCollectionId: acCollectionId,
+      startDate: startDate,
+    };
+
+    // TODO: change later to potentially support bulk bookings
+    return [{
+      key: {
+        pk: bookingRequest.pk,
+        sk: bookingRequest.sk,
+      },
+      data: bookingRequest,
+    }];
+
+  } catch (error) {
+    throw new Exception("Error creating booking", {
+      code: 400,
+      error: error,
+    });
+  }
+}
+
+module.exports = {
+  createBooking,
+  getBookingsByActivityDetails,
+  getBookingByBookingId,
+}
+

--- a/lib/layers/dataUtils/data-constants.js
+++ b/lib/layers/dataUtils/data-constants.js
@@ -1,4 +1,3 @@
-// see README.md for more information on api update configurations.
 const DEFAULT_API_UPDATE_CONFIG = {
     fields: {},
     failOnError: true,
@@ -6,6 +5,90 @@ const DEFAULT_API_UPDATE_CONFIG = {
     autoVersion: false,
 };
 
+// Available timezones for British Columbia.
+const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston'];
+
+// The following are the allowed facility types and related subtypes for facilities
+const FACILITY_TYPE_ENUMS = {
+    campground: [],
+    structure: ['parkingLot', 'boatLaunch', 'yurt', 'building', 'cabin'],
+    trail: [],
+    accessPoint: [],
+    naturalFeature: ['lake', 'summit', 'pointOfInterest', 'bay', 'river', 'beach'],
+    dayUse: []
+  };
+
+// The following are the allowed filters for the activity collection API.
+ALLOWED_FILTERS = [
+  { name: "isVisible", type: "boolean" },
+  { name: "activityType", type: "list" },
+  { name: "subActivityType", type: "list" },
+  { name: "facilities", type: "list" }
+];
+
+// The following are the allowed sub-activity types for activities.
+const SUB_ACTIVITY_TYPE_ENUMS = [
+  'campsite',
+  'walkin',
+  'rv',
+  'reservation',
+  'passport',
+  'vehicleParking',
+  'trailUse',
+  'shelterUse',
+  'saniUse',
+  'showerUse',
+  'elecUse',
+  'dockMooring',
+  'buoyMooring',
+  'frontcountry',
+  'backcountry',
+  'portionCircuit',
+  'fullCircuit',
+];
+
+// The following are the allowed activity types for activities.
+const ACTIVITY_TYPE_ENUMS = [
+  'frontcountryCamp',
+  'backcountryCamp',
+  'groupCamp',
+  'dayuse',
+  'boating',
+  'cabinStay',
+  'canoe'
+];
+
+// The following are the allowed policy types.
+const POLICY_TYPE_ENUMS = ['booking', 'change', 'fee', 'party'];
+
+const PARTY_AGE_CATEGORY_ENUMS = [
+  'adult',
+  'child',
+  'senior',
+  'youth'
+];
+
+const RATE_CLASS_ENUMS = [
+    'standard',
+    'senior',
+    'SSCFE'
+];
+
+const BOOKING_STATUS_ENUMS = [
+    'confirmed',
+    'cancelled',
+    'expired'
+]
+
 module.exports = {
     DEFAULT_API_UPDATE_CONFIG,
+    ALLOWED_FILTERS,
+    BOOKING_STATUS_ENUMS,
+    SUB_ACTIVITY_TYPE_ENUMS,
+    ACTIVITY_TYPE_ENUMS,
+    FACILITY_TYPE_ENUMS,
+    PARTY_AGE_CATEGORY_ENUMS,
+    POLICY_TYPE_ENUMS,
+    RATE_CLASS_ENUMS,
+    TIMEZONE_ENUMS,
 };

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -156,7 +156,17 @@ function validateRequestData(itemData, itemConfig) {
 
       // If fieldRules is not present, the field is not allowed in the request
       if (!fieldRules) {
-        throw new Exception(`Field '${field}' is not allowed in the request`, { code: 400, error: `Field '${field}' is not allowed in the request` });
+        throw new Exception(`Invalid field.`, { code: 400, error: `Field '${field}' is not allowed in the request` });
+      }
+
+      // If the field is an object with its own fields, validate the nested fields
+      if (fieldRules?.hasOwnProperty('fields')) {
+        // recursively validate the field rules
+        try {
+          validateRequestData(itemData[field].value, fieldRules);
+        } catch (error) {
+          throw new Exception(`Validation failed for nested field in '${field}'`, { code: 400, error: error });
+        }
       }
 
       // Execute the rule function for the field value
@@ -214,13 +224,8 @@ async function quickApiPutHandler(tableName, createList, config) {
           existingItem = await getOne(itemData.pk, itemData.sk);
         }
 
-        let dataToValidate = {};
-        Object.keys(itemData).map((field) => {
-          dataToValidate[field] = {
-            value: itemData[field],
-            action: DEFAULT_FIELD_ACTION
-          };
-        });
+        // Build the validation request
+        let dataToValidate = buildValidationRequest(itemData, itemConfig?.fields);
 
         // validate the request data using the config
         validateRequestData(dataToValidate, itemConfig);
@@ -259,6 +264,24 @@ async function quickApiPutHandler(tableName, createList, config) {
   } catch (error) {
     throw error;
   }
+}
+
+function buildValidationRequest(itemData, configFields) {
+  let nodeObj = {};
+  Object.keys(itemData).map((item) => {
+    if (configFields[item]?.hasOwnProperty('fields')) {
+      nodeObj[item] = {
+        value: buildValidationRequest(itemData[item], configFields[item]?.fields),
+        action: DEFAULT_FIELD_ACTION
+      };
+    } else {
+      nodeObj[item] = {
+        value: itemData[item],
+        action: DEFAULT_FIELD_ACTION
+      };
+    }
+  });
+  return nodeObj;
 }
 
 /**

--- a/lib/layers/dataUtils/facilities/configs.js
+++ b/lib/layers/dataUtils/facilities/configs.js
@@ -1,16 +1,8 @@
 const { rulesFns } = require('/opt/validation-rules');
+const { FACILITY_TYPE_ENUMS, TIMEZONE_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
 
-const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston'];
-const FACILITY_TYPE_ENUMS = {
-  campground: [],
-  structure: ['parkingLot', 'boatLaunch', 'yurt', 'building', 'cabin'],
-  trail: [],
-  accessPoint: [],
-  naturalFeature: ['lake', 'summit', 'pointOfInterest', 'bay', 'river', 'beach'],
-  dayUse: []
-};
 const ALLOWED_FILTERS = [
   { name: "isVisible", type: "boolean" },
   { name: "showOnMap", type: "boolean" },

--- a/lib/layers/dataUtils/geozones/configs.js
+++ b/lib/layers/dataUtils/geozones/configs.js
@@ -1,8 +1,7 @@
 const { rulesFns } = require('/opt/validation-rules');
+const { TIMEZONE_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
-
-const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston'];
 
 const ALLOWED_FILTERS = [
   { name: "isVisible", type: "boolean" },

--- a/lib/layers/dataUtils/policies/configs.js
+++ b/lib/layers/dataUtils/policies/configs.js
@@ -1,8 +1,7 @@
 const { rulesFns } = require('/opt/validation-rules');
+const { POLICY_TYPE_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
-
-const POLICY_TYPES = ['booking', 'change', 'fee', 'party'];
 
 const POLICY_BOOKING_API_UPDATE_CONFIG = {
   failOnError: true,
@@ -268,7 +267,7 @@ const POLICY_POST_MANDATORY_FIELDS = {
     policyType: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
-        rf.expectValueInList(value, POLICY_TYPES);
+        rf.expectValueInList(value, POLICY_TYPE_ENUMS);
         rf.expectAction(action, ['set']);
       }
     },
@@ -299,7 +298,7 @@ const POLICY_API_UPDATE_CONFIGS = {
 
 const POLICY_API_CREATE_CONFIGS = (() => {
   let configs = {};
-  for (const policyType of POLICY_TYPES) {
+  for (const policyType of POLICY_TYPE_ENUMS) {
     let entry = { ...POLICY_API_UPDATE_CONFIGS[policyType] };
     entry.fields = { ...entry.fields, ...POLICY_POST_MANDATORY_FIELDS.fields, };
     configs[policyType] = entry;
@@ -310,5 +309,4 @@ const POLICY_API_CREATE_CONFIGS = (() => {
 module.exports = {
   POLICY_API_UPDATE_CONFIGS,
   POLICY_API_CREATE_CONFIGS,
-  POLICY_TYPES,
 };

--- a/lib/layers/dataUtils/protectedAreas/configs.js
+++ b/lib/layers/dataUtils/protectedAreas/configs.js
@@ -1,8 +1,7 @@
 const { rulesFns } = require('/opt/validation-rules');
+const { TIMEZONE_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
-
-const TIMEZONE_ENUMS = ['America/Vancouver', 'America/Edmonton', 'America/Fort_Nelson', 'America/Creston']
 
 const PROTECTED_AREA_API_PUT_CONFIG = {
   allowOverwrite: true,
@@ -38,27 +37,27 @@ const PROTECTED_AREA_API_PUT_CONFIG = {
         rf.expectAction(action, ['add']);
       }
     },
-    schema : {
+    schema: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['protectedArea']),
-        rf.expectAction(action, ['add']);
+          rf.expectAction(action, ['add']);
       }
     },
     location: {
       isMandatory: true,
-        rulesFn: ({value, action}) => {
-          rf.expectGeopoint(value);
-          rf.expectAction(action, ['add']);
-        }
-      },
+      rulesFn: ({ value, action }) => {
+        rf.expectGeopoint(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
     boundary: {
       isMandatory: true,
-        rulesFn: ({value, action}) => {
-          rf.expectGeoshape(value);
-          rf.expectAction(action, ['add']);
-        }
-      },
+      rulesFn: ({ value, action }) => {
+        rf.expectGeoshape(value);
+        rf.expectAction(action, ['add']);
+      }
+    },
     boundaryUrl: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
@@ -66,7 +65,7 @@ const PROTECTED_AREA_API_PUT_CONFIG = {
         rf.expectAction(action, ['add']);
       }
     },
-    timezone : {
+    timezone: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, TIMEZONE_ENUMS);
@@ -94,7 +93,7 @@ const PROTECTED_AREA_API_PUT_CONFIG = {
       }
     }
   }
-}
+};
 
 const PROTECTED_AREA_API_UPDATE_CONFIG = {
   failOnError: true,
@@ -107,31 +106,31 @@ const PROTECTED_AREA_API_UPDATE_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    schema : {
+    schema: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, ['protectedArea']),
-        rf.expectAction(action, ['set']);
+          rf.expectAction(action, ['set']);
       }
     },
     location: {
-        rulesFn: ({value, action}) => {
-          rf.expectGeopoint(value);
-          rf.expectAction(action, ['set']);
-        }
-      },
+      rulesFn: ({ value, action }) => {
+        rf.expectGeopoint(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
     boundary: {
-        rulesFn: ({value, action}) => {
-          rf.expectGeoshape(value);
-          rf.expectAction(action, ['set']);
-        }
-      },
+      rulesFn: ({ value, action }) => {
+        rf.expectGeoshape(value);
+        rf.expectAction(action, ['set']);
+      }
+    },
     boundaryUrl: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
     },
-    timezone : {
+    timezone: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, TIMEZONE_ENUMS);
         rf.expectAction(action, ['set']);
@@ -156,9 +155,9 @@ const PROTECTED_AREA_API_UPDATE_CONFIG = {
       }
     }
   }
-}
+};
 
 module.exports = {
   PROTECTED_AREA_API_PUT_CONFIG,
   PROTECTED_AREA_API_UPDATE_CONFIG
-}
+};

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -4,7 +4,7 @@ class rulesFns {
 
   regexMatch(value, regex) {
     if (!regex.test(value)) {
-      throw new Exception(`Invalid value: Expected ${value} to match regex: ${regex}`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' to match regex: ${regex}`, { code: 400 });
     }
   }
 
@@ -17,7 +17,7 @@ class rulesFns {
    */
   expectType(value, types) {
     if (!types.includes(typeof value)) {
-      throw new Exception(`Invalid type: Expected ${value} to be one of type: [${types}]`, { code: 400 });
+      throw new Exception(`Invalid type: Expected '${value}' (type: '${typeof value}') to be one of type: [${types}]`, { code: 400 });
     }
   }
 
@@ -30,7 +30,7 @@ class rulesFns {
    */
   expectArray(value, type = null) {
     if (!Array.isArray(value)) {
-      throw new Exception(`Invalid value: expected ${JSON.stringify(value)} to be an array`, { code: 400 });
+      throw new Exception(`Invalid value: expected '${JSON.stringify(value)}' to be an array`, { code: 400 });
     }
     if (type && !value.every(item => type.includes(typeof item))) {
       const actualTypes = value.map(i => typeof i);
@@ -84,7 +84,7 @@ class rulesFns {
    */
   expectValueInList(value, list) {
     if (!list.includes(value)) {
-      throw new Exception(`Invalid value: Expected ${value} to be one of ${list}`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' to be one of:[${list.join(', ') || list}]`, { code: 400 });
     }
   }
 
@@ -127,10 +127,10 @@ class rulesFns {
    */
   expectInteger(value, allowNegative = false) {
     if (!Number.isInteger(value)) {
-      throw new Exception(`Invalid value: Expected ${value} to be an integer`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be an integer`, { code: 400 });
     }
     if (!allowNegative && value < 0) {
-      throw new Exception(`Invalid value: Expected ${value} to be a positive integer`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be a non-negative integer`, { code: 400 });
     }
   }
 
@@ -190,10 +190,10 @@ class rulesFns {
     this.expectType(value, ['number']);
     if (inclusive) {
       if (value < min || value > max) {
-        throw new Exception(`Invalid value: Expected ${value} to be equal to or between ${min} and ${max}`, { code: 400 });
+        throw new Exception(`Invalid value: Expected '${value}' to be equal to or between ${min} and ${max}`, { code: 400 });
       } else {
         if (value <= min || value >= max) {
-          throw new Exception(`Invalid value: Expected ${value} to be between ${min} and ${max}`, { code: 400 });
+          throw new Exception(`Invalid value: Expected '${value}' to be between ${min} and ${max}`, { code: 400 });
         }
       }
     }
@@ -278,6 +278,20 @@ class rulesFns {
     }
   }
 
+  /**
+   * Validates that the provided value is a valid envelope object.
+   *
+   * An envelope object must have a `type` property with the value `'envelope'`
+   * and a `coordinates` property that is an array containing exactly two points.
+   * Each point must be an array with valid longitude and latitude values.
+   *
+   * @param {Object} value - The envelope object to validate.
+   * @param {string} value.type - The type of the object, which must be `'envelope'`.
+   * @param {Array} value.coordinates - An array of two points representing the envelope.
+   * @throws {Exception} Throws an error if the `type` is not `'envelope'`.
+   * @throws {Exception} Throws an error if `coordinates` is not an array of two points.
+   * @throws {Exception} Throws an error if any point does not have valid longitude or latitude.
+   */
   expectEnvelope(value) {
     // Type validation
     if (!value?.type || value.type !== 'envelope') {
@@ -305,16 +319,97 @@ class rulesFns {
     }
   }
 
+  /**
+   * Validates that the provided value is a valid primary key object.
+   *
+   * The primary key object must:
+   * - Contain only the properties 'pk' and 'sk'.
+   * - Have both 'pk' and 'sk' as strings.
+   *
+   * @param {Object} value - The object to validate as a primary key.
+   * @throws {Exception} Throws an exception if the object does not meet the validation criteria.
+   */
   expectPrimaryKey(value) {
     // Expect the only properties to be 'pk' and 'sk'
-    const keys = Object.keys(value);
-    if (keys.length !== 2 || !keys.includes('pk') || !keys.includes('sk')) {
+    try {
+      this.expectObjectMustHaveProperties(value, ['pk', 'sk']);
+      this.expectObjectToOnlyHaveProperties(value, ['pk', 'sk']);
+    } catch (error) {
       throw new Exception(`Invalid primary key: Expected { pk: <string>, sk: <string> }`, { code: 400 });
     }
     for (const key in value) {
       this.expectType(value[key], ['string']);
     }
   }
+
+  // Expect the object to definitely have the properties provided (but may have more)
+  expectObjectMustHaveProperties(value, properties) {
+    const keys = Object.keys(value);
+    let missingKeys = properties.filter(property => !keys.includes(property));
+    if (missingKeys.length > 0) {
+      throw new Exception(`Invalid object: Expected object to have all properties: '${properties.join(', ') || properties}'. Missing properties: '${missingKeys.join(', ')}'.`, { code: 400 });
+    }
+  }
+
+  // Expect the object to have at least the provided minimum number of the properties provided
+  // Useful when none of the properties are mandatory, but at least one is required
+  expectObjectToHaveMinNumberOfProperties(value, properties, min = 1) {
+    const count = properties.filter(prop => value.hasOwnProperty(prop)).length;
+    if (count < min) {
+      throw new Exception(`Invalid object: Expected object to have at least ${min} properties from '${properties.join(', ')}'`, { code: 400 });
+    }
+  }
+
+  /**
+   * Validates that the given value is a string and matches the email format.
+   *
+   * @param {string} value - The value to validate as an email.
+   * @throws {Exception} Throws an exception if the value is not a string or does not match the email format.
+   */
+  expectEmailFormat(value) {
+    try {
+      this.expectType(value, ['string']);
+      this.regexMatch(value, /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/);
+    } catch (error) {
+      throw new Exception(`Invalid email format: '${value}'`, { code: 400 });
+    }
+  }
+
+  /**
+   * Validates that the provided value is a string and matches the 10-digit phone number format.
+   *
+   * @param {string} value - The value to validate as a 10-digit phone number.
+   * @throws {Exception} Throws an exception if the value is not a string or does not match the 10-digit phone number format.
+   */
+  expect10DigitPhoneFormat(value) {
+    try {
+      this.expectType(value, ['string']);
+      this.regexMatch(value, /^\d{10}$/);
+    } catch (error) {
+      throw new Exception(`Invalid 10 digit phone format: '${value}'`, { code: 400 });
+    }
+  }
+
+  /**
+   * Validates that the given value is in a valid money format.
+   *
+   * The value must be of type 'number' and match the regular expression
+   * for a monetary value, which allows an optional decimal point followed
+   * by exactly two digits (e.g., 123, 123.45).
+   *
+   * @param {number} value - The value to validate as a money format.
+   * @throws {Exception} Throws an exception if the value is not a number
+   *                     or does not match the expected money format.
+   */
+  expectMoneyFormat(value) {
+    try {
+      this.expectType(value, ['number']);
+      this.regexMatch(value, /^\d+(\.\d{2})?$/);
+    } catch (error) {
+      throw new Exception(`Invalid money format: '${value}'`, { code: 400 });
+    }
+  }
+
 }
 
 module.exports = {

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -15,6 +15,7 @@ const { webSocketApiSetup } = require('./cdk/websockets');
 // HANDLER RESOURCES
 const { authorizerSetup } = require('./handlers/authorizer/resources');
 const { activitiesSetup } = require('./handlers/activities/resources');
+const { bookingsSetup } = require('./handlers/bookings/resources');
 const { configSetup } = require('./handlers/config/resources');
 const { facilitiesSetup } = require('./handlers/facilities/resources');
 const { geozonesSetup } = require('./handlers/geozones/resources');
@@ -96,7 +97,7 @@ class ReserveRecCdkStack extends Stack {
 
 
 
-    // LAMBDA FUNCTION HANDLERS & RESOURCES (ALPHABETIZED)
+    // LAMBDA FUNCTION HANDLERS & RESOURCES
 
     // Activities
     const activitiesResources = activitiesSetup(this, {
@@ -109,6 +110,19 @@ class ReserveRecCdkStack extends Stack {
       ],
       mainTable: dynamodbResources.mainTable,
     });
+
+    // Bookings (requires activities)
+    const bookingsResources = bookingsSetup(this, {
+      env: props.env,
+      api: apigwResources.api,
+      layers: [
+        layerResources.baseLayer,
+        layerResources.awsUtilsLayer,
+        layerResources.dataUtilsLayer
+      ],
+      mainTable: dynamodbResources.mainTable,
+      activitiesResources: activitiesResources,
+    })
 
     // Config
     const configResources = configSetup(this, {


### PR DESCRIPTION
Relates to #98 .

Adding Bookings GET and POST endpoints to contribute to the E2E. Note that the data structure for bookings used in this change is not finalized but rather a temporary datatype that should support the E2E without any of the verification processes.

Waiting on previous changes to the AWS remote instance to be fixed before merging, but this code is finished for now. 

## Booking identification by UUID

Currently, database items are uniquely identified distinctly from their sibling items using a logically incremented `identifier`: 1, 2, 3 etc. This method is great when the data items are relatively static and dont change often, and we want the primary keys of the items to be somewhat logically enumerated and guessable by humans for ease of access.

Bookings are the first datatype we have encountered in this project that does not really fit the static datatype case. We expect thousands of bookings to be created per second at peak times and don't want/need to have an additional process that logically enumerates each one as that may make the whole process less performant at scale. Therefore, when a booking is created, it is given a `bookingId` in the form of a generic UUID, generated using `crypto.randomUUID`. This UUID is essentially guaranteed to be globally unique in the database and therefore can be used to uniquely identify single bookings. 

## Bookings primary key structure

The primary key structure of  bookings remains a composite `pk`/`sk` key such that bookings can be partitioned by inventory - what the booking is for, and on what date. 

```js
pk: booking::<acCollectionId>::<activityType>::<activityId>
sk: <startDate>::<bookingId>
``` 

This way, the database can be queried the following ways:

- get exactly one booking by booking ID
- get all bookings for particular inventory ( {acCollectionId}/{activityType}/{activityId})
- get all bookings for particular inventory on a particular date ({startDate})
- get all bookings for particular inventory commencing on a day on or between two dates ({startDate and endDate})

## GlobalID Index

With the introduction of a `uuid`-based property, we can index our database using UUIDs as a simple index. This changes adds `globalId-index` to the CDK code as an index of the main `reserve-rec-main` table. 

The property `globalId` is used to store the UUID on bookings, and the same property should be used on future items that use UUID identification so they can also be queried using the same index. 

A proposal for the future is to rename the property `identifier` in favour of `localId` as it is a more accurate, less confusing name for that property.

### Endpoints added: 
```js
// GET single booking by bookingId (globalId)
GET /bookings/{bookingId}

// GET all bookings for {acCollectionId}/{activityType}/{activityId} that have a startDate of {startDate}
GET /{acCollectionId}/{activityType}/{activityId}/{startDate}/bookings

// GET all bookings for {acCollectionId}/{activityType}/{activityId} that have a startDate GTE {startDate} and an endDate LTE {endDate} (get date range)
GET /{acCollectionId}/{activityType}/{activityId}/{startDate}/bookings?endDate={endDate}
```