### PR TITLE
PRDT-171-4 switching to direct userpool reference

### DIFF
--- a/lib/handlers/users/resources.js
+++ b/lib/handlers/users/resources.js
@@ -11,8 +11,8 @@ const { Fn } = require('aws-cdk-lib');
 function userSetup(scope, props) {
   console.log('User handler setup...');
 
-  const publicUserPoolArn = Fn.importValue('PublicUserPoolArn');
-  const adminUserPoolArn = Fn.importValue('AdminUserPoolArn');
+  const publicUserPool = props.publicUserPool;
+  const adminUserPool = props.adminUserPool;
 
   const userResource = props.api.root.addResource('users');
   const userPoolIdResource = userResource.addResource('{userPoolId}');
@@ -43,7 +43,7 @@ function userSetup(scope, props) {
 
   // Add DynamoDB policy to the function
   const cognitoIDPPolicy = new iam.PolicyStatement({
-    resources: [publicUserPoolArn, adminUserPoolArn],
+    resources: [publicUserPool.userPoolArn, adminUserPool.userPoolArn],
     actions: [
       'cognito-idp:AdminGetUser',
       'cognito-idp:AdminCreateUser',

--- a/lib/reserve-rec-cdk-stack.js
+++ b/lib/reserve-rec-cdk-stack.js
@@ -46,8 +46,8 @@ class ReserveRecCdkStack extends Stack {
     }
 
     // COGNITO
-    cognitoAdminSetup(this, props);
-    cognitoPublicSetup(this, props);
+    const cognitoAdmin = cognitoAdminSetup(this, props);
+    const cognitoPublic = cognitoPublicSetup(this, props);
 
     // LAMBDA LAYERS
 
@@ -263,7 +263,9 @@ class ReserveRecCdkStack extends Stack {
         layerResources.awsUtilsLayer,
         layerResources.dataUtilsLayer
       ],
-      adminRequestAuthorizer: authorizerResources.adminRequestAuthorizer
+      adminRequestAuthorizer: authorizerResources.adminRequestAuthorizer,
+      publicUserPool: cognitoPublic.publicUserPool,
+      adminUserPool: cognitoAdmin.adminUserPool,
     });
 
     // WebSocket


### PR DESCRIPTION
Using direct reference instead of `Fn.Import` (which is apparently more common to use across stacks)