### PR TITLE
fix: resolve fee policy PUT endpoint validation errors (#273)

### DIFF
--- a/src/handlers/policies/PUT/admin.js
+++ b/src/handlers/policies/PUT/admin.js
@@ -29,7 +29,7 @@ exports.handler = async (event, context) => {
         logger.debug(`Processing booking policy PUT request.`);
         res = await handlePolicyPut(body, 'booking', policyId);
         break;
-      case 'fee':
+      case 'change':
         logger.debug(`Processing change policy PUT request.`);
         res = await handlePolicyPut(body, 'change', policyId);
         break;

--- a/src/handlers/policies/configs.js
+++ b/src/handlers/policies/configs.js
@@ -941,49 +941,49 @@ const POLICY_FEE_API_PUT_CONFIG = {
     },
     adultNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     youthNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     childNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     seniorNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     baseChangeFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     unitChangeFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     baseReservationFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     unitReservationFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -996,13 +996,13 @@ const POLICY_FEE_API_PUT_CONFIG = {
     },
     maxUnitCharge: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     changeSSCFECharge: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -1014,13 +1014,13 @@ const POLICY_FEE_API_PUT_CONFIG = {
     },
     additionalVehiclesFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     damageDeposit: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -1097,49 +1097,49 @@ const POLICY_FEE_API_UPDATE_CONFIG = {
     },
     adultNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     youthNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     childNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     seniorNightlyCampingFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     baseChangeFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     unitChangeFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     baseReservationFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     unitReservationFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -1152,13 +1152,13 @@ const POLICY_FEE_API_UPDATE_CONFIG = {
     },
     maxUnitCharge: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     changeSSCFECharge: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
@@ -1170,13 +1170,13 @@ const POLICY_FEE_API_UPDATE_CONFIG = {
     },
     additionalVehiclesFee: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },
     damageDeposit: {
       rulesFn: ({ value, action }) => {
-        rf.expectNumber(value);
+        rf.expectMoneyFormat(value);
         rf.expectAction(action, ['set']);
       }
     },

--- a/src/handlers/policies/methods.js
+++ b/src/handlers/policies/methods.js
@@ -224,7 +224,24 @@ async function processPutItem(item, policyType, policyId) {
   }
 
   // Get the fields that are allowed to be updated from the update config
-  const updatableFields = Object.keys(POLICY_BOOKING_API_UPDATE_CONFIG.fields);
+  let updateConfig;
+  switch (policyType) {
+    case 'booking':
+      updateConfig = POLICY_BOOKING_API_UPDATE_CONFIG;
+      break;
+    case 'change':
+      updateConfig = POLICY_CHANGE_API_UPDATE_CONFIG;
+      break;
+    case 'party':
+      updateConfig = POLICY_PARTY_API_UPDATE_CONFIG;
+      break;
+    case 'fee':
+      updateConfig = POLICY_FEE_API_UPDATE_CONFIG;
+      break;
+    default:
+      throw new Exception(`Unknown policy type: ${policyType}`, { code: 400 });
+  }
+  const updatableFields = Object.keys(updateConfig.fields);
   console.log('updatableFields:', updatableFields);
   // Validate that only updatable fields are being modified
   console.log('item:', item);


### PR DESCRIPTION
- Replace rf.expectNumber with rf.expectMoneyFormat in fee policy configs
- Fix duplicate case 'fee' in PUT admin handler (changed to case 'change')
- Fix hardcoded POLICY_BOOKING_API_UPDATE_CONFIG in processPutItem to use dynamic config selection based on policyType

Fixes #273