### PR TITLE
BRS-97: Fix to incrementCounter and Error Throws

### DIFF
--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -129,7 +129,7 @@ async function incrementCounter(pk, collectionType = []) {
         },
         UpdateExpression: "ADD counterValue :counterValue",
         ExpressionAttributeValues: {
-          ":counterValue": { N: 1 },
+          ":counterValue": { N: "1" },
         },
         ReturnValues: "ALL_NEW",
       };
@@ -145,6 +145,7 @@ async function incrementCounter(pk, collectionType = []) {
     }
   } catch (error) {
     logger.error("Error with incrementCounter: ", error);
+    throw error;
   }
 }
 
@@ -203,6 +204,7 @@ async function resetCounter(pk, skType) {
     await dynamodb.send(new UpdateItemCommand(counterParams));
   } catch (error) {
     logger.error("Error with resetCounter: ", error)
+    throw error;
   }
 }
 async function getOneByGlobalId(globalId, globalIdAttributeName = 'globalId', tableName = TABLE_NAME, indexName = GLOBALID_INDEX_NAME) {


### PR DESCRIPTION
Relates to #97.

Fix a similar issue where `:counterValue` expects a string, and properly throw the error if it occurs.