### PR TITLE
PRDT-98-5: Fix to expectPrimaryKey Validation

### DIFF
--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -350,6 +350,15 @@ class rulesFns {
       throw new Exception(`Invalid object: Expected object to have all properties: '${properties.join(', ') || properties}'. Missing properties: '${missingKeys.join(', ')}'.`, { code: 400 });
     }
   }
+  
+  // Expect the object to only have these properties
+  expectObjectToOnlyHaveProperties(value, properties) {
+  const keys = Object.keys(value);
+  const extraKeys = keys.filter(key => !properties.includes(key));
+    if (extraKeys.length > 0) {
+      throw new Exception(`Invalid object: Expected object to only have properties: '${properties.join(', ')}'. Extra properties found: '${extraKeys.join(', ')}'.`, { code: 400 });
+    }
+  }
 
   // Expect the object to have at least the provided minimum number of the properties provided
   // Useful when none of the properties are mandatory, but at least one is required


### PR DESCRIPTION
Relates to #98 

Fix to `expectPrimaryKey` validation function. The function was missing the `expectObjectToOnlyHaveProperties` method, which checks if the object _only_ contains `pk` and `sk` in the object. No longer insta-fails on check.