### PR TITLE
PRDT-106-1: Temporary fix to try and unblock devops by creating main table by TableARN

### DIFF
--- a/lib/cdk/dynamodb.js
+++ b/lib/cdk/dynamodb.js
@@ -9,16 +9,38 @@ const dynamodb = require('aws-cdk-lib/aws-dynamodb');
 function dynamodbSetup(scope, props) {
   console.log('Setting up DynamoDB resources...');
 
+  /**
+   * Main Reserve Rec Data Table
+   *
+   * 2025-05-20 - The main table has been orphaned and recreated from a PITR backup. As such, the references to the main table
+   * have been severed, causing deployment issues, as the new table is not the one created by the CDK stack instructions.
+   *
+   * As a temporary fix, the main table is being referenced by its ARN. This will hopefully unblock the deployment process. Unfortunately,
+   * this means that the CDK stack will not be able to manage the table, and any changes to the table will need to be done manually.
+   *
+   * The proper way to adopt newly created resources into a CDK stack is to use the `cdk import` command. However, this is not possible in this case,
+   * as the developer's local environment variables are not synced up with the remote AWS account, and merging these changes is not a favourable
+   * option for quick turnaround. In the future, we should look to adopt this approach as recommended by AWS.
+   *
+   * https://aws.amazon.com/blogs/database/use-point-in-time-recovery-to-restore-an-amazon-dynamodb-table-managed-by-aws-cdk/
+   *
+   * The constructs affected by this change are the main table and the stream function that is triggered by the main table. They have been commented out.
+   *
+   * Emphasis on the fact that this is a temporary fix. The main table should be managed by the CDK stack.
+   */
+
+  const mainTable = dynamodb.Table.fromTableArn(scope, 'MainTable', 'arn:aws:dynamodb:ca-central-1:637423314715:table/reserve-rec-main');
+
   // Main Reserve Rec Data Table
-  const mainTable = new dynamodb.Table(scope, 'MainTable', {
-    tableName: props.env.TABLE_NAME,
-    partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
-    sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
-    pointInTimeRecovery: true,
-    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-    stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
-    removalPolicy: RemovalPolicy.RETAIN
-  });
+  // const mainTable = new dynamodb.Table(scope, 'MainTable', {
+  //   tableName: props.env.TABLE_NAME,
+  //   partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+  //   sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+  //   pointInTimeRecovery: true,
+  //   billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  //   stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+  //   removalPolicy: RemovalPolicy.RETAIN
+  // });
 
   // Audit Table
   const auditTable = new dynamodb.Table(scope, 'AuditTable', {
@@ -70,7 +92,7 @@ function dynamodbSetup(scope, props) {
     description: 'PubSub Table',
     exportName: 'PubSubTableName',
   });
-  
+
   new CfnOutput(scope, 'CounterTableName', {
     value: counterTable.tableName,
     description: 'Counter Table',

--- a/lib/handlers/dynamoStream/resources.js
+++ b/lib/handlers/dynamoStream/resources.js
@@ -35,15 +35,19 @@ function streamSetup(scope, props) {
   // Add DynamoDB stream processing policies to the function
 
   // Add the stream event source to the function
-  streamFunction.addEventSource(new lambdaEventSources.DynamoEventSource(
-    props.mainTable,
-    {
-      startingPosition: lambda.StartingPosition.TRIM_HORIZON,
-      batchSize: 10,
-      bisectBatchOnError: true,
-      retryAttempts: 3,
-    }
-  ));
+  /**
+   * 2025-05-20 - The stream event source has been commented out, as the main table is being referenced by its ARN.
+   * This is a temporary fix, and the stream event source should be uncommented once the main table is managed by the CDK stack.
+   */
+  // streamFunction.addEventSource(new lambdaEventSources.DynamoEventSource(
+  //   props.mainTable,
+  //   {
+  //     startingPosition: lambda.StartingPosition.TRIM_HORIZON,
+  //     batchSize: 10,
+  //     bisectBatchOnError: true,
+  //     retryAttempts: 3,
+  //   }
+  // ));
 
   return {
     streamFunction: streamFunction,


### PR DESCRIPTION
Relates to #106.

The DEV main table was orphaned and recreated from a PITR backup. The CDK stack is unable to accept any newly created DynamoDB resources unless they are imported and attached back to the AWS stack.

There are methods to achieve this import properly: https://aws.amazon.com/blogs/database/use-point-in-time-recovery-to-restore-an-amazon-dynamodb-table-managed-by-aws-cdk/, but in an effort to unblock developers while this method is fleshed out, I have implemented a temporary fix.

The main table reference is now generated from the PITR table's ARN, so the references should be correct. The drawback is that the table and its settings can no longer be managed by CDK.

This change only comments out the existing Table constructs, so they can be reintroduced later. 