### PR TITLE
PRDT-171-6 giving user get wildcard resource permissions

### DIFF
--- a/lib/cdk/cognito-admin.js
+++ b/lib/cdk/cognito-admin.js
@@ -175,7 +175,7 @@ function cognitoAdminSetup(scope, props) {
 
   return {
     adminUserPool: userPool,
-  }
+  };
 
 }
 

--- a/lib/cdk/cognito-public.js
+++ b/lib/cdk/cognito-public.js
@@ -175,7 +175,7 @@ function cognitoPublicSetup(scope, props) {
 
     return {
         publicUserPool: publicUserPool,
-    }
+    };
 
 }
 

--- a/lib/handlers/users/resources.js
+++ b/lib/handlers/users/resources.js
@@ -6,13 +6,9 @@ const lambda = require('aws-cdk-lib/aws-lambda');
 const apigateway = require('aws-cdk-lib/aws-apigateway');
 const iam = require('aws-cdk-lib/aws-iam');
 const { NodejsFunction } = require("aws-cdk-lib/aws-lambda-nodejs");
-const { Fn } = require('aws-cdk-lib');
 
 function userSetup(scope, props) {
   console.log('User handler setup...');
-
-  const publicUserPool = props.publicUserPool;
-  const adminUserPool = props.adminUserPool;
 
   const userResource = props.api.root.addResource('users');
   const userPoolIdResource = userResource.addResource('{userPoolId}');
@@ -41,9 +37,10 @@ function userSetup(scope, props) {
     }
   );
 
-  // Add DynamoDB policy to the function
+  // Add Cognito policy to the function
+  // TODO: Limit to specific pools
   const cognitoIDPPolicy = new iam.PolicyStatement({
-    resources: [publicUserPool.userPoolArn, adminUserPool.userPoolArn],
+    resources: ['*'],
     actions: [
       'cognito-idp:AdminGetUser',
       'cognito-idp:AdminCreateUser',


### PR DESCRIPTION
The antipattern of having different AWS environments for `dev`/`test`/`prod` is catching up. We have divergent creation mechanics for Cognito UserPools in `dev` and `test`. Pools in `dev` were manually created. Pools in `test` are generated by CDK. Establishing the correct reference to the correct pools in differing environments when their generation methods are different necessitates another helper stack akin to `table-manager-stack`, where the remote environment is scanned for existing constructs. 

In a future ticket we may need to consider the creation of `pool-manager-stack`, analogous to DynamoDB but for Cognito. 

For now I have simply given the IAM policy for `/users` wildcard permissions for Cognito Pools. Not best practice but should unstick us.