### PR TITLE
Shuffle domain import

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -87,7 +87,12 @@ const defaults = {
     adminUserPoolClientId: '',
     bcscKeyId: '',
   },
- 
+  secrets: {
+    qrSecretKey: {
+      name: 'qrSecretKey',
+    },
+  }
+
 };
 
 async function createAdminApiStack(scope, stackKey) {
@@ -326,22 +331,14 @@ class AdminApiStack extends BaseStack {
       openSearchDomainArn: opensearchDomainArn,
     });
 
-    // Get PUBLIC_FRONTEND_DOMAIN from SSM Parameter Store
-    // Expected SSM path: /reserve-rec/{env}/public-frontend-domain
-    const publicFrontendDomain = ssm.StringParameter.valueForStringParameter(
-      this,
-      `/reserve-rec/${this.getDeploymentName()}/public-frontend-domain`
-    );
-
     // Verify Lambdas (QR code verification)
-    // Note: Reuses the QR secret from EmailDispatchStack to ensure hash compatibility
     this.verifyConstruct = new VerifyConstruct(this, this.getConstructId('verifyConstruct'), {
       environment: {
         LOG_LEVEL: this.getConfigValue('logLevel'),
         REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
         TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
-        QR_SECRET_KEY: this.getSecretValue('qrSecretKey', 'EmailDispatchStack'),
-        PUBLIC_FRONTEND_DOMAIN: publicFrontendDomain,
+        QR_SECRET_KEY: this.getSecretValue('qrSecretKey'),
+        PUBLIC_FRONTEND_DOMAIN: scope.resolvePublicDomainName(this),
       },
       layers: [
         baseLayer,

--- a/lib/core-stack/core-stack.js
+++ b/lib/core-stack/core-stack.js
@@ -38,6 +38,8 @@ const defaults = {
     opensearchTransactionalDataIndexName: 'transactional-data-index',
     opensearchDomainEndpoint: '',
     opensearchReferenceDataIndexName: 'reference-data-index',
+    publicDomainNameSSMPath: `/reserveRecPublic/dev/distributionStack/distributionDomainName`,
+    adminDomainNameSSMPath: `/reserveRecAdmin/dev/distributionStack/distributionDomainName`,
   }
 };
 
@@ -135,6 +137,8 @@ class CoreStack extends BaseStack {
     scope.resolveKmsKey = this.resolveKmsKey.bind(this);
     scope.resolveOpenSearchReferenceDataIndexName = this.resolveOpenSearchReferenceDataIndexName.bind(this);
     scope.resolveOpenSearchTransactionalDataIndexName = this.resolveOpenSearchTransactionalDataIndexName.bind(this);
+    scope.resolveAdminDomainName = this.resolveAdminDomainName.bind(this);
+    scope.resolvePublicDomainName = this.resolvePublicDomainName.bind(this);
   }
 
   resolveBaseLayer(consumerScope) {
@@ -175,6 +179,18 @@ class CoreStack extends BaseStack {
 
   resolveOpenSearchTransactionalDataIndexName(consumerScope) {
     return this.resolveReference(consumerScope, this.getExportSSMPath('opensearchTransactionalDataIndexName'));
+  }
+
+  // Gets the Domain for the admin site from SSM
+  resolveAdminDomainName(consumerScope) {
+    const name = this.getConfigValue('publicDomainNameSSMPath') + '-APIRef'
+    return this.resolveReference(consumerScope, name);
+  }
+
+  // Gets the Domain for the public site from SSM
+  resolvePublicDomainName(consumerScope) {
+    const name = this.getConfigValue('publicDomainNameSSMPath') + '-APIRef';
+    return this.resolveReference(consumerScope, name);
   }
 
   // Getters for resources


### PR DESCRIPTION
Minor refactoring to include domain imports from reserveRecPublic and reserveRecAdmin directly from their respective SSM exported values rather than statically importing them.