### PR TITLE
PRDT-98: adding permissions to new GSI

### DIFF
--- a/lib/handlers/bookings/resources.js
+++ b/lib/handlers/bookings/resources.js
@@ -67,7 +67,7 @@ function bookingsSetup(scope, props) {
       'dynamodb:Scan',
       'dynamodb:UpdateItem',
     ],
-    resources: [props.mainTable.tableArn],
+    resources: [props.mainTable.tableArn, `${props.mainTable.tableArn}/index/*`],
   });
   bookingsGet.addToRolePolicy(dynamodbPolicy);
   bookingsPost.addToRolePolicy(dynamodbPolicy);


### PR DESCRIPTION
relates to #98 

apparently indexes aren't automagically included when blessing functions with table access policies