### PR TITLE
Add qrSecretKey to AdminApiStack to eliminate cross-stack dependency

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -71,6 +71,11 @@ const defaults = {
       name: 'VerifyConstruct',
     }
   },
+  secrets: {
+    qrSecretKey: {
+      name: 'qr-secret-key',
+    },
+  },
   config: {
     corsPreflightAllowHeaders: [
       "Content-Type",
@@ -334,13 +339,17 @@ class AdminApiStack extends BaseStack {
     );
 
     // Verify Lambdas (QR code verification)
-    // Note: Reuses the QR secret from EmailDispatchStack to ensure hash compatibility
+    // IMPORTANT: qrSecretKey MUST match EmailDispatchStack's qrSecretKey
+    // Both stacks use the same secret to generate/validate QR code HMAC hashes
+    // When rotating this secret, update both:
+    //   - /reserveRecApi/{env}/adminApiStack/qr-secret-key
+    //   - /reserveRecApi/{env}/emailDispatchStack/qr-secret-key
     this.verifyConstruct = new VerifyConstruct(this, this.getConstructId('verifyConstruct'), {
       environment: {
         LOG_LEVEL: this.getConfigValue('logLevel'),
         REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
         TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
-        QR_SECRET_KEY: this.getSecretValue('qrSecretKey', 'EmailDispatchStack'),
+        QR_SECRET_KEY: this.getSecretValue('qrSecretKey'),
         PUBLIC_FRONTEND_DOMAIN: publicFrontendDomain,
       },
       layers: [


### PR DESCRIPTION
## Summary
- Adds `qrSecretKey` to AdminApiStack's secrets configuration
- Updates VerifyConstruct to use local secret instead of cross-stack call to EmailDispatchStack
- Eliminates cross-stack method access complexity
- Created matching secret in AWS Secrets Manager for dev environment

## Problem Solved
The VerifyConstruct was calling `this.getSecretValue('qrSecretKey', 'EmailDispatchStack')` which requires complex cross-stack method access. This caused issues with stack dependencies and method binding.

## Solution (Option 1: Duplicate Secret)
Instead of complex cross-stack calls, duplicate the QR secret in both stacks:
- **EmailDispatchStack**: Uses qrSecretKey to generate QR codes in emails
- **AdminApiStack**: Uses qrSecretKey to validate QR codes

Both need the **exact same secret value** to generate/validate HMAC hashes correctly.

## Implementation
1. Added `secrets.qrSecretKey` to AdminApiStack defaults
2. Changed VerifyConstruct to use `this.getSecretValue('qrSecretKey')` (no cross-stack call)
3. Created `/reserve-rec/dev/adminApiStack/qrSecretKey` in AWS Secrets Manager with same value as EmailDispatchStack
4. Added clear documentation about keeping secrets in sync

## Secret Management
When rotating the QR secret, update **both** locations:
- `/reserveRecApi/dev/adminApiStack/qr-secret-key`
- `/reserveRecApi/dev/emailDispatchStack/qr-secret-key`

The secret is tagged in AWS with `SyncWith` to make this relationship clear.

## Testing
- [ ] Verify deployment succeeds
- [ ] Test /verify endpoints are created in API Gateway
- [ ] Test QR code validation works correctly

## Related
- Replaces the complex cross-stack fix from PR #265
- Simpler, more maintainable solution