### PR TITLE
PRDT-98-2 Removing UUID GSI CDK construct

### DIFF
--- a/lib/cdk/dynamodb.js
+++ b/lib/cdk/dynamodb.js
@@ -42,12 +42,12 @@ function dynamodbSetup(scope, props) {
   //   removalPolicy: RemovalPolicy.RETAIN
   // });
 
-  // Add gsi1pk (UUID) as a GSI
-  mainTable.addGlobalSecondaryIndex({
-    indexName: 'globalId-index',
-    partitionKey: { name: 'globalId', type: dynamodb.AttributeType.STRING },
-    projectionType: dynamodb.ProjectionType.ALL,
-  });
+  // Add gsi1pk (UUID) as a GSI (removed for now)
+  // mainTable.addGlobalSecondaryIndex({
+  //   indexName: 'globalId-index',
+  //   partitionKey: { name: 'globalId', type: dynamodb.AttributeType.STRING },
+  //   projectionType: dynamodb.ProjectionType.ALL,
+  // });
 
   // Audit Table
   const auditTable = new dynamodb.Table(scope, 'AuditTable', {


### PR DESCRIPTION
Relates to #106 and #98

UUID GSI must be manually created in the web console since we are temporarily constructing the main table by ARN reference instead of via CDK.