### PR TITLE
PRDT-103-1: fix bookings and transactions errors

### DIFF
--- a/coverage/lcov-report/handlers/bookings/GET/index.js.html
+++ b/coverage/lcov-report/handlers/bookings/GET/index.js.html
@@ -190,7 +190,7 @@ exports.handler = async (event, context) =&gt; {
     // Get relevant data from the event
     // Search by ID
     const bookingId = <span class="cstat-no" title="statement not covered" >event?.pathParameters?.bookingId || event?.queryStringParameters?.bookingId;</span>
-    const userSub = <span class="cstat-no" title="statement not covered" >event?.queryStringParameters?.user || null;</span>
+    const userId = <span class="cstat-no" title="statement not covered" >event?.queryStringParameters?.userId || null;</span>
 &nbsp;
     const acCollectionId = <span class="cstat-no" title="statement not covered" >event?.pathParameters?.acCollectionId || event?.queryStringParameters?.acCollectionId;</span>
     const activityType = <span class="cstat-no" title="statement not covered" >event?.pathParameters?.activityType || event?.queryStringParameters?.activityType;</span>
@@ -204,8 +204,8 @@ exports.handler = async (event, context) =&gt; {
 <span class="cstat-no" title="statement not covered" >      return sendResponse(200, booking, "Success", null, context);</span>
     }
     
-<span class="cstat-no" title="statement not covered" >    if (userSub) {</span>
-      const booking = <span class="cstat-no" title="statement not covered" >await getBookingsByUserSub(userSub);</span>
+<span class="cstat-no" title="statement not covered" >    if (userId) {</span>
+      const booking = <span class="cstat-no" title="statement not covered" >await getBookingsByUserSub(userId);</span>
 <span class="cstat-no" title="statement not covered" >      return sendResponse(200, booking, "Success", null, context)</span>
     }
     

--- a/coverage/lcov-report/layers/dataUtils/bookings/methods.js.html
+++ b/coverage/lcov-report/layers/dataUtils/bookings/methods.js.html
@@ -320,12 +320,12 @@ async function <span class="fstat-no" title="function not covered" >getBookingBy
   }
 }
 &nbsp;
