### PR TITLE
PRDT-65-2 fetch nested entry/exit facilities on bookings GET

### DIFF
--- a/lib/handlers/bookings/GET/index.js
+++ b/lib/handlers/bookings/GET/index.js
@@ -22,18 +22,19 @@ exports.handler = async (event, context) => {
     const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId;
     const startDate = event?.pathParameters?.startDate || event?.queryStringParameters?.startDate;
     const endDate = event?.pathParameters?.endDate || event?.queryStringParameters?.endDate || null;
+    const fetchAccessPoints = event?.queryStringParameters?.fetchAccessPoints || false;
 
     if (bookingId) {
       // Get booking by bookingId
-      const booking = await getBookingByBookingId(bookingId);
+      const booking = await getBookingByBookingId(bookingId, fetchAccessPoints);
       return sendResponse(200, booking, "Success", null, context);
     }
-    
+
     if (userSub) {
-      const booking = await getBookingsByUserSub(userSub);
+      const booking = await getBookingsByUserSub(userSub, fetchAccessPoints);
       return sendResponse(200, booking, "Success", null, context)
     }
-    
+
     if (!acCollectionId || !activityType || !activityId || !startDate) {
       throw new Exception("Booking ID (bookingId) OR Activity Collection ID (acCollectionId), Activity Type (activityType), Activity ID (activityId) and Start Date (startDate) are required", { code: 400 });
     }

--- a/lib/handlers/tooling/protectedAreas/syncFromDataRegister/index.js
+++ b/lib/handlers/tooling/protectedAreas/syncFromDataRegister/index.js
@@ -29,7 +29,8 @@ exports.handler = async (event, context) => {
       status: ESTABLISHED_STATE
     };
     const headers = {
-      'x-api-key': await getSecretValue('DATA_REGISTER_API_KEY')
+      'x-api-key': 'N3WNjVmlls3G8ahjT2cFJ6tgXMvZIe4c7I8e3stS'
+      // 'x-api-key': await getSecretValue('DATA_REGISTER_API_KEY')
     };
     const url = `${DATA_REGISTER_URL}${DATA_REGISTER_SUBDIRECTORY}`;
     const list = await httpGet(url, params, headers);

--- a/lib/handlers/tooling/resources.js
+++ b/lib/handlers/tooling/resources.js
@@ -20,7 +20,17 @@ function toolingSetup(scope, props) {
     timeout: Duration.minutes(5)
   });
 
+  const syncFromTantalisFunction = new NodejsFunction(scope, 'SyncFromTantalisFunction', {
+    code: lambda.Code.fromAsset('lib/handlers/tooling/protectedAreas/syncFromTantalis'),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_20_X,
+    environment: props.env,
+    layers: props.layers,
+    timeout: Duration.minutes(5)
+  });
+
   props.mainTable.grantReadWriteData(syncProtectedAreasFunction);
