### PR TITLE
fix: add PublicFeatureFlagsConstruct to public API stack (#113)

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -15,6 +15,7 @@ const { ProductsConstruct } = require('../../src/handlers/products/constructs');
 const { PublicBookingsConstruct } = require('../../src/handlers/bookings/constructs');
 const { TransactionsConstruct } = require('../../src/handlers/transactions/constructs');
 const { WorldlineNotificationConstruct } = require('../../src/handlers/worldlineNotification/constructs');
+const { PublicFeatureFlagsConstruct } = require('../../src/handlers/featureFlags/constructs');
 
 const defaults = {
   description: 'Public API stack providing a public API Gateway, authorization, and Lambda functions for the Reserve Recreation APIs.',
@@ -63,6 +64,9 @@ const defaults = {
     },
     worldlineNotificationConstruct: {
       name: 'WorldlineNotificationConstruct',
+    },
+    publicFeatureFlagsConstruct: {
+      name: 'PublicFeatureFlagsConstruct',
     },
   },
   config: {
@@ -339,6 +343,19 @@ class PublicApiStack extends BaseStack {
       emailQueueUrl: emailQueueUrl,
       emailQueueArn: emailQueueArn,
       kmsKey: kmsKey,
+    });
+
+    // Feature Flags Lambdas
+    this.publicFeatureFlagsConstruct = new PublicFeatureFlagsConstruct(this, this.getConstructId('publicFeatureFlagsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
     });
 
     // Export References


### PR DESCRIPTION
## Summary

Fixes the issue where the public feature flags endpoint (`/api/featureFlags`) was returning HTML instead of JSON. The `PublicFeatureFlagsConstruct` class existed but was never instantiated in the public API stack.

## Changes

- Import `PublicFeatureFlagsConstruct` in `lib/public-api-stack/public-api-stack.js`
- Add construct to defaults configuration
- Instantiate the construct to wire up the public GET `/featureFlags` endpoint

## Result

After deployment, the public API will have a working GET `/featureFlags` endpoint that:
- Returns JSON response with structure: `{ code: 200, data: { enablePayments: true }, msg: "Success", ... }`
- Requires no authentication (public endpoint)
- Allows the public frontend to fetch feature flags on app initialization

## Testing

After deployment, verify:
```bash
curl https://[public-api-domain]/api/featureFlags
```

Should return JSON instead of HTML.

## Related

- Issue #113
- Depends on previous feature flag handler fixes