### PR TITLE
Ability to include parent geozone with single activity GET

### DIFF
--- a/lib/handlers/activities/_acCollectionId/GET/index.js
+++ b/lib/handlers/activities/_acCollectionId/GET/index.js
@@ -42,7 +42,7 @@ exports.handler = async (event, context) => {
     });
 
     if (activityType && activityId) {
-      res = await getActivityByActivityId(acCollectionId, activityType, activityId);
+      res = await getActivityByActivityId(acCollectionId, activityType, activityId, queryParams?.fetchGeozone || null);
     }
 
     if (activityType && !activityId) {

--- a/lib/layers/dataUtils/activities/methods.js
+++ b/lib/layers/dataUtils/activities/methods.js
@@ -156,14 +156,17 @@ async function getActivitiesByActivityType(
  *
  * @throws {Exception} With code 400 if database operation fails
  */
-async function getActivityByActivityId(acCollectionId, activityType, activityId) {
+async function getActivityByActivityId(acCollectionId, activityType, activityId, fetchGeozone = false) {
   logger.info("Get Activity By activity type and ID");
   try {
     let res = await getOne(
       `activity::${acCollectionId}`,
       `${activityType}::${activityId}`
     );
-    console.log('res?', res)
+    if (fetchGeozone && res?.geozone?.pk && res?.geozone?.sk) {
+      const geozone = await getOne(res.geozone.pk, res.geozone.sk);
+      res.geozone = geozone;
+    }
     return res;
 
   } catch (error) {
@@ -240,7 +243,7 @@ async function processItem(
     // activityId should be taken from queryParams, but can be taken from item if it's a bulk update
     activityId = activityId ?? item?.activityId;
     sk = `${activityType}::${activityId}`;
-    
+
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;


### PR DESCRIPTION
Relates to https://github.com/bcgov/reserve-rec-public/issues/42

When calling the API for a single activity (GET by Activity ID), you now have the option to provide the query parameter `fetchGeozone=true` which will instruct the API to look at the returned activity. If the activity has a parent geozone associated with it, the API will also pull that geozone and staple it to the `activity.geozone` property.