### PR TITLE
PRDT-65 updating quickAPIHandlers to allow empty fields

### DIFF
--- a/lib/layers/dataUtils/bookings/configs.js
+++ b/lib/layers/dataUtils/bookings/configs.js
@@ -73,7 +73,6 @@ const BOOKING_PUT_CONFIG = {
       }
     },
     user: {
-      // the user sub. Will be blank if the booking is made by a guest.
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
@@ -205,13 +204,11 @@ const BOOKING_PUT_CONFIG = {
             },
             mobilePhone: {
               rulesFn: ({ value, action }) => {
-                rf.expect10DigitPhoneFormat(value);
                 rf.expectAction(action, ['set']);
               }
             },
             homePhone: {
               rulesFn: ({ value, action }) => {
-                rf.expect10DigitPhoneFormat(value);
                 rf.expectAction(action, ['set']);
               }
             },

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -159,6 +159,11 @@ function validateRequestData(itemData, itemConfig) {
         throw new Exception(`Invalid field.`, { code: 400, error: `Field '${field}' is not allowed in the request` });
       }
 
+      // If the field is empty and allowEmpty is true, skip validation.
+      if (fieldRules?.allowEmpty && (itemData[field].value === undefined || itemData[field].value === null || itemData[field].value === '')) {
+        continue;
+      }
+
       // If the field is an object with its own fields, validate the nested fields
       if (fieldRules?.hasOwnProperty('fields')) {
         // if the field is an array, we need to validate each item in the array
@@ -444,7 +449,7 @@ function buildCompKeysFromSkField(rootItem, pk, skField) {
 }
 
 /**
- * This function looks at properties of items that are expected to store primary keys. For each property, it retrieves the nested items from the database and attaches them to the item. The item's property originally is expected to contain either a single primary key or an array of primary keys. This function modifies the original item in place, replacing the property with the retrieved data. 
+ * This function looks at properties of items that are expected to store primary keys. For each property, it retrieves the nested items from the database and attaches them to the item. The item's property originally is expected to contain either a single primary key or an array of primary keys. This function modifies the original item in place, replacing the property with the retrieved data.
  * @param {*} item The item to which nested properties will be attached.
  * @param {*} properties The array of property keys to retrieve and attach to the item. The item's property will be replaced with the retrieved data.
  */

--- a/lib/layers/dataUtils/validation-rules.js
+++ b/lib/layers/dataUtils/validation-rules.js
@@ -166,8 +166,6 @@ class rulesFns {
    */
   expectISODateTimeObjFormat(value) {
     const d = new Date(value);
-    console.log('dalue:', d.toISOString());
-    console.log('value:', value);
     if (d.toISOString() !== value) {
       throw new Exception(`Invalid date format: Expected ISO 8601 date string. Received: '${value}'.`, { code: 400 });
     };


### PR DESCRIPTION
Originally had planned for the 'user' field to be empty if a booking was made with a guest account, so this code was added to allow a field to be submitted to the quickAPIHandlers as blank (all the validation rules would be ignored). 

Turns out 'user' is a field used in a GSI so it cannot be blank, but this code still holds for other fields.

Guest accounts will now have no user field. 