### PR TITLE
Don't attempt to call nested properties if there are none

### DIFF
--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -454,12 +454,15 @@ function buildCompKeysFromSkField(rootItem, pk, skField) {
  * @param {*} properties The array of property keys to retrieve and attach to the item. The item's property will be replaced with the retrieved data.
  */
 async function getAndAttachNestedProperties(item, properties) {
-  if (!item || !properties || !Array.isArray(properties)) {
-    throw new Exception("Failure getting nested properties.", { code: 400, error: "Item and properties must be provided, properties must be provided as an array of property keys" });
+  if (item?.length === 0) {
+    return; // If the item is empty, there's nothing to do.
+  }
+  if (!properties || !Array.isArray(properties)) {
+    throw new Exception("Failure getting nested properties.", { code: 400, error: `Item and properties must be provided, properties must be provided as an array of property keys. Received [item]: '${item}' and [properties]: '${properties}'.` });
   }
   for (const property of properties) {
     try {
-      let keys = item[property];
+      let keys = item?.[property];
       if (!keys) {
         logger.warn(`Property '${property}' not found in item.`, { item: item });
         continue;

--- a/lib/layers/dataUtils/data-utils.js
+++ b/lib/layers/dataUtils/data-utils.js
@@ -463,7 +463,7 @@ async function getAndAttachNestedProperties(item, properties) {
   for (const property of properties) {
     try {
       let keys = item?.[property];
-      if (!keys) {
+      if (!keys || keys?.length === 0) {
         logger.warn(`Property '${property}' not found in item.`, { item: item });
         continue;
       }


### PR DESCRIPTION
Relates to #98. In `/layers/dataUtils/data-utils/getAndAttachNestedProperties`, an error is thrown if the item's property  doesn't exist or is an empty array. Instead, the code should provide a warning and continue.