-async function <span class="fstat-no" title="function not covered" >getBookingsByUserSub(</span>userSub) {
-<span class="cstat-no" title="statement not covered" >  logger.debug("Getting booking by userSub:", userSub);</span>
+async function <span class="fstat-no" title="function not covered" >getBookingsByUserSub(</span>userId) {
+<span class="cstat-no" title="statement not covered" >  logger.debug("Getting booking by userId:", userId);</span>
 <span class="cstat-no" title="statement not covered" >  try {</span>
-<span class="cstat-no" title="statement not covered" >    return await getByGSI("user", userSub, TABLE_NAME, "bookingUserSub-index");</span>
+<span class="cstat-no" title="statement not covered" >    return await getByGSI("userId", userId, TABLE_NAME, "bookingUserSub-index");</span>
   } catch (error) {
-<span class="cstat-no" title="statement not covered" >    throw new Exception("Error getting booking by userSub", {</span>
+<span class="cstat-no" title="statement not covered" >    throw new Exception("Error getting booking by userId", {</span>
       code: 400,
       error: error,
     });

--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -243,21 +243,21 @@ class PublicApiStack extends BaseStack {
       handlerPrefix: 'admin',
     });
 
-    // // Bookings Lambdas
-    // this.publicBookingsConstruct = new PublicBookingsConstruct(this, this.getConstructId('publicBookingsConstruct'), {
-    //   environment: {
-    //     LOG_LEVEL: this.getConfigValue('logLevel'),
-    //     REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
-    //     TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
-    //   },
-    //   layers: [
-    //     baseLayer,
-    //     awsUtilsLayer,
-    //   ],
-    //   api: this.publicApi,
-    //   authorizer: requestAuthorizer,
-    //   handlerPrefix: 'public',
-    // });
+    // Bookings Lambdas
+    this.publicBookingsConstruct = new PublicBookingsConstruct(this, this.getConstructId('publicBookingsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+        TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'public',
+    });
 
     // Transactions Lambdas
     this.transactionsConstruct = new TransactionsConstruct(this, this.getConstructId('transactionsConstruct'), {

--- a/src/common/data-constants.js
+++ b/src/common/data-constants.js
@@ -88,6 +88,7 @@ const TRANSACTION_STATUS_ENUMS = [
   'refund in progress',
   'refunded',
   'partial refund',
+  'failed',
   'void',
   'unknown'
 ];

--- a/src/handlers/bookings/GET/admin.js
+++ b/src/handlers/bookings/GET/admin.js
@@ -26,7 +26,7 @@ exports.handler = async (event, context) => {
     const userId = getRequestClaimsFromEvent(event)?.sub || null;
 
     if (!userId) {
-      throw new Exception("Unauthorized: User ID not found in request claims", { code: 401 });
+      throw new Exception("Unauthorized: userId ID not found in request claims", { code: 401 });
     }
 
     if (bookingId) {

--- a/src/handlers/bookings/GET/public.js
+++ b/src/handlers/bookings/GET/public.js
@@ -1,4 +1,4 @@
-// Public GET handlers for bookings. This is used to get bookings for the logged-in user. User can only see their own bookings, but they can filter by various parameters.
+// Public GET handlers for bookings. This is used to get bookings for the logged-in userId. userId can only see their own bookings, but they can filter by various parameters.
 
 const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
 const { getBookingsByUserId, getBookingByBookingId } = require("../methods");
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
       return sendResponse(200, booking, "Success", null, context);
     }
 
-    // Otherwise, fetch bookings by user with optional filters
+    // Otherwise, fetch bookings by userId with optional filters
     const collectionId = event?.pathParameters?.collectionId || event?.queryStringParameters?.collectionId;
     const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType;
     const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId;
@@ -33,7 +33,7 @@ exports.handler = async (event, context) => {
     const userId = getRequestClaimsFromEvent(event)?.sub || null;
 
     if (!userId) {
-      throw new Exception("Unauthorized: User ID not found in request claims", { code: 401 });
+      throw new Exception("Unauthorized: userId ID not found in request claims", { code: 401 });
     }
 
     const filters = {

--- a/src/handlers/bookings/POST/public.js
+++ b/src/handlers/bookings/POST/public.js
@@ -25,8 +25,22 @@ exports.handler = async (event, context) => {
     body['userId'] = claims?.sub || null;
 
 
-    if (!collectionId || !activityType || !activityId || !startDate || !body.user) {
-      throw new Exception("Activity Collection ID (collectionId), Activity Type (activityType), Activity ID (activityId) and Start Date (startDate) are required", { code: 400 });
+    // Validate required parameters
+    const missingParams = [];
+    if (!body) missingParams.push("body");
+    if (!body.userId) missingParams.push("userId");
+    if (!collectionId) missingParams.push("collectionId");
+    if (!activityType) missingParams.push("activityType");
+    if (!activityId) missingParams.push("activityId");
+    if (!startDate) missingParams.push("startDate");
+
+    // 401 if userId is missing, 400 for others
+    if (missingParams.length > 0) {
+      const code = !body.userId ? 401 : 400;
+      throw new Exception(
+        `Cannot create booking - missing required parameter(s): ${missingParams.join(", ")}`,
+        { code }
+      );
     }
 
     let postRequests = await createBooking(collectionId, activityType, activityId, startDate, body);

--- a/src/handlers/bookings/PUT/public.js
+++ b/src/handlers/bookings/PUT/public.js
@@ -2,7 +2,7 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { completeBooking } = require("../methods")
 const { BOOKING_UPDATE_CONFIG } = require("../configs");
-const { quickApiUpdateHandler } = require("/opt/data-utils");
+const { quickApiUpdateHandler } = require("../../../common/data-utils");
 const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {

--- a/src/handlers/bookings/cancel/POST/index.js
+++ b/src/handlers/bookings/cancel/POST/index.js
@@ -43,7 +43,7 @@ exports.handler = async (event, context) => {
     const booking = await getBookingByBookingId(bookingId);
 
     // Verify ownership
-    if (booking.user !== userId) {
+    if (booking.userId !== userId) {
       throw new Exception(`User ${userId} does not own booking ${bookingId}`, {
         code: 403,
       });

--- a/src/handlers/bookings/cancel/subscriber/index.js
+++ b/src/handlers/bookings/cancel/subscriber/index.js
@@ -19,9 +19,9 @@ exports.handler = async (event, context) => {
         continue;
       }
 
-      // Extract message details, expected to contain bookingId, userSub, and reason
+      // Extract message details, expected to contain bookingId, userId, and reason
       const message = JSON.parse(record.Sns.Message);
-      const { bookingId, userSub, reason } = message;
+      const { bookingId, userId, reason } = message;
 
       logger.info(`Processing cancellation for booking: ${bookingId}`);
 
@@ -29,8 +29,8 @@ exports.handler = async (event, context) => {
       const booking = await getBookingByBookingId(bookingId);
       
       // Verify ownership
-      if (booking.userSub !== userSub) {
-        throw new Exception(`User ${userSub} does not own booking ${booking.bookingId}`, {
+      if (booking.userId !== userId) {
+        throw new Exception(`userId ${userId} does not own booking ${booking.bookingId}`, {
           code: 403,
         });
       }

--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -78,7 +78,7 @@ const BOOKING_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    user: {
+    userId: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);

--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -9,6 +9,9 @@ const defaults = {
     bookingsPOSTFunction: {
       name: 'BookingsPOST',
     },
+    bookingsCancelPOSTFunction: {
+      name: 'BookingsCancelPOST',
+    },
     bookingsPUTFunction: {
       name: 'BookingsPUT',
     },
@@ -55,46 +58,63 @@ class PublicBookingsConstruct extends LambdaConstruct {
       }
     );
 
-    // // GET /bookings
-    // this.bookingsResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
-    //   authorizationType: apigw.AuthorizationType.CUSTOM,
-    //   authorizer: this.resolveAuthorizer(),
-    // });
+    // GET /bookings
+    this.bookingsResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
-    // // GET /bookings/{bookingId}
-    // this.bookingsByBookingIdResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
-    //   authorizationType: apigw.AuthorizationType.CUSTOM,
-    //   authorizer: this.resolveAuthorizer(),
-    // });
+    // GET /bookings/{bookingId}
+    this.bookingsByBookingIdResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
-    // // GET /activities/{collectionId}/{activityType}/{activityId}/{startDate}/bookings
-    // this.bookingsByActivityResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
-    //   authorizationType: apigw.AuthorizationType.CUSTOM,
-    //   authorizer: this.resolveAuthorizer(),
-    // });
+    // GET /activities/{collectionId}/{activityType}/{activityId}/{startDate}/bookings
+    this.bookingsByActivityResource.addMethod('GET', new apigw.LambdaIntegration(this.bookingsGetFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
-    // // POST /bookings Lambda function
-    // this.bookingsPostFunction = this.generateBasicLambdaFn(
-    //   scope,
-    //   'bookingsPOSTFunction',
-    //   'src/handlers/bookings/POST',
-    //   'public.handler',
-    //   {
-    //     basicReadWrite: true,
-    //   }
-    // );
+    // POST /bookings Lambda function
+    this.bookingsPostFunction = this.generateBasicLambdaFn(
+      scope,
+      'bookingsPOSTFunction',
+      'src/handlers/bookings/POST',
+      'public.handler',
+      {
+        basicReadWrite: true,
+      }
+    );
 
-    // // POST /bookings
-    // this.bookingsResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsPostFunction), {
-    //   authorizationType: apigw.AuthorizationType.CUSTOM,
-    //   authorizer: this.resolveAuthorizer(),
-    // });
+    // POST /bookings
+    this.bookingsResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsPostFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
-    // // POST /activities/{collectionId}/{activityType}/{activityId}/{startDate}/bookings
-    // this.bookingsByActivityResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsPostFunction), {
-    //   authorizationType: apigw.AuthorizationType.CUSTOM,
-    //   authorizer: this.resolveAuthorizer(),
-    // });
+    // POST /bookings/{bookingId}/cancel Lambda function
+    this.bookingsCancelPostFunction = this.generateBasicLambdaFn(
+      scope,
+      'bookingsCancelPOSTFunction',
+      'src/handlers/bookings/cancel/POST',
+      'index.handler',
+      {
+        basicReadWrite: true,
+      }
+    );
+
+    // POST /bookings/{bookingId}/cancel
+    this.bookingsByBookingIdResource.addResource('cancel').addMethod('POST', new apigw.LambdaIntegration(this.bookingsCancelPostFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+
+    // POST /activities/{collectionId}/{activityType}/{activityId}/{startDate}/bookings
+    this.bookingsByActivityResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsPostFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
   }
 }

--- a/src/handlers/policies/configs.js
+++ b/src/handlers/policies/configs.js
@@ -1,5 +1,5 @@
-const { rulesFns } = require('/opt/validation-rules');
-const { POLICY_TYPE_ENUMS } = require('/opt/data-constants');
+const { rulesFns } = require('../../common/validation-rules');
+const { POLICY_TYPE_ENUMS } = require('../../common/data-constants');
 
 const rf = new rulesFns();
 

--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -3,7 +3,7 @@ const { TABLE_NAME, batchTransactData, runQuery, getOne, parallelizedBatchGetDat
 const { Exception, buildDateRange, buildDateTimeFromShortDate, getNow, logger } = require('/opt/base');
 const { POLICY_TYPES } = require('../policies/configs');
 const { PRODUCT_DAILY_PROPERTIES_CONFIG, PRODUCT_DEFAULT_PROPERTY_NAMES, PRODUCT_DEFAULT_SCHEDULE_RANGE } = require('./configs');
-const { quickApiPutHandler } = require('/opt/data-utils');
+const { quickApiPutHandler } = require('../../common/data-utils');
 
 async function getProducts(collectionId, activityType, activityId, seasonId = null, productId = null, options = {}) {
   logger.info('Get Product(s)');

--- a/src/handlers/protectedAreas/POST/admin.js
+++ b/src/handlers/protectedAreas/POST/admin.js
@@ -1,5 +1,5 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { quickApiPutHandler } = require("/opt/data-utils");
+const { quickApiPutHandler } = require("../../../common/data-utils");
 const { PROTECTED_AREA_API_PUT_CONFIG } = require("../configs");
 const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 

--- a/src/handlers/protectedAreas/_orcs/POST/admin.js
+++ b/src/handlers/protectedAreas/_orcs/POST/admin.js
@@ -1,5 +1,5 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { quickApiPutHandler } = require("/opt/data-utils");
+const { quickApiPutHandler } = require("../../../../common/data-utils");
 const { PROTECTED_AREA_API_PUT_CONFIG } = require("../../configs");
 const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
 

--- a/src/handlers/subareas/methods.js
+++ b/src/handlers/subareas/methods.js
@@ -3,7 +3,7 @@
  */
 
 const { TABLE_NAME, getOne, parallelizedBatchGetData, runQuery } = require('/opt/dynamodb');
-const { buildCompKeysFromSkField } = require('/opt/data-utils');
+const { buildCompKeysFromSkField } = require('../../common/data-utils');
 const { Exception, logger } = require('/opt/base');
 
 async function getSubareasByOrcs(orcs, params = null) {

--- a/src/handlers/tooling/opensearch/createBookingIndex/index.js
+++ b/src/handlers/tooling/opensearch/createBookingIndex/index.js
@@ -19,7 +19,7 @@ const bookingIndexMappingOptions = {
     },
     bookingStatus: { type: 'keyword' },
     bookedAt: { type: 'date' },
-    user: { type: 'keyword' },
+    userId: { type: 'keyword' },
     activityType: { type: 'keyword' },
     activityId: { type: 'keyword' },
     collectionId: { type: 'keyword' },

--- a/src/handlers/transactions/POST/index.js
+++ b/src/handlers/transactions/POST/index.js
@@ -14,17 +14,17 @@ exports.handler = async (event, context) => {
     logger.debug("transaction body: ", body);
 
     // Get the user sub from the authorizer context
-    let user = getRequestClaimsFromEvent(event)?.sub || null;
+    let userId = getRequestClaimsFromEvent(event)?.sub || null;
     
-    if (!user) {
-      throw new Exception("Cannot create transaction - missing user sub", { code: 401 });
+    if (!userId) {
+      throw new Exception("Cannot create transaction - missing userId", { code: 401 });
     }
 
     if (!body?.trnAmount || !body?.bookingId || !body.sessionId) {
       throw new Exception("Missing required transaction fields", { code: 400 });
     }
 
-    const postRequests = await createTransaction(body, user);
+    const postRequests = await createTransaction(body, userId);
 
     const putItems = await quickApiPutHandler(
       TRANSACTIONAL_DATA_TABLE_NAME,

--- a/src/handlers/transactions/configs.js
+++ b/src/handlers/transactions/configs.js
@@ -1,4 +1,4 @@
-const { rulesFns } = require('/opt/validation-rules');
+const { rulesFns } = require('../../common/validation-rules');
 const { TRANSACTION_STATUS_ENUMS } = require('../../common/data-constants');
 
 const rf = new rulesFns();
@@ -90,7 +90,7 @@ const TRANSACTION_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    user: {
+    userId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
@@ -563,7 +563,7 @@ const REFUND_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    user: {
+    userId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);

--- a/src/handlers/transactions/refunds/subscriber/index.js
+++ b/src/handlers/transactions/refunds/subscriber/index.js
@@ -38,7 +38,7 @@ exports.handler = async (event, context) => {
       }
 
       const message = JSON.parse(record.Sns.Message);
-      const { clientTransactionId, bookingId, user, refundAmount, reason } = message;
+      const { clientTransactionId, bookingId, userId, refundAmount, reason } = message;
 
       logger.info(
         `Processing refund for transaction: ${clientTransactionId}, amount: ${refundAmount}`
@@ -47,7 +47,7 @@ exports.handler = async (event, context) => {
       // Verify ownership before proceeding
       const transaction = await findAndVerifyTransactionOwnership(
         clientTransactionId,
-        user
+        userId
       );
 
       // Additional refund validations
@@ -77,7 +77,7 @@ exports.handler = async (event, context) => {
       try {
         // This returns: { refundHash, refundSequence, totalRefunded, totalAfterRefund }
         refundMetadata = await createAndCheckRefundHash(
-          user,
+          userId,
           transaction.clientTransactionId,
           refundAmount
         );

--- a/src/layers/awsUtils/dynamodb.js
+++ b/src/layers/awsUtils/dynamodb.js
@@ -7,8 +7,8 @@ const REFERENCE_DATA_TABLE_NAME = process.env.REFERENCE_DATA_TABLE_NAME || 'refe
 const TRANSACTIONAL_DATA_TABLE_NAME = process.env.TRANSACTIONAL_DATA_TABLE_NAME || 'transactional-data';
 const GLOBALID_INDEX_NAME = process.env.GLOBALID_INDEX_NAME || 'globalId-index';
 const GLOBALID_PROPERTY_NAME = process.env.GLOBALID_PROPERTY_NAME || 'globalId';
-const USERSUB_INDEX_NAME = process.env.USERSUB_INDEX_NAME || 'userId-index';
-const USERSUB_PROPERTY_NAME = process.env.USERSUB_PROPERTY_NAME || 'userId';
+const USERID_INDEX_NAME = process.env.USERID_INDEX_NAME || 'userId-index';
+const USERID_PROPERTY_NAME = process.env.USERID_PROPERTY_NAME || 'userId';
 const AUDIT_TABLE_NAME = process.env.AUDIT_TABLE_NAME || 'audit';
 const PUBSUB_TABLE_NAME = process.env.PUBSUB_TABLE_NAME || 'pubsub';
 const AWS_REGION = process.env.AWS_REGION || 'ca-central-1';
@@ -627,8 +627,8 @@ module.exports = {
   GLOBALID_INDEX_NAME,
   GLOBALID_PROPERTY_NAME,
   PUBSUB_TABLE_NAME,
-  USERSUB_INDEX_NAME,
-  USERSUB_PROPERTY_NAME,
+  USERID_INDEX_NAME,
+  USERID_PROPERTY_NAME,
   ScanCommand,
   UpdateItemCommand,
   PutItemCommand,

--- a/test/booking/POST.test.js
+++ b/test/booking/POST.test.js
@@ -58,7 +58,7 @@ describe("Bookings POST handler", () => {
     const event = { body: JSON.stringify({}) };
     const result = await handler(event, context);
     expect(result.status).toBe(400);
-    expect(result.message).toMatch(/Activity Collection ID/);
+    expect(result.message).toMatch("Cannot create booking - missing required parameter(s): collectionId, activityType, activityId, startDate");
   });
 
   it("should create booking and return 200 on success", async () => {
@@ -67,7 +67,7 @@ describe("Bookings POST handler", () => {
       activityType: "backcountryCamp",
       activityId: "1",
       startDate: "2024-01-01",
-      user: "test-user-123",
+      userId: "test-user-123",
     };
     const event = { body: JSON.stringify(body) };
 
@@ -87,7 +87,7 @@ describe("Bookings POST handler", () => {
         activityType: "backcountryCamp",
         activityId: "1",
         startDate: "2024-01-01",
-        user: "test-user-123",
+        userId: "test-user-123",
       })
     );
     expect(quickApiPutHandler).toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe("Bookings POST handler", () => {
   });
 
   it("should extract parameters from pathParameters and queryStringParameters", async () => {
-    const body = { user: "test-user-123" };
+    const body = { userId: "test-user-123" };
     const event = {
       body: JSON.stringify(body),
       pathParameters: {
@@ -124,7 +124,7 @@ describe("Bookings POST handler", () => {
       "id2",
       "2024-02-02",
       expect.objectContaining({
-        user: "test-user-123",
+        userId: "test-user-123",
       })
     );
     expect(result.status).toBe(200);
@@ -138,7 +138,7 @@ describe("Bookings POST handler", () => {
       activityType: "backcountry",
       activityId: "id1",
       startDate: "2024-01-01",
-      user: "test-user-123",
+      userId: "test-user-123",
     };
     const event = { body: JSON.stringify(body) };
 

--- a/test/booking/cancel-POST.test.js
+++ b/test/booking/cancel-POST.test.js
@@ -98,7 +98,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should extract user from JWT Bearer token", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: "user-from-jwt",
+      userId: "user-from-jwt",
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
     };
@@ -132,7 +132,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should return 403 if user does not own the booking", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: "different-user",
+      userId: "different-user",
       bookingStatus: "confirmed",
     };
 
@@ -163,7 +163,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should successfully cancel a booking and publish to SNS", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: mockUser,
+      userId: mockUser,
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
       feeInformation: { total: 50.0 },
@@ -202,7 +202,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should return 400 if booking is already cancelled", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: mockUser,
+      userId: mockUser,
       bookingStatus: "cancelled",
     };
 
@@ -233,7 +233,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should handle cancellation without a reason", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: mockUser,
+      userId: mockUser,
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
     };
@@ -298,7 +298,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should handle errors thrown by cancellationPublishCommand", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: mockUser,
+      userId: mockUser,
       bookingStatus: "confirmed",
     };
 
@@ -332,7 +332,7 @@ describe("Bookings Cancel POST handler", () => {
   it("should handle missing body gracefully", async () => {
     const mockBooking = {
       bookingId: mockBookingId,
-      user: mockUser,
+      userId: mockUser,
       bookingStatus: "confirmed",
     };
 

--- a/test/booking/cancel-subscriber.test.js
+++ b/test/booking/cancel-subscriber.test.js
@@ -58,7 +58,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Test",
             }),
           },
@@ -77,7 +77,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2025-11-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
     };
@@ -94,7 +94,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Change of plans",
             }),
           },
@@ -125,7 +125,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "different-user",
+      userId: "different-user",
       bookingStatus: "confirmed",
     };
 
@@ -138,7 +138,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Test",
             }),
           },
@@ -158,7 +158,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "cancelled",
       clientTransactionId: "BCPR-abc123",
     };
@@ -172,7 +172,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Test",
             }),
           },
@@ -193,7 +193,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
     };
@@ -210,7 +210,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Emergency",
             }),
           },
@@ -235,7 +235,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "confirmed",
       clientTransactionId: null,
     };
@@ -251,7 +251,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Test",
             }),
           },
@@ -271,7 +271,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-abc123",
     };
@@ -280,7 +280,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::2",
       sk: "2024-01-16",
       bookingId: "booking-456",
-      userSub: "user-456",
+      userId: "user-456",
       bookingStatus: "confirmed",
       clientTransactionId: "BCPR-def456",
     };
@@ -299,7 +299,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Reason 1",
             }),
           },
@@ -309,7 +309,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-456",
-              userSub: "user-456",
+              userId: "user-456",
               reason: "Reason 2",
             }),
           },
@@ -330,7 +330,7 @@ describe("Booking Cancellation Subscriber", () => {
       pk: "booking::bcparks_250::backcountryCamp::1",
       sk: "2024-01-15",
       bookingId: "booking-123",
-      userSub: "user-123",
+      userId: "user-123",
       bookingStatus: "confirmed",
     };
 
@@ -344,7 +344,7 @@ describe("Booking Cancellation Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               bookingId: "booking-123",
-              userSub: "user-123",
+              userId: "user-123",
               reason: "Test",
             }),
           },

--- a/test/transactions/refunds-POST.test.js
+++ b/test/transactions/refunds-POST.test.js
@@ -145,7 +145,7 @@ describe("Transaction Refund POST handler", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: mockUser,
+      userId: mockUser,
     };
 
     const mockRefundHash = {
@@ -205,7 +205,7 @@ describe("Transaction Refund POST handler", () => {
     const mockTransaction = {
       clientTransactionId: mockTransactionId,
       transactionStatus: "refunded",
-      user: mockUser,
+      userId: mockUser,
     };
 
     findAndVerifyTransactionOwnership.mockResolvedValue(mockTransaction);
@@ -250,7 +250,7 @@ describe("Transaction Refund POST handler", () => {
     const mockTransaction = {
       clientTransactionId: mockTransactionId,
       transactionStatus: "paid",
-      user: "anonymous",
+      userId: "anonymous",
     };
 
     // Mock should throw the error since the real function would throw it
@@ -277,7 +277,7 @@ describe("Transaction Refund POST handler", () => {
     const mockTransaction = {
       clientTransactionId: mockTransactionId,
       transactionStatus: "paid",
-      user: mockUser,
+      userId: mockUser,
     };
 
     const error = {
@@ -309,7 +309,7 @@ describe("Transaction Refund POST handler", () => {
       clientTransactionId: mockTransactionId,
       transactionStatus: "partial refund",
       amount: 100.0,
-      user: mockUser,
+      userId: mockUser,
     };
 
     const mockRefundHash = {
@@ -356,7 +356,7 @@ describe("Transaction Refund POST handler", () => {
     const mockTransaction = {
       clientTransactionId: mockTransactionId,
       transactionStatus: "paid",
-      user: mockUser,
+      userId: mockUser,
     };
 
     const mockRefundHash = {
@@ -401,7 +401,7 @@ describe("Transaction Refund POST handler", () => {
       clientTransactionId: mockTransactionId,
       transactionStatus: "paid",
       amount: 100.0,
-      user: mockUser,
+      userId: mockUser,
     };
 
     const mockRefundHash = {

--- a/test/transactions/refunds-subscriber.test.js
+++ b/test/transactions/refunds-subscriber.test.js
@@ -100,7 +100,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockRefundMetadata = {
@@ -144,7 +144,7 @@ describe("Refund Subscriber", () => {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
               bookingId: "booking-123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
               reason: "Cancellation by user via self-serve",
             }),
@@ -193,7 +193,7 @@ describe("Refund Subscriber", () => {
     const mockTransaction = {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "refunded",
-      user: "user-123",
+      userId: "user-123",
     };
 
     findAndVerifyTransactionOwnership.mockResolvedValue(mockTransaction);
@@ -205,7 +205,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -224,7 +224,7 @@ describe("Refund Subscriber", () => {
     const mockTransaction = {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "in progress",
-      user: "user-123",
+      userId: "user-123",
     };
 
     findAndVerifyTransactionOwnership.mockResolvedValue(mockTransaction);
@@ -236,7 +236,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -258,7 +258,7 @@ describe("Refund Subscriber", () => {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "partial refund",
       amount: 100.0,
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockRefundMetadata = {
@@ -278,7 +278,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -301,7 +301,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockRefundMetadata = {
@@ -341,7 +341,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 100.0,
             }),
           },
@@ -374,7 +374,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockRefundMetadata = {
@@ -417,7 +417,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -442,7 +442,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockTransaction2 = {
@@ -452,7 +452,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 200.0,
       trnId: "worldline-456",
-      user: "user-456",
+      userId: "user-456",
     };
 
     const mockRefundMetadata1 = {
@@ -513,7 +513,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -523,7 +523,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-def456",
-              user: "user-456",
+              userId: "user-456",
               refundAmount: 75.0,
             }),
           },
@@ -547,7 +547,7 @@ describe("Refund Subscriber", () => {
       transactionStatus: "paid",
       amount: 100.0,
       trnId: "worldline-123",
-      user: "user-123",
+      userId: "user-123",
     };
 
     const mockRefundMetadata = {
@@ -587,7 +587,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 30.0,
             }),
           },
@@ -609,7 +609,7 @@ describe("Refund Subscriber", () => {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "paid",
       amount: 100.0,
-      user: "user-123",
+      userId: "user-123",
     };
 
     const error = new Error("Duplicate refund attempt detected");
@@ -625,7 +625,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0,
             }),
           },
@@ -650,7 +650,7 @@ describe("Refund Subscriber", () => {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "partial refund",
       amount: 100.0,
-      user: "user-123",
+      userId: "user-123",
       refundAmounts: [{ "RFND-old123": 30.0 }],
       // Show that an old refund exists with a timestamp outside the window
       existingRefunds: [
@@ -696,7 +696,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 30.0, // Same amount as old refund
             }),
           },
@@ -721,7 +721,7 @@ describe("Refund Subscriber", () => {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "partial refund",
       amount: 100.0,
-      user: "user-123",
+      userId: "user-123",
       refundAmounts: [{ "RFND-recent123": 30.0 }],
       // Show that a recent refund exists with a timestamp within the window
       existingRefunds: [
@@ -747,7 +747,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 30.0, // Same amount as recent refund
             }),
           },
@@ -774,7 +774,7 @@ describe("Refund Subscriber", () => {
       clientTransactionId: "BCPR-abc123",
       transactionStatus: "partial refund",
       amount: 100.0,
-      user: "user-123",
+      userId: "user-123",
       refundAmounts: [{ "RFND-first123": 20.0 }],
       // Show that a recent refund exists within the window but with a different amount
       existingRefunds: [
@@ -819,7 +819,7 @@ describe("Refund Subscriber", () => {
           Sns: {
             Message: JSON.stringify({
               clientTransactionId: "BCPR-abc123",
-              user: "user-123",
+              userId: "user-123",
               refundAmount: 50.0, // Different amount from existing 20.0
             }),
           },


### PR DESCRIPTION
PRDT-103

### Ticket URL:

#103 

### Description:

- Mass change to `userSub` and `user` to be `userId`
- Fixes to local polling for transaction cancellation
- Re-enabled Bookings endpoints / lambdas to test end-to-end booking and cancellation (very hacky on the frontend while we pivot)