### PR TITLE
Add QR code verification endpoint for admin API

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -1,5 +1,6 @@
 const { Duration } = require('aws-cdk-lib');
 const apigw = require('aws-cdk-lib/aws-apigateway');
+const ssm = require('aws-cdk-lib/aws-ssm');
 const { logger } = require("../helpers/utils");
 const { StackPrimer } = require("../helpers/stack-primer");
 const { BaseStack } = require('../helpers/base-stack');
@@ -15,6 +16,7 @@ const { UsersConstruct } = require('../../src/handlers/users/constructs');
 const { PoliciesConstruct } = require('../../src/handlers/policies/constructs');
 const { AdminBookingsConstruct } = require('../../src/handlers/bookings/constructs');
 const { BCSCConstruct } = require('../../src/handlers/bcsc/constructs');
+const { VerifyConstruct } = require('../../src/handlers/verify/constructs');
 
 
 const defaults = {
@@ -64,6 +66,9 @@ const defaults = {
     },
     bcscConstruct: {
       name: 'BCSCConstruct',
+    },
+    verifyConstruct: {
+      name: 'VerifyConstruct',
     }
   },
   config: {
@@ -319,6 +324,31 @@ class AdminApiStack extends BaseStack {
       authorizer: requestAuthorizer,
       handlerPrefix: 'admin',
       openSearchDomainArn: opensearchDomainArn,
+    });
+
+    // Get PUBLIC_FRONTEND_DOMAIN from SSM Parameter Store
+    // Expected SSM path: /reserve-rec/{env}/public-frontend-domain
+    const publicFrontendDomain = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/reserve-rec/${this.getDeploymentName()}/public-frontend-domain`
+    );
+
+    // Verify Lambdas (QR code verification)
+    // Note: Reuses the QR secret from EmailDispatchStack to ensure hash compatibility
+    this.verifyConstruct = new VerifyConstruct(this, this.getConstructId('verifyConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+        TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
+        QR_SECRET_KEY: this.getSecretValue('qrSecretKey', 'EmailDispatchStack'),
+        PUBLIC_FRONTEND_DOMAIN: publicFrontendDomain,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.adminApi,
+      authorizer: requestAuthorizer,
     });
 
     // Export References

--- a/src/handlers/verify/GET/admin.js
+++ b/src/handlers/verify/GET/admin.js
@@ -1,0 +1,211 @@
+// Verify booking QR code - GET /verify/:bookingId/:hash (Admin only)
+
+const { logger, sendResponse, getRequestClaimsFromEvent, Exception } = require("/opt/base");
+const { validateHash } = require("../../../../lib/handlers/emailDispatch/qrCodeHelper");
+const { getBookingByBookingId } = require("../../bookings/methods");
+
+/**
+ * Validate SuperAdmin authorization from event claims
+ * @param {Object} event - Lambda event
+ * @returns {Object} Claims object if authorized
+ * @throws {Exception} If user is not a SuperAdmin
+ */
+function validateSuperAdminAuth(event) {
+  // Extract claims from authorizer context
+  const claims = event.requestContext?.authorizer?.claims || getRequestClaimsFromEvent(event);
+  
+  if (!claims) {
+    logger.warn('No authorization claims found in request');
+    throw new Exception("Unauthorized - Authentication required", { code: 401 });
+  }
+  
+  // Check if user is a SuperAdmin
+  const cognitoGroups = claims['cognito:groups'] || [];
+  const isSuperAdmin = cognitoGroups.some(group => 
+    group.includes('SuperAdminGroup')
+  );
+
+  if (!isSuperAdmin) {
+    logger.warn(`Unauthorized QR verification attempt by user ${claims.sub}`);
+    throw new Exception("Forbidden - SuperAdmin access required", { code: 403 });
+  }
+
+  logger.info(`SuperAdmin QR verification access granted for user ${claims.sub}`);
+  return claims;
+}
+
+exports.handler = async (event, context) => {
+  // Log request metadata only (not full event)
+  logger.info("Verify Booking GET (Admin):", {
+    method: event.httpMethod,
+    hasBookingId: !!event.pathParameters?.bookingId,
+    hasHash: !!event.pathParameters?.hash
+  });
+
+  // Allow CORS
+  if (event.httpMethod === "OPTIONS") {
+    return sendResponse(200, {}, "Success", null, context);
+  }
+
+  try {
+    // Validate admin authorization
+    const claims = validateSuperAdminAuth(event);
+
+    // Extract bookingId and hash from path parameters
+    const bookingId = event.pathParameters?.bookingId;
+    const hash = event.pathParameters?.hash;
+
+    if (!bookingId || !hash) {
+      throw new Exception("Missing required parameters: bookingId and hash", { code: 400 });
+    }
+
+    // Validate bookingId format (UUID format)
+    if (!/^[a-zA-Z0-9-_]{8,100}$/.test(bookingId)) {
+      logger.warn("Invalid bookingId format", { bookingIdLength: bookingId.length });
+      return sendResponse(400, { 
+        valid: false,
+        reason: "Invalid or expired QR code"
+      }, "Invalid QR code", null, context);
+    }
+
+    // Validate hash format (16 hexadecimal characters)
+    if (!/^[a-f0-9]{16}$/i.test(hash)) {
+      logger.warn("Invalid hash format", { hashLength: hash.length });
+      return sendResponse(400, { 
+        valid: false,
+        reason: "Invalid or expired QR code"
+      }, "Invalid QR code", null, context);
+    }
+
+    logger.info("Verifying QR code", { bookingId, userId: claims.sub });
+
+    // Step 1: Fetch the booking from database FIRST (before hash validation)
+    // This prevents timing attacks that could reveal if a bookingId exists
+    let booking;
+    try {
+      booking = await getBookingByBookingId(bookingId, null, true); // fetch with access points
+    } catch (error) {
+      // Return same generic error as invalid hash to prevent enumeration
+      logger.warn("Booking not found for QR verification", { bookingId });
+      return sendResponse(400, {
+        valid: false,
+        reason: "Invalid or expired QR code"
+      }, "Invalid QR code", null, context);
+    }
+
+    if (!booking) {
+      // Return same generic error as invalid hash to prevent enumeration
+      logger.warn("Booking not found (null result)", { bookingId });
+      return sendResponse(400, {
+        valid: false,
+        reason: "Invalid or expired QR code"
+      }, "Invalid QR code", null, context);
+    }
+
+    // Step 2: Validate the hash (after confirming booking exists)
+    const isValidHash = validateHash(bookingId, hash);
+
+    if (!isValidHash) {
+      logger.warn("Invalid QR code hash", { bookingId, verifiedBy: claims.sub });
+      return sendResponse(400, { 
+        valid: false,
+        reason: "Invalid or expired QR code"
+      }, "Invalid QR code", null, context);
+    }
+
+    logger.info("QR code hash validated successfully", { bookingId, verifiedBy: claims.sub });
+
+    // Step 3: Check booking status
+    const bookingStatus = booking.bookingStatus;
+    const isExpired = booking.sessionExpiry && new Date(booking.sessionExpiry) < new Date();
+    const isCancelled = bookingStatus === "cancelled";
+    const isConfirmed = bookingStatus === "confirmed";
+
+    // Calculate party size (aggregate count, not detailed breakdown)
+    const partySize = (booking.partyInformation?.adult || 0) + 
+                     (booking.partyInformation?.senior || 0) +
+                     (booking.partyInformation?.youth || 0) +
+                     (booking.partyInformation?.child || 0);
+
+    // Log verification attempt for audit trail
+    logger.info("QR code verification completed", {
+      bookingId,
+      status: bookingStatus,
+      isExpired,
+      isCancelled,
+      isConfirmed,
+      verifiedBy: claims.sub,
+      verifiedAt: new Date().toISOString()
+    });
+
+    // Step 4: Return MINIMAL booking details (prevent excessive PII disclosure)
+    // Only include information necessary for park staff to verify the reservation
+    const response = {
+      valid: true,
+      bookingId: booking.bookingId,
+      status: bookingStatus,
+      statusDetails: {
+        isConfirmed,
+        isCancelled,
+        isExpired,
+        isPending: bookingStatus === "in progress"
+      },
+      booking: {
+        // Core verification info only
+        bookingId: booking.bookingId,
+        displayName: booking.displayName,
+        
+        // Dates (needed to verify reservation period)
+        startDate: booking.startDate,
+        endDate: booking.endDate,
+        
+        // Guest name only (no email, phone, or address)
+        guestName: booking.namedOccupant 
+          ? `${booking.namedOccupant.firstName} ${booking.namedOccupant.lastName}`
+          : null,
+        
+        // Party size only (not detailed age breakdown)
+        partySize: partySize,
+        
+        // Location info (needed to verify correct park/activity)
+        collectionId: booking.collectionId,
+        activityType: booking.activityType,
+        displayName: booking.displayName,
+        
+        // Access points (if available, for trail/backcountry permits)
+        entryPoint: booking.entryPoint,
+        exitPoint: booking.exitPoint,
+        location: booking.location,
+        
+        // Vehicle info (if available, for parking passes)
+        vehicleInformation: booking.vehicleInformation,
+        
+        // DO NOT include: 
+        // - namedOccupant (contains email, phone, address)
+        // - partyInformation (age breakdown not needed)
+        // - feeInformation (payment details not needed for verification)
+        // - sessionId, sessionExpiry (internal session state)
+        // - globalId, activityId (internal IDs)
+        // - equipmentInformation (not needed for basic verification)
+        // - bookedAt (not needed for verification)
+      },
+      verificationMetadata: {
+        verifiedAt: new Date().toISOString(),
+        verifiedBy: claims.sub
+        // DO NOT include verifierEmail (not needed in response)
+      }
+    };
+
+    return sendResponse(200, response, "Success", null, context);
+
+  } catch (error) {
+    logger.error("Error in Verify Booking GET:", error);
+    return sendResponse(
+      Number(error?.code) || 500,
+      error?.data || null,
+      error?.msg || "Error verifying booking",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/src/handlers/verify/constructs.js
+++ b/src/handlers/verify/constructs.js
@@ -1,0 +1,55 @@
+const { LambdaConstruct } = require("../../../lib/helpers/base-lambda");
+const apigw = require("aws-cdk-lib/aws-apigateway");
+
+const defaults = {
+  resources: {
+    verifyGETFunction: {
+      name: 'VerifyGET',
+    }
+  },
+};
+
+class VerifyConstruct extends LambdaConstruct {
+  constructor(scope, id, props) {
+    super(scope, id, {
+      ...props,
+      defaults: defaults
+    });
+
+    // /verify resource
+    this.verifyResource = this.resolveApi().root.addResource('verify');
+
+    // /verify/{bookingId} resource
+    this.verifyBookingIdResource = this.verifyResource.addResource('{bookingId}');
+
+    // /verify/{bookingId}/{hash} resource
+    this.verifyHashResource = this.verifyBookingIdResource.addResource('{hash}');
+
+    // GET /verify/{bookingId}/{hash} Lambda function
+    this.verifyGetFunction = this.generateBasicLambdaFn(
+      scope,
+      'verifyGETFunction',
+      'src/handlers/verify/GET',
+      'admin.handler',
+      {
+        transDataBasicRead: true,
+      }
+    );
+
+    // GET /verify/{bookingId}/{hash} (admin-only endpoint)
+    this.verifyHashResource.addMethod('GET', new apigw.LambdaIntegration(this.verifyGetFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+
+    // Add permissions to read from transactional data table
+    this.grantBasicTransDataTableRead(this.verifyGetFunction);
+    
+    // Add permissions to read from reference data table (for access points)
+    this.grantBasicRefDataTableRead(this.verifyGetFunction);
+  }
+}
+
+module.exports = {
+  VerifyConstruct,
+};

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,0 +1,628 @@
+/**
+ * Unit tests for QR code verification endpoint
+ * 
+ * Tests cover:
+ * - Hash validation
+ * - Admin authorization
+ * - Booking retrieval
+ * - Status validation (confirmed, cancelled, expired, pending)
+ * - Error handling (invalid hash, missing booking, unauthorized)
+ */
+
+// Mock environment variables for testing
+process.env.NODE_ENV = 'test';
+process.env.QR_SECRET_KEY = 'test-secret-key-for-unit-tests-only-do-not-use-in-production';
+process.env.PUBLIC_FRONTEND_DOMAIN = 'test.reserve-rec.bcparks.ca';
+process.env.AWS_SAM_LOCAL = 'true'; // Use mock claims
+
+// Mock the base layer
+jest.mock('/opt/base', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  sendResponse: jest.fn((code, data, message) => ({
+    statusCode: code,
+    body: JSON.stringify({ data, message })
+  })),
+  getRequestClaimsFromEvent: jest.fn(),
+  Exception: class Exception extends Error {
+    constructor(message, options) {
+      super(message);
+      this.code = options?.code;
+      this.data = options?.data;
+    }
+  }
+}));
+
+// Mock the QR code helper
+const { generateQRURL } = require('../lib/handlers/emailDispatch/qrCodeHelper');
+jest.mock('../lib/handlers/emailDispatch/qrCodeHelper', () => {
+  const actual = jest.requireActual('../lib/handlers/emailDispatch/qrCodeHelper');
+  return {
+    validateHash: actual.validateHash,
+    generateQRURL: actual.generateQRURL,
+  };
+});
+
+// Mock the bookings methods
+const mockGetBookingByBookingId = jest.fn();
+jest.mock('../src/handlers/bookings/methods', () => ({
+  getBookingByBookingId: mockGetBookingByBookingId,
+}));
+
+const { handler } = require('../src/handlers/verify/GET/admin');
+const { sendResponse } = require('/opt/base');
+
+describe('Verify Endpoint', () => {
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Admin Authorization', () => {
+    it('should allow SuperAdmin access', async () => {
+      const bookingId = 'BOOK-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'confirmed',
+        startDate: '2025-12-20',
+        endDate: '2025-12-22',
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          valid: true,
+          bookingId: bookingId,
+        }),
+        'Success',
+        null,
+        {}
+      );
+    });
+
+    it('should reject non-admin users', async () => {
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: 'BOOK-123',
+          hash: 'somehash',
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-user',
+              'cognito:groups': ['RegularUserGroup'],
+              email: 'user@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        403,
+        expect.any(Object),
+        expect.any(String),
+        expect.anything(),
+        {}
+      );
+    });
+
+    it('should reject requests without authorization', async () => {
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: 'BOOK-123',
+          hash: 'somehash',
+        },
+        requestContext: {
+          // No authorizer
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        401,
+        expect.any(Object),
+        expect.any(String),
+        expect.anything(),
+        {}
+      );
+    });
+  });
+
+  describe('Hash Validation', () => {
+    it('should accept valid hash', async () => {
+      const bookingId = 'BOOK-VALID-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'confirmed',
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          valid: true,
+        }),
+        'Success',
+        null,
+        {}
+      );
+    });
+
+    it('should reject invalid hash format', async () => {
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: 'BOOK-123',
+          hash: 'invalid-hash-123', // Invalid format (not 16 hex chars)
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        400,
+        expect.objectContaining({
+          valid: false,
+          reason: 'Invalid or expired QR code',
+        }),
+        'Invalid QR code',
+        null,
+        {}
+      );
+    });
+
+    it('should reject hash from different bookingId', async () => {
+      const bookingId1 = 'BOOK-123';
+      const bookingId2 = 'BOOK-456';
+      
+      const url1 = generateQRURL(bookingId1);
+      const hash1 = url1.split('/').pop();
+
+      // Mock booking exists for bookingId2 (to pass timing attack prevention)
+      mockGetBookingByBookingId.mockResolvedValue({
+        bookingId: bookingId2,
+        bookingStatus: 'confirmed',
+        startDate: '2025-12-20',
+        endDate: '2025-12-22',
+      });
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId2, // Different bookingId
+          hash: hash1, // Hash from bookingId1
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        400,
+        expect.objectContaining({
+          valid: false,
+          reason: 'Invalid or expired QR code',
+        }),
+        'Invalid QR code',
+        null,
+        {}
+      );
+    });
+  });
+
+  describe('Booking Status', () => {
+    it('should return confirmed booking details', async () => {
+      const bookingId = 'BOOK-CONFIRMED-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'confirmed',
+        startDate: '2025-12-20',
+        endDate: '2025-12-22',
+        collectionId: 'bcparks_kootenay',
+        activityType: 'backcountry',
+        displayName: 'Kootenay Backcountry Campsite',
+        namedOccupant: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john.doe@example.com',
+          phone: '555-1234',
+        },
+        partyInformation: {
+          adult: 2,
+          child: 1,
+        },
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          valid: true,
+          bookingId: bookingId,
+          status: 'confirmed',
+          statusDetails: expect.objectContaining({
+            isConfirmed: true,
+            isCancelled: false,
+          }),
+          booking: expect.objectContaining({
+            bookingId: bookingId,
+            displayName: 'Kootenay Backcountry Campsite',
+            guestName: 'John Doe', // Changed: aggregated name, not full namedOccupant
+            partySize: 3, // Changed: total count, not detailed breakdown
+            // Security: Should NOT include email, phone, feeInformation, globalId, activityId
+          }),
+        }),
+        'Success',
+        null,
+        {}
+      );
+
+      // Verify sensitive data is NOT in response
+      const responseData = sendResponse.mock.calls[0][1];
+      expect(responseData.booking.namedOccupant).toBeUndefined();
+      expect(responseData.booking.partyInformation).toBeUndefined();
+      expect(responseData.booking.feeInformation).toBeUndefined();
+      expect(responseData.booking.globalId).toBeUndefined();
+      expect(responseData.booking.activityId).toBeUndefined();
+      expect(responseData.booking.bookedAt).toBeUndefined();
+      expect(responseData.booking.sessionId).toBeUndefined();
+      expect(responseData.booking.sessionExpiry).toBeUndefined();
+    });
+
+    it('should identify cancelled booking', async () => {
+      const bookingId = 'BOOK-CANCELLED-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'cancelled',
+        startDate: '2025-12-20',
+        endDate: '2025-12-22',
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          valid: true,
+          status: 'cancelled',
+          statusDetails: expect.objectContaining({
+            isCancelled: true,
+            isConfirmed: false,
+          }),
+        }),
+        'Success',
+        null,
+        {}
+      );
+    });
+
+    it('should identify expired session', async () => {
+      const bookingId = 'BOOK-EXPIRED-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'in progress',
+        sessionExpiry: '2025-01-01T00:00:00.000Z', // Past date
+        startDate: '2025-12-20',
+        endDate: '2025-12-22',
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          valid: true,
+          statusDetails: expect.objectContaining({
+            isExpired: true,
+          }),
+        }),
+        'Success',
+        null,
+        {}
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle missing bookingId parameter', async () => {
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          hash: 'somehash',
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        400,
+        expect.any(Object),
+        expect.any(String),
+        expect.anything(),
+        {}
+      );
+    });
+
+    it('should reject invalid bookingId format', async () => {
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: 'invalid@booking!id', // Invalid characters
+          hash: 'a1b2c3d4e5f6g7h8',
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        400,
+        expect.objectContaining({
+          valid: false,
+          reason: 'Invalid or expired QR code',
+        }),
+        'Invalid QR code',
+        null,
+        {}
+      );
+    });
+
+    it('should handle booking not found', async () => {
+      const bookingId = 'BOOK-NOTFOUND-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      mockGetBookingByBookingId.mockRejectedValue(new Error('Booking not found'));
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'test-admin',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@example.com'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      // Changed: Returns 400 (not 404) to prevent bookingId enumeration
+      expect(sendResponse).toHaveBeenCalledWith(
+        400,
+        expect.objectContaining({
+          valid: false,
+          reason: 'Invalid or expired QR code', // Changed: generic message
+        }),
+        'Invalid QR code',
+        null,
+        {}
+      );
+    });
+
+    it('should handle CORS preflight', async () => {
+      const event = {
+        httpMethod: 'OPTIONS',
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(200, {}, 'Success', null, {});
+    });
+  });
+
+  describe('Audit Trail', () => {
+    it('should include verification metadata in response', async () => {
+      const bookingId = 'BOOK-AUDIT-123';
+      const url = generateQRURL(bookingId);
+      const hash = url.split('/').pop();
+
+      const mockBooking = {
+        bookingId: bookingId,
+        bookingStatus: 'confirmed',
+      };
+
+      mockGetBookingByBookingId.mockResolvedValue(mockBooking);
+
+      const event = {
+        httpMethod: 'GET',
+        pathParameters: {
+          bookingId: bookingId,
+          hash: hash,
+        },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'admin-user-123',
+              'cognito:groups': ['ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup'],
+              email: 'admin@bcparks.ca'
+            }
+          }
+        }
+      };
+
+      await handler(event, {});
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          verificationMetadata: expect.objectContaining({
+            verifiedBy: 'admin-user-123',
+            verifiedAt: expect.any(String),
+            // Changed: verifierEmail removed from response (privacy)
+          }),
+        }),
+        'Success',
+        null,
+        {}
+      );
+
+      // Verify verifierEmail is NOT in response
+      const responseData = sendResponse.mock.calls[0][1];
+      expect(responseData.verificationMetadata.verifierEmail).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Add QR code verification endpoint for admin API

**Resolves:** #320

### Summary

Implements backend API endpoint for SuperAdmin users to verify QR codes from booking confirmations. Enables park staff to validate reservations on-site.

**Endpoint:** `GET /verify/{bookingId}/{hash}`

### Security

- SuperAdmin-only access via Cognito
- Input validation (bookingId/hash format)
- Timing attack prevention (unified error responses)
- Minimal PII in response (no email/phone/address/payment data)