### PR TITLE
PRDT-59 and 58: facilities, geozones, and activities fixes for CRUD

### DIFF
--- a/lib/handlers/activities/_acCollectionId/DELETE/index.js
+++ b/lib/handlers/activities/_acCollectionId/DELETE/index.js
@@ -9,21 +9,16 @@ exports.handler = async (event, context) => {
   logger.info("DELETE Activities", event);
   try {
     const acCollectionId = event?.pathParameters?.acCollectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
     const body = JSON.parse(event?.body);
 
-    if (!acCollectionId) {
-      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
+    if (!acCollectionId || !activityType || !activityId) {
+      throw new Exception("Activity Collection ID, Activity Type, and Activity ID are required", { code: 400 });
     }
 
     if (body) {
       throw new Exception("Body is not allowed", { code: 400 });
-    }
-
-    // Grab the activityType or activityId
-    const { activityType, activityId } = event?.queryStringParameters || {};
-
-    if (!activityType && !activityId) {
-      throw new Exception("activityType and activityId are required", { code: 400 });
     }
 
     const deleteItem = createDeleteCommand(acCollectionId, activityType, activityId)

--- a/lib/handlers/activities/_acCollectionId/PUT/index.js
+++ b/lib/handlers/activities/_acCollectionId/PUT/index.js
@@ -12,8 +12,11 @@ exports.handler = async (event, context) => {
   logger.info("PUT Activities", event);
   try {
     const acCollectionId = event?.pathParameters?.acCollectionId;
-    if (!acCollectionId) {
-      throw new Exception("Activity Collection ID (acCollectionId) is required", { code: 400 });
+    const activityType = event?.pathParameters?.activityType || event?.queryStringParameters || {};
+    const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId;
+
+    if (!acCollectionId && !activityType && !activityId) {
+      throw new Exception("Activity Collection ID, Activity Type, and Activity ID are required", { code: 400 });
     }
 
     const body = JSON.parse(event?.body);
@@ -21,7 +24,6 @@ exports.handler = async (event, context) => {
       throw new Exception("Body is required", { code: 400 });
     }
 
-    const { activityType, activityId } = event?.queryStringParameters || {};
     let updateRequests = await parseRequest(acCollectionId, body, "PUT", activityType, activityId);
 
     // Use quickApiPutHandler to create the put items
@@ -45,24 +47,4 @@ exports.handler = async (event, context) => {
     );
   }
 };
-
-function processItem(orcs, activityType, activityId, sk, item) {
-  return createPutCommand(orcs, activityType, activityId, sk, item);
-}
-
-function createPutCommand(acCollectionId, activityType, activityId, sk, item) {
-  const pk = `activity::${acCollectionId}`;
-  sk = sk ? sk : `${activityType}::${activityId}`;
-
-  // Remove pk, sk, activityType, and activityId as these can't be updated
-  delete item.pk;
-  delete item.sk;
-  delete item.activityType;
-  delete item.activityId;
-
-  return {
-    key: { pk: pk, sk: sk },
-    data: item,
-  };
-}
 

--- a/lib/handlers/activities/resources.js
+++ b/lib/handlers/activities/resources.js
@@ -14,6 +14,7 @@ function activitiesSetup(scope, props) {
 
   // /activities/{acCollectionId}/ resource
   const activitiesCollectionIdResource = activitiesResource.addResource('{acCollectionId}');
+  const activitiesCollectionTypeIdResource = activitiesCollectionIdResource.addResource('{activityType}').addResource('{activityId}');
 
   // GET /activities/{acCollectionId}
   const activitiesGetByAcCollectionId = new NodejsFunction(scope, 'ActivitiesGetByAcCollectionId', {
@@ -35,25 +36,25 @@ function activitiesSetup(scope, props) {
   });
   activitiesCollectionIdResource.addMethod('POST', new apigateway.LambdaIntegration(activitiesPostByAcCollectionId));
 
-  // PUT /activities/{acCollectionId}
-  const activitiesPutByAcCollectionId = new NodejsFunction(scope, 'ActivitiesPutByAcCollectionId', {
+  // PUT /activities/{acCollectionId}/{activityType}/{activityId}
+  const activitiesPutByCollectionTypeId = new NodejsFunction(scope, 'ActivitiesPutByCollectionTypeId', {
     code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/PUT'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesCollectionIdResource.addMethod('PUT', new apigateway.LambdaIntegration(activitiesPutByAcCollectionId));
+  activitiesCollectionTypeIdResource.addMethod('PUT', new apigateway.LambdaIntegration(activitiesPutByCollectionTypeId));
 
-  // DELETE /activities/{acCollectionId}
-  const activitiesDeleteByAcCollectionId = new NodejsFunction(scope, 'ActivitiesDeleteByAcCollectionId', {
+  // DELETE /activities/{acCollectionId}/{activityType}/{activityId}
+  const activitiesDeleteByCollectionTypeId = new NodejsFunction(scope, 'ActivitiesDeleteByCollectionTypeId', {
     code: lambda.Code.fromAsset('lib/handlers/activities/_acCollectionId/DELETE'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  activitiesCollectionIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(activitiesDeleteByAcCollectionId));
+  activitiesCollectionTypeIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(activitiesDeleteByCollectionTypeId));
 
   // Add DynamoDB query & getItem policies to the functions
   const dynamoDbPolicy = new iam.PolicyStatement({
@@ -70,16 +71,17 @@ function activitiesSetup(scope, props) {
 
   activitiesGetByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
   activitiesPostByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
-  activitiesPutByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
-  activitiesDeleteByAcCollectionId.addToRolePolicy(dynamoDbPolicy);
+  activitiesPutByCollectionTypeId.addToRolePolicy(dynamoDbPolicy);
+  activitiesDeleteByCollectionTypeId.addToRolePolicy(dynamoDbPolicy);
 
   return {
     activitiesGetByAcCollectionId: activitiesGetByAcCollectionId,
     activitiesPostByAcCollectionId: activitiesPostByAcCollectionId,
-    activitiesPutByAcCollectionId: activitiesPutByAcCollectionId,
-    activitiesDeleteByAcCollectionId: activitiesDeleteByAcCollectionId,
+    activitiesPutByCollectionTypeId: activitiesPutByCollectionTypeId,
+    activitiesDeleteByCollectionTypeId: activitiesDeleteByCollectionTypeId,
     activitiesResource: activitiesResource,
     activitiesCollectionIdResource: activitiesCollectionIdResource,
+    activitiesCollectionTypeIdResource: activitiesCollectionTypeIdResource
   };
 }
 

--- a/lib/handlers/bookings/resources.js
+++ b/lib/handlers/bookings/resources.js
@@ -27,11 +27,7 @@ function bookingsSetup(scope, props) {
   const bookingsByBookingIdResource = bookingsResource.addResource('{bookingId}');
 
   // /bookings by activity resource (extends from /activities/{acCollectionId}/{activityType}/{activityId}/{startDate}/bookings)
-  const bookingsByActivityResource = props.activitiesResources.activitiesCollectionIdResource
-    .addResource('{activityType}')
-    .addResource('{activityId}')
-    .addResource('{startDate}')
-    .addResource('bookings');
+  const bookingsByActivityResource = props.activitiesResources.activitiesCollectionTypeIdResource;
 
   // GET /bookings
   const bookingsGet = new NodejsFunction(scope, 'BookingsGet', {
@@ -67,7 +63,6 @@ function bookingsSetup(scope, props) {
   });
 
   bookingsResource.addMethod('PUT', new apigateway.LambdaIntegration(bookingsPut));
-  bookingsByActivityResource.addMethod('PUT', new apigateway.LambdaIntegration(bookingsPut));
 
   const dynamodbPolicy = new iam.PolicyStatement({
     actions: [

--- a/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/DELETE/index.js
@@ -9,21 +9,16 @@ exports.handler = async (event, context) => {
   logger.info("DELETE Facilities", event);
   try {
     const fcCollectionId = event?.pathParameters?.fcCollectionId;
+    const facilityType = event?.pathParameters?.facilityType || event?.queryStringParameters?.facilityType;
+    const facilityId = event?.pathParameters?.facilityId || event?.queryStringParameters?.facilityId;
     const body = JSON.parse(event?.body);
 
-    if (!fcCollectionId) {
-      throw new Exception("Facility Collection Id (fcCollectionId) is required", { code: 400 });
+    if (!fcCollectionId || !facilityType || !facilityId) {
+      throw new Exception("Facility Collection ID, Facility Type, and Facility ID are required", { code: 400 });
     }
 
     if (body) {
       throw new Exception("Body is not allowed", { code: 400 });
-    }
-
-    // Grab the facilityType or facilityId
-    const { facilityType, facilityId } = event?.queryStringParameters || {};
-
-    if (!facilityType && !facilityId) {
-      throw new Exception("facilityType and facilityId are required", { code: 400 });
     }
 
     const deleteItem = createDeleteCommand(fcCollectionId, facilityType, facilityId)

--- a/lib/handlers/facilities/_fcCollectionId/POST/index.js
+++ b/lib/handlers/facilities/_fcCollectionId/POST/index.js
@@ -22,6 +22,9 @@ exports.handler = async (event, context) => {
       throw new Exception("Body is required", { code: 400 });
     }
 
+    body['fcCollectionId'] = fcCollectionId;
+    body['schema'] = 'facility';
+
     // Attempt to batch create a facility.
     // If it fails, reset the counter on reserve-rec-counter table and try again.
     let res;

--- a/lib/handlers/geozones/_gzCollectionId/DELETE/index.js
+++ b/lib/handlers/geozones/_gzCollectionId/DELETE/index.js
@@ -2,25 +2,22 @@ const { Exception, logger, sendResponse } = require("/opt/base");
 const { TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
 
 /**
- * @api {delete} /geozones/{gzCollectionId}/ DELETE
+ * @api {delete} /geozones/{gzCollectionId}/{geozoneId} DELETE
  * Delete Geozones
  */
 exports.handler = async (event, context) => {
   logger.info("DELETE Geozones", event);
   try {
     const gzCollectionId = event?.pathParameters?.gzCollectionId;
-    if (!gzCollectionId) {
+    const geozoneId = event?.pathParameters?.geozoneId;
+    const body = JSON.parse(event?.body);
+
+    if (!gzCollectionId || !geozoneId) {
       throw new Exception("gzCollectionId is required", { code: 400 });
     }
 
-    const body = JSON.parse(event?.body);
     if (body) {
       throw new Exception("Body is not allowed", { code: 400 });
-    }
-
-    const { geozoneId } = event?.queryStringParameters || {};
-    if (!geozoneId) {
-      throw new Exception("geozoneId is required", { code: 400 });
     }
 
     const deleteItem = createDeleteCommand(gzCollectionId, geozoneId)

--- a/lib/handlers/geozones/resources.js
+++ b/lib/handlers/geozones/resources.js
@@ -53,14 +53,14 @@ function geozonesSetup(scope, props) {
   geozonesGeozoneIdResource.addMethod('PUT', new apigateway.LambdaIntegration(geozonesPutByGzCollectionId));
 
   // DELETE /geozones/{gzCollectionId}
-  const geozonesDeleteByGzCollectionId = new NodejsFunction(scope, 'GeozonesDeleteByGzCollectionId', {
+  const geozonesDeleteByGeozoneId = new NodejsFunction(scope, 'GeozonesDeleteByGeozoneId', {
     code: lambda.Code.fromAsset('lib/handlers/geozones/_gzCollectionId/DELETE'),
     handler: 'index.handler',
     runtime: lambda.Runtime.NODEJS_20_X,
     environment: props.env,
     layers: props.layers,
   });
-  geozonesGzCollectionIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(geozonesDeleteByGzCollectionId));
+  geozonesGeozoneIdResource.addMethod('DELETE', new apigateway.LambdaIntegration(geozonesDeleteByGeozoneId));
 
   // Add DynamoDB query & getItem policies to the functions
   const dynamoDbPolicy = new iam.PolicyStatement({
@@ -78,13 +78,13 @@ function geozonesSetup(scope, props) {
   geozonesGetByGzCollectionId.addToRolePolicy(dynamoDbPolicy);
   geozonesPostByGzCollectionId.addToRolePolicy(dynamoDbPolicy);
   geozonesPutByGzCollectionId.addToRolePolicy(dynamoDbPolicy);
-  geozonesDeleteByGzCollectionId.addToRolePolicy(dynamoDbPolicy);
+  geozonesDeleteByGeozoneId.addToRolePolicy(dynamoDbPolicy);
 
   return {
     geozonesGetByGzCollectionId: geozonesGetByGzCollectionId,
     geozonesPostByGzCollectionId: geozonesPostByGzCollectionId,
     geozonesPutByGzCollectionId: geozonesPutByGzCollectionId,
-    geozonesDeleteByGzCollectionId: geozonesDeleteByGzCollectionId,
+    geozonesDeleteByGeozoneId: geozonesDeleteByGeozoneId,
     geozonesResource: geozonesResource
   };
 }

--- a/lib/layers/awsUtils/dynamodb.js
+++ b/lib/layers/awsUtils/dynamodb.js
@@ -104,7 +104,13 @@ async function incrementCounter(pk, collectionType = []) {
     };
 
     const countRes = await dynamodb.send(new QueryCommand(countParams));
-    const countActual = countRes?.Count;
+    let countActual = countRes?.Count;
+    
+    // If no skType, we need to exclude the counter item from the count
+    if (!skType && countActual > 0) {
+      countActual = countActual - 1;
+    }
+    
     logger.debug(`The actual count of items is: ${countActual}`);
 
     // Compare the actualCount to the counter's counterValue. If the countActual is
@@ -185,7 +191,13 @@ async function resetCounter(pk, skType) {
 
     // Through all the items pulled, just find the highest identifier
     const res = await runQuery(identifierQuery, null, null, false); // no pagination, return all
-    const items = res.items || [];
+    let items = res.items || [];
+    
+    // If no skType, filter out the counter item manually
+    if (!skType) {
+      items = items.filter(item => item.sk !== 'counter');
+    }
+    
     const identifiers = items.map(item => Number(item.identifier || 0));
     const maxIdentifier = identifiers.length > 0 ? Math.max(...identifiers) : 0;
     logger.debug(`Max identifier found: ${maxIdentifier}`);

--- a/lib/layers/dataUtils/activities/configs.js
+++ b/lib/layers/dataUtils/activities/configs.js
@@ -102,7 +102,6 @@ const ACTIVITY_API_PUT_CONFIG = {
       }
     },
     isVisible: {
-      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
         rf.expectAction(action, ['set']);

--- a/lib/layers/dataUtils/facilities/configs.js
+++ b/lib/layers/dataUtils/facilities/configs.js
@@ -117,7 +117,6 @@ const FACILITY_API_PUT_CONFIG = {
     }
   },
   isVisible: {
-    isMandatory: true,
     rulesFn: ({ value, action }) => {
       rf.expectType(value, ['boolean']);
       rf.expectAction(action, ['set']);

--- a/lib/layers/dataUtils/geozones/methods.js
+++ b/lib/layers/dataUtils/geozones/methods.js
@@ -88,6 +88,12 @@ async function getGeozonesByGzCollectionId(
     queryObj = addFilters(queryObj, filters);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
+    
+    // Filter out the counter item
+    if (res?.items) {
+      res.items = res.items.filter(item => item.sk !== 'counter');
+    }
+    
     logger.info(`Geozones: ${res?.items?.length} found.`);
     return res;
   } catch (error) {


### PR DESCRIPTION
### Ticket:
PRDT-59, PRDT-58

### Ticket URL:
[#59](https://github.com/bcgov/reserve-rec-admin/issues/59), [#58](https://github.com/bcgov/reserve-rec-admin/issues/58)

### Description:
- Activities endpoints
  - Modified DELETE and PUT endpoints for activities from `/activities/{acCollectionId}` to `/activities/{acCollectionId}/{activityType}/{activityId}`
  - Updated DELETE endpoint for geozones from `/geozones/{gzCollectionId}` to `/geozones/{gzCollectionId}/{geozoneId}`
  - Refactored parameter extraction to use path parameters instead of query string parameters

- Activities handler updates
  - DELETE handler now extracts `activityType` and `activityId` from path parameters instead of query parameters
  - PUT handler parameter logic with fallback to query parameters for backwards compatibility
  - Added nested resource structure `{acCollectionId}/{activityType}/{activityId}`
  
- Bookings update:
  - Resource cleanup: Consolidated booking endpoints to use the new activities structure

- Geozones handler updates:
  - DELETE handler now requires `geozoneId` as path parameter instead of query parameter
  - Updated to use path-based routing for geozone deletion
  - ensured counter items don't appear in API responses

- Facilities updates:
  - Updated DELETE handler to support both path and query parameters for `facilityType` and `facilityId`
  - Added automatic setting of `fcCollectionId` and `schema` fields

- Fix to `incrementCounter`:
  - Counter logic: Enhanced `incrementCounter` and `resetCounter` functions to properly handle items without `skType`
  - Item filtering: Added logic to exclude counter items from actual count calculations
  - Query optimization: Improved handling of counter items in geozone queries

- Configs updates:
  - Removed mandatory requirement for `isVisible` field in both activities and facilities configurations
