### PR TITLE
#176: Add sessionExpiry to booking validation config

### DIFF
--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -390,6 +390,12 @@ const BOOKING_PUT_CONFIG = {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
+    },
+    sessionExpiry: {
+      rulesFn: ({ value, action }) => {
+        rf.expectISODateTimeObjFormat(value);
+        rf.expectAction(action, ['set']);
+      }
     }
   }
 };


### PR DESCRIPTION
## Summary
Fixes validation error where bookings were rejected with "Field 'sessionExpiry' is not allowed in the request".

## Issue
After merging #243 (timezone fix), the booking creation was failing because `sessionExpiry` field was being added by `createBooking()` method but wasn't in the `BOOKING_PUT_CONFIG` allowed fields list.

## Fix
Added `sessionExpiry` field to `BOOKING_PUT_CONFIG` in `src/handlers/bookings/configs.js`:
- Validates as ISO DateTime format
- Allows 'set' action
- Required for 30-minute payment retry session functionality

## Testing
- All 132 tests pass
- Fixes the "Invalid field" error in DEV

## Related
- Original issue: #176
- Previous PRs: #241, #243