### PR TITLE
Relabel policy config prop

### DIFF
--- a/src/handlers/policies/configs.js
+++ b/src/handlers/policies/configs.js
@@ -391,13 +391,13 @@ const POLICY_CHANGE_API_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    changesAcceptedUntilHour: {
+    changesAcceptedUntilTime: {
       rulesFn: ({ value, action }) => {
         rf.expect24hTimeObjFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
-    cancellationsAcceptedUntilHour: {
+    cancellationsAcceptedUntilTime: {
       rulesFn: ({ value, action }) => {
         rf.expect24hTimeObjFormat(value);
         rf.expectAction(action, ['set']);
@@ -492,13 +492,13 @@ const POLICY_CHANGE_API_UPDATE_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
-    changesAcceptedUntilHour: {
+    changesAcceptedUntilTime: {
       rulesFn: ({ value, action }) => {
         rf.expect24hTimeObjFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
-    cancellationsAcceptedUntilHour: {
+    cancellationsAcceptedUntilTime: {
       rulesFn: ({ value, action }) => {
         rf.expect24hTimeObjFormat(value);
         rf.expectAction(action, ['set']);


### PR DESCRIPTION
`changesAcceptedUntilHour` implies that the property is an hour of the day, when it may be any time (7th hour, 30th minute, for example). 

Changing to `changesAcceptedUntilTime`

<img width="503" height="496" alt="image" src="https://github.com/user-attachments/assets/691a084e-534c-4d4d-969b-b23a20e797bf" />
