### PR TITLE
PRDT-171-2: Updating userpool imports to use ARN instead of userpoolId

### DIFF
--- a/lib/cdk/cognito-admin.js
+++ b/lib/cdk/cognito-admin.js
@@ -149,6 +149,12 @@ function cognitoAdminSetup(scope, props) {
     exportName: 'AdminUserPoolId',
   });
 
+  new cdk.CfnOutput(scope, 'AdminUserPoolArn', {
+    value: userPool.userPoolArn,
+    description: 'Admin User Pool Arn Reference',
+    exportName: 'AdminUserPoolArn',
+  });
+
   new cdk.CfnOutput(scope, 'AdminUserPoolClientId', {
     value: userPoolClient.userPoolClientId,
     description: 'Admin User Pool Client Id Reference',
@@ -166,6 +172,10 @@ function cognitoAdminSetup(scope, props) {
     description: 'Admin User Pool Domain Reference',
     exportName: 'AdminUserPoolDomainUrl',
   });
+
+  return {
+    adminUserPool: userPool,
+  }
 
 }
 

--- a/lib/cdk/cognito-public.js
+++ b/lib/cdk/cognito-public.js
@@ -149,6 +149,12 @@ function cognitoPublicSetup(scope, props) {
         exportName: 'PublicUserPoolId',
     });
 
+    new cdk.CfnOutput(scope, 'PublicUserPoolArn', {
+        value: publicUserPool.userPoolArn,
+        description: 'Public User Pool Arn Reference',
+        exportName: 'PublicUserPoolArn',
+    });
+
     new cdk.CfnOutput(scope, 'PublicUserPoolClientId', {
         value: publicUserPoolClient.userPoolClientId,
         description: 'Public User Pool Client Id Reference',
@@ -166,6 +172,10 @@ function cognitoPublicSetup(scope, props) {
         description: 'Public User Pool Domain Reference',
         exportName: 'PublicUserPoolDomainUrl',
     });
+
+    return {
+        publicUserPool: publicUserPool,
+    }
 
 }
 

--- a/lib/cdk/lambda.js
+++ b/lib/cdk/lambda.js
@@ -36,6 +36,7 @@ function layerSetup(scope, props) {
     // TODO: Change RemovalPolicy to RETAIN when we've figured everything out
     removalPolicy: RemovalPolicy.DESTROY, // Will delete the layer when the stack is deleted
   });
+  const baseLayerVersion = lambda.LayerVersion.fromLayerVersionArn(scope, 'BaseLayerVersion', baseLayer.layerVersionArn);
 
   const awsUtilsLayerEntry = path.join(__dirname, '../layers/awsUtils');
   const awsUtilsLayer = new lambda.LayerVersion(scope, 'AwsUtilsLambdaLayer', {
@@ -59,6 +60,7 @@ function layerSetup(scope, props) {
     licenseInfo: 'Apache-2.0',
     removalPolicy: RemovalPolicy.DESTROY, // Will delete the layer when the stack is deleted
   });
+  const awsUtilsLayerVersion = lambda.LayerVersion.fromLayerVersionArn(scope, 'AWSUtilsLayerVersion', awsUtilsLayer.layerVersionArn);
 
   const dataUtilsEntry = path.join(__dirname, '../layers/dataUtils');
   const dataUtilsLayer = new lambda.LayerVersion(scope, 'DataUtilsLambdaLayer', {
@@ -82,6 +84,7 @@ function layerSetup(scope, props) {
     licenseInfo: 'Apache-2.0',
     removalPolicy: RemovalPolicy.DESTROY, // Will delete the layer when the stack is deleted
   });
+  const dataUtilsLayerVersion = lambda.LayerVersion.fromLayerVersionArn(scope, 'DataUtilsLayerVersion', dataUtilsLayer.layerVersionArn);
 
   const jwtEntry = path.join(__dirname, '../layers/jwt');
   const jwtLayer = new lambda.LayerVersion(scope, 'JwtLambdaLayer', {
@@ -105,6 +108,7 @@ function layerSetup(scope, props) {
     licenseInfo: 'Apache-2.0',
     removalPolicy: RemovalPolicy.DESTROY, // Will delete the layer when the stack is deleted
   });
+  const jwtLayerVersion = lambda.LayerVersion.fromLayerVersionArn(scope, 'JwtLayerVersion', jwtLayer.layerVersionArn);
 
   // Outputs
   new CfnOutput(scope, 'BaseLayerArn', {
@@ -132,10 +136,10 @@ function layerSetup(scope, props) {
   });
 
   return {
-    baseLayer: baseLayer,
-    awsUtilsLayer: awsUtilsLayer,
-    dataUtilsLayer: dataUtilsLayer,
-    jwtLayer: jwtLayer,
+    baseLayer: baseLayerVersion,
+    awsUtilsLayer: awsUtilsLayerVersion,
+    dataUtilsLayer: dataUtilsLayerVersion,
+    jwtLayer: jwtLayerVersion,
   };
 }
 

--- a/lib/handlers/users/resources.js
+++ b/lib/handlers/users/resources.js
@@ -11,8 +11,8 @@ const { Fn } = require('aws-cdk-lib');
 function userSetup(scope, props) {
   console.log('User handler setup...');
 
-  const publicUserPoolId = Fn.importValue('PublicUserPoolId');
-  const adminUserPoolId = Fn.importValue('AdminUserPoolId');
+  const publicUserPoolArn = Fn.importValue('publicUserPoolArn');
+  const adminUserPoolArn = Fn.importValue('adminUserPoolArn');
 
   const userResource = props.api.root.addResource('users');
   const userPoolIdResource = userResource.addResource('{userPoolId}');
@@ -43,7 +43,7 @@ function userSetup(scope, props) {
 
   // Add DynamoDB policy to the function
   const cognitoIDPPolicy = new iam.PolicyStatement({
-    resources: [publicUserPoolId, adminUserPoolId],
+    resources: [publicUserPoolArn, adminUserPoolArn],
     actions: [
       'cognito-idp:AdminGetUser',
       'cognito-idp:AdminCreateUser',


### PR DESCRIPTION
Relates to #171.

Ran into deployment error where assigning IAM policies based on `UserPoolId` resulted in an error. Added `CfnOutput`s for `UserPoolArn`s and seeing if that solves the issue.