### PR TITLE
PRDT-212-5: Public Authorizer and User Claim Validation Logic FIX

### DIFF
--- a/lib/handlers/refundSubscriber/index.js
+++ b/lib/handlers/refundSubscriber/index.js
@@ -68,7 +68,7 @@ exports.handler = async (event, context) => {
         transaction.transactionStatus !== "paid" &&
         transaction.transactionStatus !== "partial refund"
       ) {
-        logger.warn(`Transaction ${clientTransactionId} not eligible for refund. Status: ${transaction.status}`);
+        logger.warn(`Transaction ${clientTransactionId} not eligible for refund. Status: ${transaction.transactionStatus}`);
         results.push({ 
           clientTransactionId, 
           transactionStatus: 'not_eligible',

--- a/lib/reference-data-stack/reference-data-stack.js
+++ b/lib/reference-data-stack/reference-data-stack.js
@@ -19,10 +19,10 @@ const defaults = {
       name: 'PubSubTable',
     },
     globalIdGsi: {
-      name: 'GlobalIdIndex',
+      name: 'globalId-index',
     },
-    userSubGsi: {
-      name: 'UserSubIndex',
+    userIdGsi: {
+      name: 'userId-index',
     },
     dynamoStreamRole: {
       name: 'DynamoStreamRole',
@@ -40,8 +40,8 @@ const defaults = {
     pubsubTableDeletionProtection: 'false',
     globalIdGsiPartitionKey: 'globalId',
     globalIdGsiSortKey: 'sk',
-    userSubGsiPartitionKey: 'userSub',
-    userSubGsiSortKey: 'sk',
+    userIdGsiPartitionKey: 'userId',
+    userIdGsiSortKey: 'sk',
     logLevel: process.env.LOG_LEVEL || 'info',
     overrides: {
       referenceDataTableName: '',
@@ -90,9 +90,9 @@ class ReferenceDataStack extends BaseStack {
     // Add Global Secondary Index (User Sub)
     // TODO: Consider if this is needed on reference data table since transactional data will be in its own table in the Transactional Data Stack
     this.refDataTable.addGlobalSecondaryIndex({
-      indexName: this.getConstructName('userSubGsi'),
-      partitionKey: { name: this.getConfigValue('userSubGsiPartitionKey'), type: dynamodb.AttributeType.STRING },
-      sortKey: { name: this.getConfigValue('userSubGsiSortKey'), type: dynamodb.AttributeType.STRING },
+      indexName: this.getConstructName('userIdGsi'),
+      partitionKey: { name: this.getConfigValue('userIdGsiPartitionKey'), type: dynamodb.AttributeType.STRING },
+      sortKey: { name: this.getConfigValue('userIdGsiSortKey'), type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL
     });
 

--- a/lib/transactional-data-stack/transactional-data-stack.js
+++ b/lib/transactional-data-stack/transactional-data-stack.js
@@ -14,10 +14,10 @@ const defaults = {
       name: 'TransactionalDataTable',
     },
     globalIdGsi: {
-      name: 'GlobalIdGSI',
+      name: 'globalId-index',
     },
-    userSubGsi: {
-      name: 'UserSubGSI',
+    userIdGsi: {
+      name: 'userId-index',
     },
     dynamoStreamRole: {
       name: 'DynamoStreamRole',
@@ -34,8 +34,8 @@ const defaults = {
     refTableDeletionProtection: 'false',
     globalIdGsiPartitionKey: 'globalId',
     globalIdGsiSortKey: 'sk',
-    userSubGsiPartitionKey: 'userSub',
-    userSubGsiSortKey: 'sk',
+    userIdGsiPartitionKey: 'userId',
+    userIdGsiSortKey: 'sk',
     logLevel: process.env.LOG_LEVEL || 'info',
   },
   secrets: {},
@@ -87,9 +87,9 @@ class TransactionalDataStack extends BaseStack {
 
     // Add Global Secondary Index (User Sub)
     this.transDataTable.addGlobalSecondaryIndex({
-      indexName: this.getConstructName('userSubGsi'),
-      partitionKey: { name: this.getConfigValue('userSubGsiPartitionKey'), type: dynamodb.AttributeType.STRING },
-      sortKey: { name: this.getConfigValue('userSubGsiSortKey'), type: dynamodb.AttributeType.STRING },
+      indexName: this.getConstructName('userIdGsi'),
+      partitionKey: { name: this.getConfigValue('userIdGsiPartitionKey'), type: dynamodb.AttributeType.STRING },
+      sortKey: { name: this.getConfigValue('userIdGsiSortKey'), type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL
     });
 

--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -366,13 +366,6 @@ const BOOKING_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    bookingStatus: {
-      isMandatory: true,
-      rulesFn: ({ value, action }) => {
-        rf.expectValueInList(value, BOOKING_STATUS_ENUMS);
-        rf.expectAction(action, ['set']);
-      }
-    },
     sessionId: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {


### PR DESCRIPTION
- Fix to GSI names
  - Change to use `userId` for pk in `userIdGsi` (destroy almost all references to `userSub`)
  - Update names to `globalId-index` and `userId-index`
- Fix non-issues in bookings `config.js` and an incorrect error log in `refundSubscriber`