### PR TITLE
BRS-97-5: Fix to resetCounter Function

### DIFF
--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -194,7 +194,7 @@ async function resetCounter(pk, skType) {
       },
       UpdateExpression: "SET counterValue = :initialValue",
       ExpressionAttributeValues: {
-          ":initialValue": { N: maxIdentifier },
+          ":initialValue": { N: maxIdentifier.toString() },
       },
       ReturnValues: "ALL_NEW",
     };


### PR DESCRIPTION
Relates to #97 

Fix to `resetCounter` as `:initialValue` is expecting a value to be a string.