### PR TITLE
PRDT-169-1: Fix public user pool creation attributes

### DIFF
--- a/lib/cdk/cognito-public.js
+++ b/lib/cdk/cognito-public.js
@@ -17,11 +17,31 @@ function cognitoPublicSetup(scope, props) {
                 required: true,
                 mutable: true,
             },
+            givenName: {
+                required: true,
+                mutable: true,
+            },
+            familyName: {
+                required: true,
+                mutable: true,
+            },
         },
         userPoolName: props.env.publicUserPoolName,
         userAttributeUpdateSettings: {
             attributesRequireVerificationBeforeUpdate: ['email'],
         },
+        customAttributes: {
+            'custom:city': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:country': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:homeAddress': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:homePhone': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:licensePlate': new cognito.StringAttribute({ minLen: 1, maxLen: 14, mutable: true }),
+            'custom:mobilePhone': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:postalCode': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:province': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:pwUpdate': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+            'custom:secondaryNumber': new cognito.StringAttribute({ maxLen: 2048, mutable: true }),
+        }
     });
 
     // Set up User Pool Domain for public users


### PR DESCRIPTION
### Ticket:
Relates to PRDT-169

### Ticket URL:
[#169](https://github.com/bcgov/reserve-rec-public/issues/169)

### Description:
- Rebuild the User Pool with CDK. Adds the required attributes `given_name`, `family_name`, alongside `email`. Also adds the custom attributes:
  - `custom:city`
  - `custom:country`
  - `custom:homeAddress`
  - `custom:homePhone`
  - `custom:licensePlate`
  - `custom:mobilePhone`
  - `custom:postalCode`
  - `custom:province`
  - `custom:pwUpdate`
  - `custom:secondaryNumber`