### PR TITLE
Change stack creation order to original flow

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -313,9 +313,9 @@ class CDKProject {
 
     const coreStack = await this.addStack('coreStack', createCoreStack);
     const adminIdentityStack = await this.addStack('adminIdentityStack', createAdminIdentityStack);
+    const publicIdentityStack = await this.addStack('publicIdentityStack', createPublicIdentityStack);
     const openSearchStack = await this.addStack('openSearchStack', createOpenSearchStack);
     const transactionalDataStack = await this.addStack('transactionalDataStack', createTransactionalDataStack);
-    const publicIdentityStack = await this.addStack('publicIdentityStack', createPublicIdentityStack);
     const bookingWorkflowStack = await this.addStack('bookingWorkflowStack', createBookingWorkflowStack);
     const emailDispatchStack = await this.addStack('emailDispatchStack', createEmailDispatchStack);
     const referenceDataStack = await this.addStack('referenceDataStack', createReferenceDataStack);

--- a/lib/opensearch-stack/opensearch-stack.js
+++ b/lib/opensearch-stack/opensearch-stack.js
@@ -73,9 +73,9 @@ class OpenSearchStack extends BaseStack {
     const awsUtilsLayer = scope.resolveAwsUtilsLayer(this);
     const kmsKey = scope.resolveKmsKey(this);
 
-    // OpenSearch Indexes - use config values directly
-    const referenceIndexName = this.getConfigValue('opensearchReferenceDataIndexName');
-    const transactionIndexName = this.getConfigValue('opensearchTransactionalDataIndexName');
+    // OpenSearch Indexes
+    const referenceIndexName = scope.resolveOpenSearchReferenceDataIndexName(this);
+    const transactionIndexName = scope.resolveOpenSearchTransactionalDataIndexName(this);
 
     // Setup OpenSearch Cluster
     this.osDomainArn = this.createSearchDomainArn();


### PR DESCRIPTION
When creating the new Public Identity Integration Stack I changed to order of stack creation (remnant from trying to put trigger into public identity stack). Reverting the order and subsequent debugging. 