### PR TITLE
fix: remove guest checkout logic - require authentication for bookings (#251)

### DIFF
--- a/src/handlers/transactions/GET/index.js
+++ b/src/handlers/transactions/GET/index.js
@@ -2,7 +2,6 @@
 
 const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
 const { getTransactionByTransactionId } = require("../methods");
-const { getOneByGlobalId, TRANSACTIONAL_DATA_TABLE_NAME } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {
   logger.info("Transactions GET:", event);
@@ -19,7 +18,6 @@ exports.handler = async (event, context) => {
       event?.pathParameters?.clientTransactionId ||
       event?.queryStringParameters?.clientTransactionId;
     const email = event?.queryStringParameters?.email || null;
-    const sessionId = event?.queryStringParameters?.sessionId || null;
 
     if (!clientTransactionId) {
       throw new Exception("Required items are missing", { code: 400 });
@@ -40,7 +38,7 @@ exports.handler = async (event, context) => {
       );
     }
 
-    // Email provided - verify email matches transaction email (for guest/unauthenticated lookup)
+    // Email provided - verify email matches transaction email (for authenticated user lookup)
     if (email) {
       // We capture the user's email in ref3 field, instead of comparing to trnEmailAddress
       if (transactions?.ref3 !== email) {
@@ -51,49 +49,8 @@ exports.handler = async (event, context) => {
       }
       // Email matches, allow access
       return sendResponse(200, transactions, "Success", null, context);
-    } else if (sessionId) {
-      // SessionId provided - verify sessionId matches transaction sessionId (for guest payment retry)
-      if (transactions?.sessionId !== sessionId) {
-        throw new Exception(
-          `Forbidden: Session does not match transaction`,
-          { code: 403 }
-        );
-      }
-      
-      // Validate session hasn't expired by checking the associated booking
-      try {
-        const bookingId = transactions.bookingId;
-        if (!bookingId) {
-          throw new Exception(`Transaction has no associated booking`, { code: 400 });
-        }
-        
-        const booking = await getOneByGlobalId(bookingId, TRANSACTIONAL_DATA_TABLE_NAME, 'globalId', 'globalId-index');
-        
-        if (!booking) {
-          throw new Exception(`Associated booking not found`, { code: 404 });
-        }
-        
-        // Check if session has expired
-        if (booking.sessionExpiry) {
-          const expiryTime = new Date(booking.sessionExpiry).getTime();
-          const now = Date.now();
-          if (now > expiryTime) {
-            logger.warn(`Expired session: booking ${bookingId} expired at ${booking.sessionExpiry}`);
-            throw new Exception("Session has expired", { code: 410 });
-          }
-        }
-      } catch (error) {
-        // If it's already an Exception, re-throw it
-        if (error instanceof Exception) {
-          throw error;
-        }
-        // Otherwise wrap it
-        throw new Exception(`Error validating session: ${error.message}`, { code: 500 });
-      }
-      
-      // SessionId matches and session is valid, allow access
-      return sendResponse(200, transactions, "Success", null, context);
     } else if (userId) {
+      // UserId provided - verify userId matches transaction userId
       if (transactions.userId !== userId) {
         throw new Exception(
           `Forbidden: Access denied`,

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -39,21 +39,6 @@ describe('Base Layer Tests', () => {
       expect(body.other2).toBe(2);
     });
 
-    it('should handle guestSub in headers', () => {
-      const response = sendResponse(200, {}, 'Success', null, null, { guestSub: 'guest123' });
-      expect(response.headers['x-guest-sub']).toBe('guest123');
-      const body = JSON.parse(response.body);
-      expect(body.guestSub).toBeUndefined();
-    });
-
-    it('should handle guestSub with other fields', () => {
-      const response = sendResponse(200, {}, 'Success', null, null, { guestSub: 'guest456', extra: 'data' });
-      expect(response.headers['x-guest-sub']).toBe('guest456');
-      const body = JSON.parse(response.body);
-      expect(body.guestSub).toBeUndefined();
-      expect(body.extra).toBe('data');
-    });
-
     it('should include CORS headers', () => {
       const response = sendResponse(200, {}, 'Success', null, null);
       expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
@@ -109,33 +94,30 @@ describe('Base Layer Tests', () => {
       expect(claims.email).toBe('test@example.com');
     });
 
-    it('should generate guest sub when authorizer is missing', () => {
-      const event = {
-        requestContext: {}
-      };
-      const claims = getRequestClaimsFromEvent(event);
-      expect(claims.sub).toMatch(/^guest-/);
-    });
-
-    it('should generate guest sub when requestContext is missing', () => {
-      const event = {};
-      const claims = getRequestClaimsFromEvent(event);
-      expect(claims.sub).toMatch(/^guest-/);
-    });
-
-    it('should reuse guest sub from Authorization header', () => {
+    it('should return null when authorizer indicates unauthenticated', () => {
       const event = {
         requestContext: {
           authorizer: {
             isAuthenticated: false
           }
-        },
-        headers: {
-          Authorization: 'Guest guest-existing-uuid'
         }
       };
       const claims = getRequestClaimsFromEvent(event);
-      expect(claims.sub).toBe('guest-existing-uuid');
+      expect(claims).toBeNull();
+    });
+
+    it('should return null when authorizer is missing', () => {
+      const event = {
+        requestContext: {}
+      };
+      const claims = getRequestClaimsFromEvent(event);
+      expect(claims).toBeNull();
+    });
+
+    it('should return null when requestContext is missing', () => {
+      const event = {};
+      const claims = getRequestClaimsFromEvent(event);
+      expect(claims).toBeNull();
     });
 
     it('should construct claims from new context format', () => {

--- a/test/transactions/refunds-POST.test.js
+++ b/test/transactions/refunds-POST.test.js
@@ -246,7 +246,7 @@ describe("Transaction Refund POST handler", () => {
     expect(result.message).toContain("Unauthorized");
   });
 
-  it ("should (for now) throw an error if the user is anonymous", async () => {
+  it ("should throw an error if the user is anonymous (guest checkout not allowed)", async () => {
     const mockTransaction = {
       clientTransactionId: mockTransactionId,
       transactionStatus: "paid",


### PR DESCRIPTION
## Summary

Removes the ability for unauthenticated users to create bookings in the reserve-rec-api. This PR implements the backend portion of issue #251.

### Changes Made

- **Base Layer** (`src/layers/base/base.js`):
  - Removed `x-guest-sub` from CORS headers
  - Modified `getRequestClaimsFromEvent()` to return `null` for unauthenticated users instead of generating guest UUIDs
  - Removed all guest UUID generation logic

- **Booking POST Handler** (`src/handlers/bookings/POST/public.js`):
  - Added authentication check: throws 401 error if claims is null or claims.sub is missing
  - Removed guest sub response header logic

- **Transaction GET Handler** (`src/handlers/transactions/GET/index.js`):
  - Removed `sessionId` query parameter support for transaction lookup
  - Removed sessionId verification path for guest payment retry
  - Kept email verification path for authenticated Cognito/federated users
  - Kept userId verification path for authenticated users

- **Tests Updated**:
  - Updated `test/base.test.js` to verify `getRequestClaimsFromEvent()` returns null for unauthenticated users
  - Updated `test/transactions/refunds-POST.test.js` test name to clarify guest checkout not allowed

### Important Notes

- **sessionId is still used** for payment flow integrity (Transaction POST, Worldline callback, booking completion) - only removed from Transaction GET authorization
- **Email-based lookup preserved** for Cognito/federated users (BC Services Card)
- **Frontend changes required** in reserve-rec-public to handle 401 responses and redirect to login

### Acceptance Criteria

- [x] Given I'm not logged in
- [x] When I attempt to create a booking
- [x] Then I receive a 401 Unauthorized error
- [x] Authenticated users can still create bookings normally
- [x] Transaction lookup works for authenticated users via userId or email

### Related PRs

- Frontend PR in reserve-rec-public (to be created)

Fixes #251