### PR TITLE
PRDT-190 ability to include related activities as part of a single facility GET

### DIFF
--- a/lib/handlers/facilities/_fcCollectionId/GET/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/GET/index.js
@@ -44,7 +44,7 @@ exports.handler = async (event, context) => {
     });
 
     if (facilityType && facilityId) {
-      res = await getFacilityByFacilityId(fcCollectionId, facilityType, facilityId);
+      res = await getFacilityByFacilityId(fcCollectionId, facilityType, facilityId, queryParams?.fetchActivities || false);
     }
 
     if (facilityType && !facilityId) {

--- a/lib/layers/dataUtils/facilities/methods.js
+++ b/lib/layers/dataUtils/facilities/methods.js
@@ -1,4 +1,4 @@
-const { TABLE_NAME, runQuery, getOne, marshall, incrementCounter } = require("/opt/dynamodb");
+const { TABLE_NAME, batchGetData, runQuery, getOne, marshall, incrementCounter } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("/opt/facilities/configs");
 
@@ -157,13 +157,17 @@ async function getFacilitiesByFacilityType(
  *
  * @throws {Exception} With code 400 if database operation fails
  */
-async function getFacilityByFacilityId(fcCollectionId, facilityType, facilityId) {
+async function getFacilityByFacilityId(fcCollectionId, facilityType, facilityId, fetchActivities = false) {
   logger.info("Get Facility By Facility Type and ID");
   try {
     let res = await getOne(
       `facility::${fcCollectionId}`,
       `${facilityType}::${facilityId}`
     );
+    if (fetchActivities && res?.activities) {
+      // Batch get the activities and staple them to the response
+      res.activities = await batchGetData(res.activities, TABLE_NAME);
+    }
     return res;
   } catch (error) {
     throw new Exception("Error getting facility", { code: 400, error: error });
@@ -239,7 +243,7 @@ async function processItem(
     // facilityId should be taken from queryParams, but can be taken from item if it's a bulk update
     facilityId = facilityId ?? item?.facilityId;
     sk = `${facilityType}::${facilityId}`;
-    
+
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;


### PR DESCRIPTION
Relates to https://github.com/bcgov/reserve-rec-public/issues/190

When doing a single facility GET (providing `fcCollectionId`, `facilityType` and `facilityId` in the query), you can additionally provide `fetchActivities=true` as a query parameter. After performing the single Facility GET, the API will check the facility's `activities` property (which is structured as an array of primary keys). If there are activity keys in the `activities` property, the API will perform a `batchGetItem` and replace the `activities` property in the returned facility with a list of related activities. 