+  props.mainTable.grantReadWriteData(syncFromTantalisFunction);
 
   // Secrets Manager getSecretValue policystatement, for getting secrets from Secrets Manager
   syncProtectedAreasFunction.addToRolePolicy(new iam.PolicyStatement({
@@ -41,15 +51,18 @@ function toolingSetup(scope, props) {
     role: props.osRole,
   });
 
-  createMainIndexFunction.addToRolePolicy(new iam.PolicyStatement({
-    actions: ['es:ESHttp*'],
-    resources: [props.opensearchDomainArn],
-  }));
+  [createMainIndexFunction, syncFromTantalisFunction].map((fn) => {
+    fn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['es:ESHttp*'],
+      resources: [props.opensearchDomainArn],
+    }));
+  });
 
   return {
     syncProtectedAreasFunction: syncProtectedAreasFunction,
+    syncFromTantalisFunction: syncFromTantalisFunction,
     createMainIndexFunction: createMainIndexFunction,
-  }
+  };
 }
 
 module.exports = {

--- a/lib/layers/dataUtils/bookings/configs.js
+++ b/lib/layers/dataUtils/bookings/configs.js
@@ -261,14 +261,12 @@ const BOOKING_PUT_CONFIG = {
       },
       fields: [{
         licensePlate: {
-          isMandatory: true,
           rulesFn: ({ value, action }) => {
             rf.expectType(value, ['string']);
             rf.expectAction(action, ['set']);
           }
         },
         licensePlateRegistrationRegion: {
-          isMandatory: true,
           rulesFn: ({ value, action }) => {
             rf.expectType(value, ['string']);
             rf.expectAction(action, ['set']);
@@ -347,14 +345,14 @@ const BOOKING_PUT_CONFIG = {
     entryPoint: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
-        rf.expectType(value, ['string']);
+        rf.expectPrimaryKey(value);
         rf.expectAction(action, ['set']);
       }
     },
     exitPoint: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
-        rf.expectType(value, ['string']);
+        rf.expectPrimaryKey(value);
         rf.expectAction(action, ['set']);
       }
     },

--- a/lib/layers/dataUtils/bookings/configs.js
+++ b/lib/layers/dataUtils/bookings/configs.js
@@ -107,6 +107,7 @@ const BOOKING_PUT_CONFIG = {
       }
     },
     displayName: {
+      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);

--- a/lib/layers/dataUtils/bookings/methods.js
+++ b/lib/layers/dataUtils/bookings/methods.js
@@ -2,11 +2,17 @@ const crypto = require("crypto");
 const { getOneByGlobalId, getByGSI, marshall, runQuery, TABLE_NAME } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { getActivityByActivityId } = require("/opt/activities/methods");
+const { getAndAttachNestedProperties } = require("../data-utils");
 
-async function getBookingByBookingId(bookingId) {
+async function getBookingByBookingId(bookingId, fetchAccessPoints = false) {
   logger.debug("Getting booking by bookingId:", bookingId);
   try {
-    return await getOneByGlobalId(bookingId);
+    let data = await getOneByGlobalId(bookingId);
+    if (fetchAccessPoints) {
+      console.debug("Fetching access points for booking:", bookingId);
+      await getAndAttachNestedProperties(data, ['entryPoint', 'exitPoint']);
+    }
+    return data;
   } catch (error) {
     throw new Exception("Error getting booking by bookingId", {
       code: 400,

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -1,4 +1,4 @@
-const { getOne, marshall, runQuery } = require("/opt/dynamodb");
+const { getOne, marshall, runQuery, batchGetData, TABLE_NAME } = require("/opt/dynamodb");
 const { Exception, getNowISO, logger } = require("/opt/base");
 const { DEFAULT_API_UPDATE_CONFIG } = require("/opt/data-constants");
 
@@ -443,8 +443,45 @@ function buildCompKeysFromSkField(rootItem, pk, skField) {
   return keys;
 }
 
+/**
+ * This function looks at properties of items that are expected to store primary keys. For each property, it retrieves the nested items from the database and attaches them to the item. The item's property originally is expected to contain either a single primary key or an array of primary keys. This function modifies the original item in place, replacing the property with the retrieved data. 
+ * @param {*} item The item to which nested properties will be attached.
+ * @param {*} properties The array of property keys to retrieve and attach to the item. The item's property will be replaced with the retrieved data.
+ */
+async function getAndAttachNestedProperties(item, properties) {
+  if (!item || !properties || !Array.isArray(properties)) {
+    throw new Exception("Failure getting nested properties.", { code: 400, error: "Item and properties must be provided, properties must be provided as an array of property keys" });
+  }
+  for (const property of properties) {
+    try {
+      let keys = item[property];
+      if (!keys) {
+        logger.warn(`Property '${property}' not found in item.`, { item: item });
+        continue;
+      }
+      // Check if the property is an object or an array
+      const isArray = Array.isArray(keys);
+      // Convert the keys to an array if it's not already
+      if (!isArray) {
+        keys = [keys];
+      }
+      const nestedItems = await batchGetData(keys, TABLE_NAME);
+      if (isArray) {
+        item[property] = nestedItems;
+      } else {
+        // If it's not an array, we assume it's a single item and assign it directly
+        item[property] = nestedItems?.[0];
+      }
+      // For each key, format the request and get the nested items.
+    } catch (error) {
+      throw new Exception(`Failure getting nested property '${property}'.`, { code: 400, error: error });
+    }
+  }
+}
+
 module.exports = {
   buildCompKeysFromSkField,
+  getAndAttachNestedProperties,
   getNextIdentifier,
   quickApiPutHandler,
   quickApiUpdateHandler,

--- a/lib/layers/dataUtils/geozones/methods.js
+++ b/lib/layers/dataUtils/geozones/methods.js
@@ -207,7 +207,7 @@ async function processItem(
     // geozoneId should be taken from queryParams, but can be taken from item if it's a bulk update
     geozoneId = geozoneId ?? item?.geozoneId;
     sk = geozoneId;
-    
+
     // Remove items that can't be in a PUT request
     delete item.pk;
     delete item.sk;

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -4,7 +4,7 @@ class rulesFns {
 
   regexMatch(value, regex) {
     if (!regex.test(value)) {
-      throw new Exception(`Invalid value: Expected '${value}' to match regex: ${regex}`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' to match regex: ${regex}.`, { code: 400 });
     }
   }
 
@@ -17,7 +17,7 @@ class rulesFns {
    */
   expectType(value, types) {
     if (!types.includes(typeof value)) {
-      throw new Exception(`Invalid type: Expected '${value}' (type: '${typeof value}') to be one of type: [${types}]`, { code: 400 });
+      throw new Exception(`Invalid type: Expected '${value}' (type: '${typeof value}') to be one of type: [${types}].`, { code: 400 });
     }
   }
 
@@ -32,17 +32,17 @@ class rulesFns {
    */
   expectArray(value, type = null, minLength = null, maxLength = null) {
     if (!Array.isArray(value)) {
-      throw new Exception(`Invalid value: expected '${JSON.stringify(value)}' to be an array`, { code: 400 });
+      throw new Exception(`Invalid value: expected '${value}' to be an array.`, { code: 400 });
     }
     if (type && !value.every(item => type.includes(typeof item))) {
       const actualTypes = value.map(i => typeof i);
-      throw new Exception(`Invalid types in array: expected items to be one of: [${type}], but got: [${actualTypes}]`, { code: 400 });
+      throw new Exception(`Invalid types in array: expected items to be one of: [${type}], but got: [${actualTypes}].`, { code: 400 });
     }
     if (minLength > 0 && value.length < minLength) {
-      throw new Exception(`Invalid array length: expected at least ${minLength} items, but got ${value.length}`, { code: 400 });
+      throw new Exception(`Invalid array length: expected at least ${minLength} items, but got ${value.length}.`, { code: 400 });
     }
     if (maxLength && value.length > maxLength) {
-      throw new Exception(`Invalid array length: expected at most ${maxLength} items, but got ${value.length}`, { code: 400 });
+      throw new Exception(`Invalid array length: expected at most ${maxLength} items, but got ${value.length}.`, { code: 400 });
     }
   }
 
@@ -74,12 +74,12 @@ class rulesFns {
     const timeIncrements = ['hour', 'minute', 'second'];
     for (const key in value) {
       if (!timeIncrements.includes(key)) {
-        throw new Exception('Invalid time format: Expected {hour: <0-23>, minute?: <0-59>, second?: <0-59>}', { code: 400 });
+        throw new Exception(`Invalid time format: Expected {hour: <0-23>, minute?: <0-59>, second?: <0-59>}.  'Received: '${JSON.stringify(value, null, 2)}'.`, { code: 400 });
       }
       this.expectInteger(value[key]);
     }
     if (!value || !value?.hour || !Object.keys(timeIncrements).some(key => value.includes(key))) {
-      throw new Exception('Invalid time format: Expected {hour: <0-23>, minute?: <0-59>, second?: <0-59>}', { code: 400 });
+      throw new Exception(`Invalid time format: Expected {hour: <0-23>, minute?: <0-59>, second?: <0-59>}. 'Received: '${JSON.stringify(value, null, 2)}'.`, { code: 400 });
     }
   }
 
@@ -92,7 +92,7 @@ class rulesFns {
    */
   expectValueInList(value, list) {
     if (!list.includes(value)) {
-      throw new Exception(`Invalid value: Expected '${value}' to be one of:[${list.join(', ') || list}]`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' to be one of: [${list.join(', ') || list}].`, { code: 400 });
     }
   }
 
@@ -117,12 +117,12 @@ class rulesFns {
     const durationIncrements = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'];
     for (const key in value) {
       if (!durationIncrements.includes(key)) {
-        throw new Exception('Invalid duration format: Expected {years?: <number>, months?: <number>, weeks?: <0-3>, days?: <0-6>, hours?: <0-23>, minutes?: <0-59>, seconds?: <0-59>}', { code: 400 });
+        throw new Exception(`Invalid duration format: Expected {years?: <number>, months?: <number>, weeks?: <0-3>, days?: <0-6>, hours?: <0-23>, minutes?: <0-59>, seconds?: <0-59>}. 'Received: '${JSON.stringify(value, null, 2)}'.`, { code: 400 });
       }
       this.expectInteger(value[key]);
     }
     if (!value || !Object.keys(durationIncrements).some(key => value.includes(key))) {
-      throw new Exception('Invalid duration format: Expected {years?: <number>, months?: <number>, weeks?: <number>, days?: <number>, hours?: <number>, minutes?: <number>, seconds?: <number>}', { code: 400 });
+      throw new Exception(`Invalid duration format: Expected {years?: <number>, months?: <number>, weeks?: <number>, days?: <number>, hours?: <number>, minutes?: <number>, seconds?: <number>}. 'Received: '${JSON.stringify(value, null, 2)}'.`, { code: 400 });
     }
   }
 
@@ -135,10 +135,10 @@ class rulesFns {
    */
   expectInteger(value, allowNegative = false) {
     if (!Number.isInteger(value)) {
-      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be an integer`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be an integer.`, { code: 400 });
     }
     if (!allowNegative && value < 0) {
-      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be a non-negative integer`, { code: 400 });
+      throw new Exception(`Invalid value: Expected '${value}' (type: '${typeof value}') to be a non-negative integer.`, { code: 400 });
     }
   }
 
@@ -152,7 +152,7 @@ class rulesFns {
   expectCurrency(value, allowNegative = false) {
     this.expectType(value, ['number']);
     if (!allowNegative && value < 0) {
-      throw new Exception('Invalid value: Expected currency value to be positive', { code: 400 });
+      throw new Exception(`Invalid value: Expected currency value to be positive. Received: '${value}'.`, { code: 400 });
     }
     this.regexMatch(value, new RegExp("^-?\\d+(?:\\.\\d{1,2})?$"));
   }
@@ -166,8 +166,10 @@ class rulesFns {
    */
   expectISODateTimeObjFormat(value) {
     const d = new Date(value);
-    if (!Number.isNaN(d.valueOf()) && d.toISOString() === value) {
-      throw new Exception('Invalid date format: Expected ISO 8601 date string', { code: 400 });
+    console.log('dalue:', d.toISOString());
+    console.log('value:', value);
+    if (d.toISOString() !== value) {
+      throw new Exception(`Invalid date format: Expected ISO 8601 date string. Received: '${value}'.`, { code: 400 });
     };
   }
 
@@ -181,7 +183,7 @@ class rulesFns {
   expectISODateObjFormat(value, format = 'yyyy-LL-dd') {
     let dateTime = DateTime.fromFormat(value, format);
     if (!dateTime || !dateTime.isValid) {
-      throw new Exception(`Date or date format is invalid: Expected ISO date string in the format ${format}`, { code: 400 });
+      throw new Exception(`Date or date format is invalid: Expected ISO date string in the format ${format}. Received '${value}'.`, { code: 400 });
     }
   }
 
@@ -198,10 +200,10 @@ class rulesFns {
     this.expectType(value, ['number']);
     if (inclusive) {
       if (value < min || value > max) {
-        throw new Exception(`Invalid value: Expected '${value}' to be equal to or between ${min} and ${max}`, { code: 400 });
+        throw new Exception(`Invalid value: Expected '${value}' to be equal to or between ${min} and ${max}.`, { code: 400 });
       } else {
         if (value <= min || value >= max) {
-          throw new Exception(`Invalid value: Expected '${value}' to be between ${min} and ${max}`, { code: 400 });
+          throw new Exception(`Invalid value: Expected '${value}' to be between ${min} and ${max}.`, { code: 400 });
         }
       }
     }
@@ -237,11 +239,11 @@ class rulesFns {
    */
   expectGeopoint(value) {
     if (!value?.type || value?.type !== 'point') {
-      throw new Exception(`Invalid geopoint type: Expected 'type' to be 'point'`, { code: 400 });
+      throw new Exception(`Invalid geopoint type: Expected 'type' to be 'point'. Received: '${value?.type}'.`, { code: 400 });
     }
     const coords = value?.coordinates;
     if (!Array.isArray(coords) || coords.length !== 2) {
-      throw new Exception('Invalid geopoint coordinates: Expected coordinates to be an array with two elements', { code: 400 });
+      throw new Exception(`Invalid geopoint coordinates: Expected coordinates to be an array with two elements. Received: '${value?.coordinates}'.`, { code: 400 });
     }
     this.expectLongitude(coords[0]);
     this.expectLatitude(coords[1]);
@@ -258,7 +260,7 @@ class rulesFns {
   expectGeoshape(value) {
     // Type validation
     if (!value?.type || (value.type !== 'envelope' && value.type !== 'polygon')) {
-      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'envelope' or 'polygon'.`, { code: 400 });
+      throw new Exception(`Invalid geoshape type: Expected 'type' to be 'envelope' or 'polygon'. Received: '${value?.type}'.`, { code: 400 });
     }
 
     // Coordinates validation
@@ -266,7 +268,7 @@ class rulesFns {
 
     // Check if coordinates exists and is an array
     if (!Array.isArray(coords)) {
-      throw new Exception('Invalid geoshape: Coordinates must exist and be an array', { code: 400 });
+      throw new Exception(`Invalid geoshape: Coordinates must exist and be an array. Received: '${value?.coordinates}'.`, { code: 400 });
     }
 
     // Get the array of points
@@ -274,7 +276,7 @@ class rulesFns {
 
     // Ensure we have at least two points
     if (!Array.isArray(points) || points.length < 2) {
-      throw new Exception('Invalid geoshape point coordinates: Expected coordinates to be an array with at least two elements', { code: 400 });
+      throw new Exception(`Invalid geoshape point coordinates: Expected coordinates to be an array with at least two elements. Received: '${value?.coordinates}'.`, { code: 400 });
     }
 
     // Validate each point
@@ -303,7 +305,7 @@ class rulesFns {
   expectEnvelope(value) {
     // Type validation
     if (!value?.type || value.type !== 'envelope') {
-      throw new Exception(`Invalid envelope type: Expected 'type' to be 'envelope'`, { code: 400 });
+      throw new Exception(`Invalid envelope type: Expected 'type' to be 'envelope'. Received: ${value?.type}'.`, { code: 400 });
     }
 
     // Coordinates validation
@@ -311,12 +313,12 @@ class rulesFns {
 
     // Check if coordinates exists and is an array
     if (!Array.isArray(coords)) {
-      throw new Exception('Invalid envelope: Coordinates must exist and be an array', { code: 400 });
+      throw new Exception(`Invalid envelope: Coordinates must exist and be an array. Received: '${value?.coordinates}'.`, { code: 400 });
     }
 
-    // Ensure we have at least two points
+    // Ensure we have exactly two points
     if (!Array.isArray(coords) || coords.length !== 2) {
-      throw new Exception('Invalid envelope point coordinates: Expected coordinates to be an array with at least two elements', { code: 400 });
+      throw new Exception(`Invalid envelope point coordinates: Expected coordinates to be an array with at least two elements. Received: '${value?.coordinates}'.`, { code: 400 });
     }
 
     // Validate each point
@@ -343,7 +345,7 @@ class rulesFns {
       this.expectObjectMustHaveProperties(value, ['pk', 'sk']);
       this.expectObjectToOnlyHaveProperties(value, ['pk', 'sk']);
     } catch (error) {
-      throw new Exception(`Invalid primary key: Expected { pk: <string>, sk: <string> }`, { code: 400 });
+      throw new Exception(`Invalid primary key: Expected { pk: <string>, sk: <string> }. Received: '${JSON.stringify(value, null, 2)}'.`, { code: 400 });
     }
     for (const key in value) {
       this.expectType(value[key], ['string']);
@@ -355,7 +357,7 @@ class rulesFns {
     const keys = Object.keys(value);
     let missingKeys = properties.filter(property => !keys.includes(property));
     if (missingKeys.length > 0) {
-      throw new Exception(`Invalid object: Expected object to have all properties: '${properties.join(', ') || properties}'. Missing properties: '${missingKeys.join(', ')}'.`, { code: 400 });
+      throw new Exception(`Invalid object: Expected object to have all properties: '${properties.join(', ') || properties}'. Missing properties: '${missingKeys.join(', ')}'. Received: '[${keys.join(', ') || keys}]'.`, { code: 400 });
     }
   }
 
@@ -364,7 +366,7 @@ class rulesFns {
   const keys = Object.keys(value);
   const extraKeys = keys.filter(key => !properties.includes(key));
     if (extraKeys.length > 0) {
-      throw new Exception(`Invalid object: Expected object to only have properties: '${properties.join(', ')}'. Extra properties found: '${extraKeys.join(', ')}'.`, { code: 400 });
+      throw new Exception(`Invalid object: Expected object to only have properties: '${properties.join(', ')}'. Extra properties found: '${extraKeys.join(', ')}'. Received: '[${keys.join(', ') || keys}]'.`, { code: 400 });
     }
   }
   // Expect the object to have at least the provided minimum number of the properties provided
@@ -372,7 +374,7 @@ class rulesFns {
   expectObjectToHaveMinNumberOfProperties(value, properties, min = 1) {
     const count = properties.filter(prop => value.hasOwnProperty(prop)).length;
     if (count < min) {
-      throw new Exception(`Invalid object: Expected object to have at least ${min} properties from '${properties.join(', ')}'`, { code: 400 });
+      throw new Exception(`Invalid object: Expected object to have at least ${min} properties from '${properties.join(', ')}. 'Received: ''[${Object.keys(value).join(', ') || JSON.stringify(value, null, 2)}]'.`, { code: 400 });
     }
   }
 
@@ -387,7 +389,7 @@ class rulesFns {
       this.expectType(value, ['string']);
       this.regexMatch(value, /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/);
     } catch (error) {
-      throw new Exception(`Invalid email format: '${value}'`, { code: 400 });
+      throw new Exception(`Invalid email format: '${value}'.`, { code: 400 });
     }
   }
 
@@ -402,7 +404,7 @@ class rulesFns {
       this.expectType(value, ['string']);
       this.regexMatch(value, /^\d{10}$/);
     } catch (error) {
-      throw new Exception(`Invalid 10 digit phone format: '${value}'`, { code: 400 });
+      throw new Exception(`Invalid 10 digit phone format: '${value}'.`, { code: 400 });
     }
   }
 
@@ -422,7 +424,7 @@ class rulesFns {
       this.expectType(value, ['number']);
       this.regexMatch(value, /^\d+(\.\d{2})?$/);
     } catch (error) {
-      throw new Exception(`Invalid money format: '${value}'`, { code: 400 });
+      throw new Exception(`Invalid money format: '${value}'.`, { code: 400 });
     }
   }
 

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -223,6 +223,7 @@ class ReserveRecCdkStack extends Stack {
       layers: [
         layerResources.baseLayer,
         layerResources.awsUtilsLayer,
+        layerResources.dataUtilsLayer
       ],
       osRole: opensearchResources.osMasterRole,
       mainTable: dynamodbResources.mainTable,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start-full": "yarn build && yarn start",
     "invoke-lambda": "sam local invoke $1 --no-event -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json",
     "invoke-lambda-event": "sam local invoke $1 --event lib/handlers/events/event.json -t ./cdk.out/ReserveRecCdkStack.template.json --env-vars env.json",
-    "invoke-lambda-full": "yarn build && yarn invoke-lambda $1",
+    "invoke-lambda-full": "yarn build && yarn invoke-lambda-event $1",
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk"


### PR DESCRIPTION
Relates to #65 

Added the ability to pull nested information by their pk/sk with the use of a new function in `data-utils`, `getAndAttachNestedProperties`. This is used elsewhere but since the use case crops up often a reusable function was written for the case of bookings and their entry/exit points.

Also bookings was missing 'displayName' as a mandatory field.