### PR TITLE
PRDT-65 updating bookings api to match FE designs

### DIFF
--- a/lib/layers/dataUtils/bookings/configs.js
+++ b/lib/layers/dataUtils/bookings/configs.js
@@ -1,5 +1,5 @@
 const { rulesFns } = require('/opt/validation-rules');
-const { ACTIVITY_TYPE_ENUMS, BOOKING_STATUS_ENUMS, SUB_ACTIVITY_TYPE_ENUMS, TIMEZONE_ENUMS, PARTY_AGE_CATEGORY_ENUMS, RATE_CLASS_ENUMS } = require('/opt/data-constants');
+const { ACTIVITY_TYPE_ENUMS, BOOKING_STATUS_ENUMS, SUB_ACTIVITY_TYPE_ENUMS, TIMEZONE_ENUMS, RATE_CLASS_ENUMS } = require('/opt/data-constants');
 
 const rf = new rulesFns();
 
@@ -73,7 +73,7 @@ const BOOKING_PUT_CONFIG = {
       }
     },
     user: {
-      isMandatory: true,
+      // the user sub. Will be blank if the booking is made by a guest.
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
@@ -184,7 +184,6 @@ const BOOKING_PUT_CONFIG = {
           }
         },
         age: {
-          isMandatory: true,
           rulesFn: ({ value, action }) => {
             rf.expectInteger(value);
             rf.expectAction(action, ['set']);
@@ -193,7 +192,7 @@ const BOOKING_PUT_CONFIG = {
         contactInfo: {
           rulesFn: ({ value, action }) => {
             rf.expectType(value, ['object']);
-            rf.expectObjectToHaveMinNumberOfProperties(value, ['email', 'phone'], 1);
+            rf.expectObjectToHaveMinNumberOfProperties(value, ['email', 'mobilePhone', 'homePhone'], 1);
             rf.expectAction(action, ['set']);
           },
           fields: {
@@ -203,9 +202,51 @@ const BOOKING_PUT_CONFIG = {
                 rf.expectAction(action, ['set']);
               }
             },
-            phone: {
+            mobilePhone: {
               rulesFn: ({ value, action }) => {
                 rf.expect10DigitPhoneFormat(value);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            homePhone: {
+              rulesFn: ({ value, action }) => {
+                rf.expect10DigitPhoneFormat(value);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            streetAddress: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            unitNumber: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            postalCode: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            city: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            province: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
+                rf.expectAction(action, ['set']);
+              }
+            },
+            country: {
+              rulesFn: ({ value, action }) => {
+                rf.expectType(value, ['string']);
                 rf.expectAction(action, ['set']);
               }
             }
@@ -215,10 +256,10 @@ const BOOKING_PUT_CONFIG = {
     },
     vehicleInformation: {
       rulesFn: ({ value, action }) => {
-        rf.expectType(value, ['object']);
+        rf.expectArray(value);
         rf.expectAction(action, ['set']);
       },
-      fields: {
+      fields: [{
         licensePlate: {
           isMandatory: true,
           rulesFn: ({ value, action }) => {
@@ -251,7 +292,7 @@ const BOOKING_PUT_CONFIG = {
             rf.expectAction(action, ['set']);
           }
         }
-      }
+      }]
     },
     equipmentInformation: {
       rulesFn: ({ value, action }) => {

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -161,11 +161,26 @@ function validateRequestData(itemData, itemConfig) {
 
       // If the field is an object with its own fields, validate the nested fields
       if (fieldRules?.hasOwnProperty('fields')) {
-        // recursively validate the field rules
-        try {
-          validateRequestData(itemData[field].value, fieldRules);
-        } catch (error) {
-          throw new Exception(`Validation failed for nested field in '${field}'`, { code: 400, error: error });
+        // if the field is an array, we need to validate each item in the array
+        if (Array.isArray(fieldRules.fields)) {
+          if (!Array.isArray(itemData[field].value)) {
+            throw new Exception(`Invalid field value.`, { code: 400, error: `Field '${field}' should be an array` });
+          }
+          // validate each item in the array
+          for (const item of itemData[field].value) {
+            try {
+              validateRequestData(item, {fields: fieldRules.fields[0] || fieldRules.fields});
+            } catch (error) {
+              throw new Exception(`Validation failed for nested array item with index [${itemData[field].value.indexOf(item)}] in '${field}'`, { code: 400, error: error });
+            }
+          }
+        } else {
+          // recursively validate the field rules
+          try {
+            validateRequestData(itemData[field].value, fieldRules);
+          } catch (error) {
+            throw new Exception(`Validation failed for nested field in '${field}'`, { code: 400, error: error });
+          }
         }
       }
 
@@ -269,11 +284,23 @@ async function quickApiPutHandler(tableName, createList, config) {
 function buildValidationRequest(itemData, configFields) {
   let nodeObj = {};
   Object.keys(itemData).map((item) => {
+    // If the item is an array, we need to handle it differently
     if (configFields[item]?.hasOwnProperty('fields')) {
-      nodeObj[item] = {
-        value: buildValidationRequest(itemData[item], configFields[item]?.fields),
-        action: DEFAULT_FIELD_ACTION
-      };
+      if (Array.isArray(itemData[item])) {
+        let arr = [];
+        for (const arrayItem of itemData[item]) {
+          arr.push(buildValidationRequest(arrayItem, configFields[item]?.fields[0] || configFields[item]?.fields));
+        }
+        nodeObj[item] = {
+          value: arr,
+          action: DEFAULT_FIELD_ACTION
+        };
+      } else {
+        nodeObj[item] = {
+          value: buildValidationRequest(itemData[item], configFields[item]?.fields),
+          action: DEFAULT_FIELD_ACTION
+        };
+      }
     } else {
       nodeObj[item] = {
         value: itemData[item],

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -25,16 +25,24 @@ class rulesFns {
    * Validates that the array matches the expected type
    *
    * @param {Array} value - The array value to be checked.
-   * @param {string[]} type - An array of expected types as strings that the array contains.
-   * @throws {Exception} Throws an exception if the value is not an array and if any of the values does not match the expected type.
+   * @param {string[]} type - An array of expected primitive types as strings that the array contains.
+   * @param {number} [minLength=null] - The minimum length of the array. If specified, the array must have at least this many elements.
+   * @param {number} [maxLength=null] - The maximum length of the array. If specified, the array must have at most this many elements.
+   * @throws {Exception} Throws an exception if the value is not an array and if any of the values does not match the expected type, or the array does not meet the length requirements.
    */
-  expectArray(value, type = null) {
+  expectArray(value, type = null, minLength = null, maxLength = null) {
     if (!Array.isArray(value)) {
       throw new Exception(`Invalid value: expected '${JSON.stringify(value)}' to be an array`, { code: 400 });
     }
     if (type && !value.every(item => type.includes(typeof item))) {
       const actualTypes = value.map(i => typeof i);
       throw new Exception(`Invalid types in array: expected items to be one of: [${type}], but got: [${actualTypes}]`, { code: 400 });
+    }
+    if (minLength > 0 && value.length < minLength) {
+      throw new Exception(`Invalid array length: expected at least ${minLength} items, but got ${value.length}`, { code: 400 });
+    }
+    if (maxLength && value.length > maxLength) {
+      throw new Exception(`Invalid array length: expected at most ${maxLength} items, but got ${value.length}`, { code: 400 });
     }
   }
 
@@ -249,8 +257,8 @@ class rulesFns {
    */
   expectGeoshape(value) {
     // Type validation
-    if (!value?.type || (value.type !== 'envelope' && value.type !== 'Polygon')) {
-      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'envelope'`, { code: 400 });
+    if (!value?.type || (value.type !== 'envelope' && value.type !== 'polygon')) {
+      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'envelope' or 'polygon'.`, { code: 400 });
     }
 
     // Coordinates validation
@@ -350,7 +358,7 @@ class rulesFns {
       throw new Exception(`Invalid object: Expected object to have all properties: '${properties.join(', ') || properties}'. Missing properties: '${missingKeys.join(', ')}'.`, { code: 400 });
     }
   }
-  
+
   // Expect the object to only have these properties
   expectObjectToOnlyHaveProperties(value, properties) {
   const keys = Object.keys(value);
@@ -359,7 +367,6 @@ class rulesFns {
       throw new Exception(`Invalid object: Expected object to only have properties: '${properties.join(', ')}'. Extra properties found: '${extraKeys.join(', ')}'.`, { code: 400 });
     }
   }
-
   // Expect the object to have at least the provided minimum number of the properties provided
   // Useful when none of the properties are mandatory, but at least one is required
   expectObjectToHaveMinNumberOfProperties(value, properties, min = 1) {


### PR DESCRIPTION
Relates to [983644](https://github.com/bcgov/reserve-rec-public/issues/65)

Some minor changes to the bookings API configuration such that the API can receive forms values straight from the front end. 

Namely a major update to the `data-utils.js` Data Layer code such that the validation step of `quickAPIPutHandler` can handle arrays of complex objects being passed in as a field. The vehicle field can receive more than one of the same type of object: 
```
[
  {
     "licensePlate": "ABC 123",
     "licensePlateRegistrationRegion": "British Columbia"
  },
  {
     "licensePlate": "XYZ 789",
     "licensePlateRegistrationRegion": "Alberta"
  }
]
```
^ Is now permissible and verifiable in the POST body.