### PR TITLE
BRS-97-7: Fix geozone config

### DIFF
--- a/lib/layers/dataUtils/geozones/configs.js
+++ b/lib/layers/dataUtils/geozones/configs.js
@@ -120,14 +120,14 @@ const GEOZONE_API_PUT_CONFIG = {
     },
     facilities: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
+        rf.expectArray(value, ['object']);
         value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
+        rf.expectArray(value, ['object']);
         value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
@@ -220,14 +220,14 @@ const GEOZONE_API_UPDATE_CONFIG = {
     },
     facilities: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
+        rf.expectArray(value, ['object']);
         value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }
     },
     activities: {
       rulesFn: ({ value, action }) => {
-        rf.expectArray(value, ['string']);
+        rf.expectArray(value, ['object']);
         value.map(v => rf.expectPrimaryKey(v));
         rf.expectAction(action, ['set']);
       }


### PR DESCRIPTION
Relates to #97. Fix to geozone config following changes to data model and how `activities` and `facilities` are saved.