### PR TITLE
BRS-97-6: Fix when Counter Needs a Reset vs Initialization

### DIFF
--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -71,14 +71,15 @@ async function incrementCounter(pk, collectionType = []) {
     const getRes = await dynamodb.send(new GetItemCommand(getCounterParams));
 
     // If we don't return an Item, it means there's no counter to begin with
-    // but we can set to 0 and use that to flag a probable reason to reset.
-    const rawItem = getRes?.Item;
+    // Track whether the counter was missing and set counter to 0
+    const counterItemMissing = !getRes?.Item;
     let item;
-    if (rawItem) {
-      item = unmarshall(rawItem);
-    } else {
+
+    if (counterItemMissing) {
       item = { counterValue: 0 };
       logger.debug("No counter found — defaulting to 0");
+    } else {
+      item = unmarshall(getRes.Item);
     }
 
     const countCurrent = item?.counterValue;
@@ -109,9 +110,10 @@ async function incrementCounter(pk, collectionType = []) {
     // Compare the actualCount to the counter's counterValue. If the countActual is
     // higher, then the counter could provide an ID that already exists (collision),
     // or provide an ID that already existed but was deleted (replacement - avoid this too).
-    // Initiate the reset and retry. If countCurrent 0, counter might have been deleted so
+    // Initiate the reset and retry. If counterItemMissing is true, counter was deleted so
     // reset anyway.
-    if (countCurrent === 0 || countActual > countCurrent) {
+    if (counterItemMissing || countActual > countCurrent) {
+      logger.debug(`counterItemMissing: ${counterItemMissing}`);
       logger.debug(`countActual: ${countActual}`);
       logger.debug(`countCurrent: ${countCurrent}`);
       // attempt to reset the counter
@@ -195,7 +197,7 @@ async function resetCounter(pk, skType) {
       },
       UpdateExpression: "SET counterValue = :initialValue",
       ExpressionAttributeValues: {
-          ":initialValue": { N: maxIdentifier.toString() },
+          ":initialValue": { N: `${maxIdentifier}` },
       },
       ReturnValues: "ALL_NEW",
     };


### PR DESCRIPTION
Relates to #97.

Fix to an infinite loop when counter is not existent and there are no existing items in the main table.