### PR TITLE
feat: improve sandbox infrastructure with shared identity resources

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -67,17 +67,17 @@ class CDKProject {
   }
 
   /**
-   * Gets the deployment environment name from the CDK context.
+   * Gets the deployment environment name for resource naming and config lookups.
    * Used for environment-specific resource naming and configuration.
-   * If a sandboxName is provided, it appends it to create an isolated sandbox environment.
+   * If a sandboxName is provided, it returns just the sandbox name for shorter resource names.
    *
-   * @returns {string} The deployment environment name (dev, test, prod, or dev-sandboxName) or 'local' as default
+   * @returns {string} The deployment environment name (dev, test, prod, or sandboxName) or 'local' as default
    */
   getDeploymentName() {
     const baseName = this.context?.DEPLOYMENT_NAME || 'local';
     const sandboxName = this.getSandboxName();
     if (sandboxName) {
-      return `${baseName}-${sandboxName}`;
+      return sandboxName;
     }
     return baseName;
   }

--- a/lib/admin-identity-stack/admin-identity-stack.js
+++ b/lib/admin-identity-stack/admin-identity-stack.js
@@ -94,6 +94,59 @@ class AdminIdentityStack extends BaseStack {
 
     logger.info(`Creating Admin Identity Stack: ${primer.stackId}`);
 
+    // Import mode: If skipCreation override is set, import dev's identity resources instead of creating new ones
+    // This is used for sandbox environments to share dev's admin user pool and identity pool
+    if (this.overrides?.skipCreation === true) {
+      logger.info('Import mode enabled: Using existing admin identity resources from override values');
+      
+      // Validate required override values
+      const requiredOverrides = [
+        'adminUserPoolId',
+        'adminUserPoolClientId', 
+        'adminIdentityPoolId',
+        'adminUserPoolProviderName',
+        'adminUserPoolDomain',
+        'cognitoAuthRoleArn',
+        'cognitoUnauthRoleArn'
+      ];
+      
+      const missingOverrides = requiredOverrides.filter(key => !this.overrides[key]);
+      if (missingOverrides.length > 0) {
+        throw new Error(`Import mode requires these override values: ${missingOverrides.join(', ')}`);
+      }
+
+      // Export override values to sandbox's SSM paths (so downstream stacks can resolve them)
+      this.exportReference(this, 'adminUserPoolId', this.overrides.adminUserPoolId, `ID of the Admin User Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'adminUserPoolClientId', this.overrides.adminUserPoolClientId, `ID of the Admin User Pool Client in ${this.stackId} (imported)`);
+      this.exportReference(this, 'adminIdentityPoolId', this.overrides.adminIdentityPoolId, `ID of the Admin Identity Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'adminUserPoolDomain', this.overrides.adminUserPoolDomain, `Domain of the Admin User Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'adminUserPoolProviderName', this.overrides.adminUserPoolProviderName, `Provider Name of the Admin User Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'cognitoAuthRoleArn', this.overrides.cognitoAuthRoleArn, `ARN of the Cognito Authenticated Role in ${this.stackId} (imported)`);
+      this.exportReference(this, 'cognitoUnauthRoleArn', this.overrides.cognitoUnauthRoleArn, `ARN of the Cognito Unauthenticated Role in ${this.stackId} (imported)`);
+
+      // Export role ARNs if provided
+      if (this.overrides.superAdminRoleArn) {
+        this.exportReference(this, 'superAdminRoleArn', this.overrides.superAdminRoleArn, `ARN of the superAdmin role in ${this.stackId} (imported)`);
+      }
+      if (this.overrides.administratorRoleArn) {
+        this.exportReference(this, 'administratorRoleArn', this.overrides.administratorRoleArn, `ARN of the administrator role in ${this.stackId} (imported)`);
+      }
+      if (this.overrides.parkOperatorRoleArn) {
+        this.exportReference(this, 'parkOperatorRoleArn', this.overrides.parkOperatorRoleArn, `ARN of the parkOperator role in ${this.stackId} (imported)`);
+      }
+
+      // Bind resolve functions to scope for other stacks to consume
+      scope.resolveAdminUserPoolId = this.resolveAdminUserPoolId.bind(this);
+      scope.resolveAdminUserPoolClientId = this.resolveAdminUserPoolClientId.bind(this);
+      scope.resolveAdminIdentityPoolId = this.resolveAdminIdentityPoolId.bind(this);
+      scope.resolveAdminUserPoolProviderName = this.resolveAdminUserPoolProviderName.bind(this);
+      scope.resolveAdminAuthenticatedCognitoRoleArn = this.resolveAdminAuthenticatedCognitoRoleArn.bind(this);
+      scope.resolveAdminUnauthenticatedCognitoRoleArn = this.resolveAdminUnauthenticatedCognitoRoleArn.bind(this);
+
+      logger.info('Import mode: Admin Identity Stack configured with imported resources');
+      return; // Skip resource creation
+    }
+
     // Create an administrative Cognito User Pool
     this.adminUserPool = new cognito.UserPool(this, this.getConstructId('adminUserPool'), {
       userPoolName: this.getConstructId('adminUserPool'),

--- a/lib/helpers/stack-primer.js
+++ b/lib/helpers/stack-primer.js
@@ -97,7 +97,11 @@ class StackPrimer {
         logger.debug('Loading context from SSM Parameter Store');
         // Production or other environments
         const retrievedConfig = await getParameterFromSSM(this.configPath);
-        this.config = { ...this.config, ...JSON.parse(retrievedConfig) };
+        if (retrievedConfig) {
+          this.config = { ...this.config, ...JSON.parse(retrievedConfig) };
+        } else {
+          logger.warn(`No SSM config found for ${this.stackKey}, using defaults`);
+        }
       }
       logger.debug('Loaded config:', this.config);
     } catch (error) {

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -107,6 +107,12 @@ async function getParameterFromSSM(paramName) {
     const response = await ssmClient.send(command);
     return response.Parameter.Value;
   } catch (error) {
+    // For ParameterNotFound, return null to allow falling back to defaults
+    if (error.name === 'ParameterNotFound') {
+      logger.warn(`SSM parameter not found: ${paramName} - using defaults`);
+      return null;
+    }
+    // For other errors, throw
     throw `SSM GET error.\n ${error}`;
   }
 }

--- a/lib/public-identity-stack/public-identity-stack.js
+++ b/lib/public-identity-stack/public-identity-stack.js
@@ -138,6 +138,48 @@ class PublicIdentityStack extends BaseStack {
 
     logger.info(`Creating Public Identity Stack: ${this.stackId}`);
 
+    // Import mode: If skipCreation override is set, import dev's identity resources instead of creating new ones
+    // This is used for sandbox environments to share dev's public user pool and identity pool
+    if (this.overrides?.skipCreation === true) {
+      logger.info('Import mode enabled: Using existing public identity resources from override values');
+      
+      // Validate required override values
+      const requiredOverrides = [
+        'publicUserPoolId',
+        'publicUserPoolClientId',
+        'publicIdentityPoolId',
+        'cognitoAuthRoleArn',
+        'cognitoUnauthRoleArn'
+      ];
+      
+      const missingOverrides = requiredOverrides.filter(key => !this.overrides[key]);
+      if (missingOverrides.length > 0) {
+        throw new Error(`Import mode requires these override values: ${missingOverrides.join(', ')}`);
+      }
+
+      // Export override values to sandbox's SSM paths (so downstream stacks can resolve them)
+      this.exportReference(this, 'publicUserPoolId', this.overrides.publicUserPoolId, `ID of the Public Cognito User Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'publicUserPoolClientId', this.overrides.publicUserPoolClientId, `ID of the Public Cognito User Pool Client in ${this.stackId} (imported)`);
+      this.exportReference(this, 'publicIdentityPoolId', this.overrides.publicIdentityPoolId, `ID of the Public Cognito Identity Pool in ${this.stackId} (imported)`);
+      this.exportReference(this, 'cognitoAuthRoleArn', this.overrides.cognitoAuthRoleArn, `ARN of the Cognito Authenticated Role in ${this.stackId} (imported)`);
+      this.exportReference(this, 'cognitoUnauthRoleArn', this.overrides.cognitoUnauthRoleArn, `ARN of the Cognito Unauthenticated Role in ${this.stackId} (imported)`);
+
+      // Export role ARN if provided
+      if (this.overrides.publicRoleArn) {
+        this.exportReference(this, 'publicRoleArn', this.overrides.publicRoleArn, `ARN of the public role in ${this.stackId} (imported)`);
+      }
+
+      // Bind resolve functions to scope for other stacks to consume
+      scope.resolvePublicUserPoolId = this.resolvePublicUserPoolId.bind(this);
+      scope.resolvePublicUserPoolClientId = this.resolvePublicUserPoolClientId.bind(this);
+      scope.resolvePublicIdentityPoolId = this.resolvePublicIdentityPoolId.bind(this);
+      scope.resolvePublicAuthenticatedCognitoRoleArn = this.resolvePublicAuthenticatedCognitoRoleArn.bind(this);
+      scope.resolvePublicUnauthenticatedCognitoRoleArn = this.resolvePublicUnauthenticatedCognitoRoleArn.bind(this);
+
+      logger.info('Import mode: Public Identity Stack configured with imported resources');
+      return; // Skip resource creation
+    }
+
     // Create a public Cognito User Pool
     this.publicUserPool = new cognito.UserPool(this, this.getConstructId('publicUserPool'), {
       userPoolName: this.getConstructId('publicUserPool'),

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -6,7 +6,7 @@ set -e
 
 SANDBOX_NAME="${1:?Usage: ./sandbox-setup.sh <sandbox-name> [base-env]}"
 BASE_ENV="${2:-dev}"  # Default to dev as base
-DEPLOYMENT_NAME="${BASE_ENV}-${SANDBOX_NAME}"
+DEPLOYMENT_NAME="${SANDBOX_NAME}"  # Sandboxes use just the sandbox name (not base-sandbox)
 APP_NAME="reserveRecApi"
 REGION="ca-central-1"
 
@@ -55,31 +55,173 @@ for STACK in "${STACKS[@]}"; do
 done
 
 echo ""
+echo "Step 1.5: Injecting identity overrides for shared resources..."
+echo "----------------------------------------------------------------"
+
+# Sandboxes share dev's admin and public identity resources (user pools, identity pools)
+# We inject these as overrides so the identity stacks skip creation and just export dev's values
+
+# Helper function to inject overrides into a config
+inject_identity_overrides() {
+  local STACK_NAME=$1
+  local CONFIG_PATH="/${APP_NAME}/${DEPLOYMENT_NAME}/${STACK_NAME}/config"
+  
+  echo "  ${STACK_NAME}:"
+  
+  # Get current config
+  CURRENT_CONFIG=$(aws ssm get-parameter --region ${REGION} --name "${CONFIG_PATH}" --query 'Parameter.Value' --output text 2>/dev/null || echo "{}")
+  
+  if [ "$CURRENT_CONFIG" == "{}" ]; then
+    echo "    ⚠ WARNING: Config not found, skipping override injection"
+    return
+  fi
+  
+  # Build overrides JSON based on stack type
+  if [ "$STACK_NAME" == "adminIdentityStack" ]; then
+    # Read dev's admin identity exports
+    ADMIN_USER_POOL_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/adminUserPoolId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    ADMIN_USER_POOL_CLIENT_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/adminUserPoolClientId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    ADMIN_IDENTITY_POOL_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/adminIdentityPoolId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    ADMIN_USER_POOL_PROVIDER_NAME=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/adminUserPoolProviderName" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    ADMIN_USER_POOL_DOMAIN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/adminUserPoolDomain" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    COGNITO_AUTH_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/cognitoAuthRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    COGNITO_UNAUTH_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/cognitoUnauthRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    SUPER_ADMIN_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/superAdminRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    ADMINISTRATOR_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/administratorRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    PARK_OPERATOR_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/parkOperatorRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    
+    OVERRIDES_JSON=$(cat <<EOF
+{
+  "skipCreation": true,
+  "adminUserPoolId": "${ADMIN_USER_POOL_ID}",
+  "adminUserPoolClientId": "${ADMIN_USER_POOL_CLIENT_ID}",
+  "adminIdentityPoolId": "${ADMIN_IDENTITY_POOL_ID}",
+  "adminUserPoolProviderName": "${ADMIN_USER_POOL_PROVIDER_NAME}",
+  "adminUserPoolDomain": "${ADMIN_USER_POOL_DOMAIN}",
+  "cognitoAuthRoleArn": "${COGNITO_AUTH_ROLE_ARN}",
+  "cognitoUnauthRoleArn": "${COGNITO_UNAUTH_ROLE_ARN}",
+  "superAdminRoleArn": "${SUPER_ADMIN_ROLE_ARN}",
+  "administratorRoleArn": "${ADMINISTRATOR_ROLE_ARN}",
+  "parkOperatorRoleArn": "${PARK_OPERATOR_ROLE_ARN}"
+}
+EOF
+)
+  elif [ "$STACK_NAME" == "publicIdentityStack" ]; then
+    # Read dev's public identity exports
+    PUBLIC_USER_POOL_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/publicUserPoolId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    PUBLIC_USER_POOL_CLIENT_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/publicUserPoolClientId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    PUBLIC_IDENTITY_POOL_ID=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/publicIdentityPoolId" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    COGNITO_AUTH_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/cognitoAuthRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    COGNITO_UNAUTH_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/cognitoUnauthRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    PUBLIC_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/publicIdentityStack/publicRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    
+    OVERRIDES_JSON=$(cat <<EOF
+{
+  "skipCreation": true,
+  "publicUserPoolId": "${PUBLIC_USER_POOL_ID}",
+  "publicUserPoolClientId": "${PUBLIC_USER_POOL_CLIENT_ID}",
+  "publicIdentityPoolId": "${PUBLIC_IDENTITY_POOL_ID}",
+  "cognitoAuthRoleArn": "${COGNITO_AUTH_ROLE_ARN}",
+  "cognitoUnauthRoleArn": "${COGNITO_UNAUTH_ROLE_ARN}",
+  "publicRoleArn": "${PUBLIC_ROLE_ARN}"
+}
+EOF
+)
+  else
+    echo "    Unknown stack type"
+    return
+  fi
+  
+  # Merge overrides into current config using jq
+  # This preserves any existing overrides (like opensearchDomainArn) and adds identity overrides
+  UPDATED_CONFIG=$(echo "${CURRENT_CONFIG}" | jq --argjson newOverrides "${OVERRIDES_JSON}" '
+    .overrides = (.overrides // {}) * $newOverrides
+  ')
+  
+  # Update SSM parameter
+  aws ssm put-parameter --region ${REGION} \
+    --name "${CONFIG_PATH}" \
+    --type String \
+    --value "${UPDATED_CONFIG}" \
+    --overwrite >/dev/null
+  
+  echo "    ✓ Overrides injected"
+}
+
+# Inject overrides for both identity stacks
+inject_identity_overrides "adminIdentityStack"
+inject_identity_overrides "publicIdentityStack"
+
+echo ""
+echo "Step 1.6: Copying frontend domain parameter..."
+echo "------------------------------------------------"
+
+# Frontend domain uses a different app name prefix (/reserve-rec vs /reserveRecApi)
+# Copy dev's frontend domain for sandbox use
+FRONTEND_DOMAIN=$(aws ssm get-parameter --region ${REGION} --name "/reserve-rec/${BASE_ENV}/public-frontend-domain" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+
+if [ -n "${FRONTEND_DOMAIN}" ]; then
+  echo "  Copying: /reserve-rec/${BASE_ENV}/public-frontend-domain -> /reserve-rec/${DEPLOYMENT_NAME}/public-frontend-domain"
+  echo "    Value: ${FRONTEND_DOMAIN}"
+  aws ssm put-parameter --region ${REGION} \
+    --name "/reserve-rec/${DEPLOYMENT_NAME}/public-frontend-domain" \
+    --type String \
+    --value "${FRONTEND_DOMAIN}" \
+    --overwrite \
+    --description "Frontend domain for ${SANDBOX_NAME} (shared from ${BASE_ENV})" >/dev/null
+  echo "    ✓ Copied"
+else
+  echo "  ⚠ WARNING: Frontend domain parameter not found in ${BASE_ENV}, skipping"
+fi
+
+echo ""
 echo "Step 2: Copying Secrets Manager secrets..."
 echo "-------------------------------------------"
 
-# Define all secrets needed
-declare -A SECRETS
-SECRETS["adminIdentityStack/AzureClientSecret"]="Azure OIDC client secret"
-SECRETS["adminIdentityStack/BCSCClientSecret"]="BCSC client secret (admin)"
-SECRETS["publicIdentityStack/BCSCClientSecret"]="BCSC client secret (public)"
-SECRETS["opensearchStack/OpensearchMasterUserPassword"]="OpenSearch master password"
-SECRETS["publicApiStack/MerchantId"]="Worldline merchant ID"
-SECRETS["publicApiStack/HashKey"]="Worldline hash key"
-SECRETS["publicApiStack/WorldlineWebhookSecret"]="Worldline webhook secret"
-SECRETS["publicApiStack/qr-secret-key"]="QR code secret (public API)"
-SECRETS["adminApiStack/qrSecretKey"]="QR code secret (admin API)"
-SECRETS["bookingWorkflowStack/MerchantId"]="Worldline merchant ID (workflow)"
-SECRETS["bookingWorkflowStack/HashKey"]="Worldline hash key (workflow)"
-SECRETS["emailDispatchStack/qr-secret-key"]="QR code secret (email)"
+# Define secret mappings with explicit source->target paths
+# Format: "source_path|target_path"="description"
+# Paths differ due to naming convention changes between when dev secrets were created
+# and current code expectations (pre/post Jan 22, 2026 secret naming fix)
+declare -A SECRET_MAPPINGS
 
-for SECRET_PATH in "${!SECRETS[@]}"; do
-  SECRET_DESC="${SECRETS[$SECRET_PATH]}"
-  SOURCE_PATH="/${APP_NAME}/${BASE_ENV}/${SECRET_PATH}"
-  TARGET_PATH="/${APP_NAME}/${DEPLOYMENT_NAME}/${SECRET_PATH}"
+# Identity stack secrets
+SECRET_MAPPINGS["adminIdentityStack/azureClientSecret|adminIdentityStack/AzureClientSecret"]="Azure OIDC client secret"
+SECRET_MAPPINGS["adminIdentityStack/bcscClientSecret|adminIdentityStack/bcscClientSecret"]="BCSC client secret (admin)"
+SECRET_MAPPINGS["publicIdentityStack/bcscClientSecret|publicIdentityStack/bcscClientSecret"]="BCSC client secret (public)"
+
+# QR code secrets
+SECRET_MAPPINGS["adminApiStack/qr-secret-key|adminApiStack/qrSecretKey"]="QR code secret (admin API)"
+SECRET_MAPPINGS["publicApiStack/qr-secret-key|publicApiStack/qr-secret-key"]="QR code secret (public API)"
+
+# Worldline payment secrets
+SECRET_MAPPINGS["publicApiStack/merchantId|publicApiStack/MerchantId"]="Worldline merchant ID (public)"
+SECRET_MAPPINGS["publicApiStack/hashKey|publicApiStack/HashKey"]="Worldline hash key (public)"
+SECRET_MAPPINGS["publicApiStack/worldlineWebhookSecret|publicApiStack/WorldlineWebhookSecret"]="Worldline webhook secret"
+SECRET_MAPPINGS["bookingWorkflowStack/merchantId|bookingWorkflowStack/MerchantId"]="Worldline merchant ID (workflow)"
+SECRET_MAPPINGS["bookingWorkflowStack/hashKey|bookingWorkflowStack/HashKey"]="Worldline hash key (workflow)"
+
+# Note: OpenSearch password not needed - sandboxes reuse dev domain via SSM config overrides
+# Note: emailDispatchStack/qr-secret-key removed - doesn't exist in dev environment
+
+for MAPPING in "${!SECRET_MAPPINGS[@]}"; do
+  DESC="${SECRET_MAPPINGS[$MAPPING]}"
   
-  echo "  ${SECRET_PATH}"
-  echo "    Description: ${SECRET_DESC}"
+  # Parse source|target mapping
+  if [[ "$MAPPING" == *"|"* ]]; then
+    SOURCE_RELATIVE="${MAPPING%|*}"  # Before pipe
+    TARGET_RELATIVE="${MAPPING#*|}"  # After pipe
+  else
+    # No explicit mapping, use same path for both
+    SOURCE_RELATIVE="$MAPPING"
+    TARGET_RELATIVE="$MAPPING"
+  fi
+  
+  SOURCE_PATH="/${APP_NAME}/${BASE_ENV}/${SOURCE_RELATIVE}"
+  TARGET_PATH="/${APP_NAME}/${DEPLOYMENT_NAME}/${TARGET_RELATIVE}"
+  
+  echo "  ${TARGET_RELATIVE}"
+  echo "    Source: ${SOURCE_PATH}"
+  echo "    Description: ${DESC}"
   
   # Try to get secret value from source
   SECRET_VALUE=$(aws secretsmanager get-secret-value --region ${REGION} \
@@ -89,7 +231,7 @@ for SECRET_PATH in "${!SECRETS[@]}"; do
     # Try to create new secret, or update if exists
     aws secretsmanager create-secret --region ${REGION} \
       --name "${TARGET_PATH}" \
-      --description "Sandbox secret for ${SANDBOX_NAME}: ${SECRET_DESC}" \
+      --description "Sandbox secret for ${SANDBOX_NAME}: ${DESC}" \
       --secret-string "${SECRET_VALUE}" >/dev/null 2>&1 || \
     aws secretsmanager put-secret-value --region ${REGION} \
       --secret-id "${TARGET_PATH}" \

--- a/scripts/sandbox-teardown.sh
+++ b/scripts/sandbox-teardown.sh
@@ -6,7 +6,7 @@ set -e
 
 SANDBOX_NAME="${1:?Usage: ./sandbox-teardown.sh <sandbox-name> [base-env]}"
 BASE_ENV="${2:-dev}"
-DEPLOYMENT_NAME="${BASE_ENV}-${SANDBOX_NAME}"
+DEPLOYMENT_NAME="${SANDBOX_NAME}"  # Sandboxes use just the sandbox name (not base-sandbox)
 APP_NAME="reserveRecApi"
 REGION="ca-central-1"
 
@@ -19,76 +19,13 @@ echo "  1. Destroy all CDK stacks"
 echo "  2. Delete all SSM parameters"
 echo "  3. Delete all Secrets Manager secrets"
 echo ""
+echo "Note: Shared identity resources (user pools) from ${BASE_ENV} will NOT be affected."
+echo ""
 read -p "Are you sure? Type 'yes' to continue: " CONFIRM
 
 if [ "$CONFIRM" != "yes" ]; then
   echo "Aborted."
   exit 1
-fi
-
-echo ""
-echo "Step 0: Preparing Cognito User Pools for deletion..."
-echo "------------------------------------------------------"
-
-# Get user pool IDs from SSM (if they exist)
-ADMIN_POOL=$(aws ssm get-parameter --region ${REGION} \
-  --name "/${APP_NAME}/${DEPLOYMENT_NAME}/adminIdentityStack/adminUserPoolId" \
-  --query 'Parameter.Value' --output text 2>/dev/null || echo "")
-
-PUBLIC_POOL=$(aws ssm get-parameter --region ${REGION} \
-  --name "/${APP_NAME}/${DEPLOYMENT_NAME}/publicIdentityStack/publicUserPoolId" \
-  --query 'Parameter.Value' --output text 2>/dev/null || echo "")
-
-# Handle Admin User Pool
-if [ -n "$ADMIN_POOL" ]; then
-  echo "  Processing admin user pool: $ADMIN_POOL"
-  
-  # Get and delete domain if it exists
-  ADMIN_DOMAIN=$(aws cognito-idp describe-user-pool --region ${REGION} \
-    --user-pool-id "$ADMIN_POOL" \
-    --query 'UserPool.Domain' --output text 2>/dev/null || echo "")
-  
-  if [ -n "$ADMIN_DOMAIN" ] && [ "$ADMIN_DOMAIN" != "None" ]; then
-    echo "    Deleting domain: $ADMIN_DOMAIN"
-    aws cognito-idp delete-user-pool-domain --region ${REGION} \
-      --domain "$ADMIN_DOMAIN" \
-      --user-pool-id "$ADMIN_POOL" 2>/dev/null || true
-  fi
-  
-  # Disable deletion protection
-  echo "    Disabling deletion protection"
-  aws cognito-idp update-user-pool --region ${REGION} \
-    --user-pool-id "$ADMIN_POOL" \
-    --deletion-protection INACTIVE 2>/dev/null || true
-fi
-
-# Handle Public User Pool
-if [ -n "$PUBLIC_POOL" ]; then
-  echo "  Processing public user pool: $PUBLIC_POOL"
-  
-  # Get and delete domain if it exists
-  PUBLIC_DOMAIN=$(aws cognito-idp describe-user-pool --region ${REGION} \
-    --user-pool-id "$PUBLIC_POOL" \
-    --query 'UserPool.Domain' --output text 2>/dev/null || echo "")
-  
-  if [ -n "$PUBLIC_DOMAIN" ] && [ "$PUBLIC_DOMAIN" != "None" ]; then
-    echo "    Deleting domain: $PUBLIC_DOMAIN"
-    aws cognito-idp delete-user-pool-domain --region ${REGION} \
-      --domain "$PUBLIC_DOMAIN" \
-      --user-pool-id "$PUBLIC_POOL" 2>/dev/null || true
-  fi
-  
-  # Disable deletion protection
-  echo "    Disabling deletion protection"
-  aws cognito-idp update-user-pool --region ${REGION} \
-    --user-pool-id "$PUBLIC_POOL" \
-    --deletion-protection INACTIVE 2>/dev/null || true
-fi
-
-if [ -z "$ADMIN_POOL" ] && [ -z "$PUBLIC_POOL" ]; then
-  echo "  No user pools found (may have been deleted already)"
-else
-  echo "  ✓ User pools prepared for deletion"
 fi
 
 echo ""


### PR DESCRIPTION
- Simplify sandbox deployment names (use just sandbox name, not dev-sandboxName)
- Add import mode to AdminIdentityStack and PublicIdentityStack
- Sandboxes now share dev's Cognito user pools and identity pools
- Add identity override injection to sandbox-setup.sh
- Add frontend domain parameter copying to sandbox-setup.sh
- Simplify sandbox-teardown.sh (no user pool cleanup needed)

This reduces deployment time and avoids resource name length limits.