### PR TITLE
#176: Allow empty email when other contact methods provided

### DIFF
--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -197,7 +197,11 @@ const BOOKING_PUT_CONFIG = {
           fields: {
             email: {
               rulesFn: ({ value, action }) => {
-                rf.expectEmailFormat(value);
+                // Only validate email format if a value is provided (not empty string)
+                // At least one contact method (email/mobilePhone/homePhone) is required at parent level
+                if (value && value !== '') {
+                  rf.expectEmailFormat(value);
+                }
                 rf.expectAction(action, ['set']);
               }
             },


### PR DESCRIPTION
## Summary
- Fixes validation error when email field is not provided in booking contact info
- Email validation now skips empty strings, as at least one contact method (email/mobilePhone/homePhone) is required but not all three

## Changes
- Updated `src/handlers/bookings/configs.js` to conditionally validate email format only when a value is provided
- Backend's `sanitizeString` converts undefined fields to empty strings, which were triggering validation errors
- All 134 tests pass

## Related
- Part of Issue #176
- Builds on PRs #241, #243, #244, #245, #246