### PR TITLE
PRDT-57: Protected Areas Front-End CRUD Setup

### DIFF
--- a/lib/layers/dataUtils/protectedAreas/configs.js
+++ b/lib/layers/dataUtils/protectedAreas/configs.js
@@ -91,6 +91,24 @@ const PROTECTED_AREA_API_PUT_CONFIG = {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['add']);
       }
+    },
+    isVisible: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    searchTerms: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
     }
   }
 };
@@ -149,6 +167,24 @@ const PROTECTED_AREA_API_UPDATE_CONFIG = {
       }
     },
     imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    isVisible: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    adminNotes: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    searchTerms: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);


### PR DESCRIPTION
### Ticket:
PRDT-57

### Ticket URL:
#57 

### Description:
- Adds `isVisible`, `adminNotes`, and `searchTerms` to Protected Area.
- `isVisible` may need to be added to [data model](https://github.com/bcgov/reserve-rec-api/wiki/Data-Model#protected-areas)