### PR TITLE
BRS-97: Fix to Permissions for Counter Table

### DIFF
--- a/lib/handlers/activities/resources.js
+++ b/lib/handlers/activities/resources.js
@@ -65,7 +65,7 @@ function activitiesSetup(scope, props) {
       'dynamodb:Delete*',
       'dynamodb:Update*',
     ],
-    resources: [props.mainTable.tableArn],
+    resources: [props.mainTable.tableArn, props.counterTable.tableArn],
   });
 
   activitiesGetByAcCollectionId.addToRolePolicy(dynamoDbPolicy);

--- a/lib/handlers/facilities/resources.js
+++ b/lib/handlers/facilities/resources.js
@@ -65,7 +65,7 @@ function facilitiesSetup(scope, props) {
       'dynamodb:Delete*',
       'dynamodb:Update*'
     ],
-    resources: [props.mainTable.tableArn],
+    resources: [props.mainTable.tableArn, props.counterTable.tableArn],
   });
 
   facilitiesGetByFcCollectionId.addToRolePolicy(dynamoDbPolicy);

--- a/lib/handlers/geozones/resources.js
+++ b/lib/handlers/geozones/resources.js
@@ -65,7 +65,7 @@ function geozonesSetup(scope, props) {
       'dynamodb:Delete*',
       'dynamodb:Update*'
     ],
-    resources: [props.mainTable.tableArn],
+    resources: [props.mainTable.tableArn, props.counterTable.tableArn],
   });
 
   geozonesGetByGzCollectionId.addToRolePolicy(dynamoDbPolicy);

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -109,6 +109,7 @@ class ReserveRecCdkStack extends Stack {
         layerResources.dataUtilsLayer
       ],
       mainTable: dynamodbResources.mainTable,
+      counterTable: dynamodbResources.counterTable
     });
 
     // Bookings (requires activities)
@@ -145,6 +146,7 @@ class ReserveRecCdkStack extends Stack {
         layerResources.dataUtilsLayer
       ],
       mainTable: dynamodbResources.mainTable,
+      counterTable: dynamodbResources.counterTable
     });
 
     // Geozone
@@ -157,6 +159,7 @@ class ReserveRecCdkStack extends Stack {
         layerResources.dataUtilsLayer
       ],
       mainTable: dynamodbResources.mainTable,
+      counterTable: dynamodbResources.counterTable
     });
 
     // Products


### PR DESCRIPTION
Relates to #97 

Add permissions to `geozones`, `facilities`, and `activities` so the resources can interact with `reserve-rec-counter` table.