### PR TITLE
Reduce name length, resolve table name for nested stack

### DIFF
--- a/lib/public-identity-integration-stack/public-identity-integration-stack.js
+++ b/lib/public-identity-integration-stack/public-identity-integration-stack.js
@@ -1,7 +1,8 @@
-const { Duration } = require('aws-cdk-lib');
+const { Duration, CustomResource } = require('aws-cdk-lib');
 const lambda = require('aws-cdk-lib/aws-lambda');
 const cognito = require('aws-cdk-lib/aws-cognito');
 const iam = require('aws-cdk-lib/aws-iam');
+const cr = require('aws-cdk-lib/custom-resources');
 const { StackPrimer } = require("../helpers/stack-primer");
 const { BaseStack } = require('../helpers/base-stack');
 const { logger } = require('../helpers/utils');
@@ -10,7 +11,7 @@ const defaults = {
   description: 'Public Identity Integration stack managing Cognito triggers and cross-stack identity integrations for the Reserve Recreation APIs.',
   constructs: {
     newUserRegisterFunction: {
-      name: 'NewUserRegisterFunction',
+      name: 'PostConfirm',
     },
   },
   config: {
@@ -41,13 +42,6 @@ class PublicIdentityIntegrationStack extends BaseStack {
     const transDataTableArn = scope.resolveTransDataTableArn(this);
     const publicUserPoolId = scope.resolvePublicUserPoolId(this);
 
-    // Import existing User Pool
-    const publicUserPool = cognito.UserPool.fromUserPoolId(
-      this,
-      'ImportedPublicUserPool',
-      publicUserPoolId
-    );
-
     // POST_CONFIRMATION trigger - write new users to DynamoDB
     this.newUserRegisterFunction = new lambda.Function(this, this.getConstructId('newUserRegisterFunction'), {
       functionName: this.getConstructId('newUserRegisterFunction'),
@@ -75,13 +69,48 @@ class PublicIdentityIntegrationStack extends BaseStack {
       resources: [transDataTableArn]
     }));
 
-    // Attach POST_CONFIRMATION trigger to User Pool
-    publicUserPool.addTrigger(
-      cognito.UserPoolOperation.POST_CONFIRMATION,
-      this.newUserRegisterFunction
-    );
+    // Grant Cognito permission to invoke the Lambda
+    this.newUserRegisterFunction.addPermission('CognitoInvokePermission', {
+      principal: new iam.ServicePrincipal('cognito-idp.amazonaws.com'),
+      sourceArn: `arn:aws:cognito-idp:${this.region}:${this.account}:userpool/${publicUserPoolId}`,
+    });
 
-    logger.info(`POST_CONFIRMATION trigger attached to User Pool: ${publicUserPoolId}`);
+    const updateUserPoolTrigger = new cr.AwsCustomResource(this, 'UpdateUserPoolTrigger', {
+      onCreate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'updateUserPool',
+        parameters: {
+          UserPoolId: publicUserPoolId,
+          LambdaConfig: {
+            PostConfirmation: this.newUserRegisterFunction.functionArn
+          }
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`${publicUserPoolId}-post-confirmation-trigger`)
+      },
+      onUpdate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'updateUserPool',
+        parameters: {
+          UserPoolId: publicUserPoolId,
+          LambdaConfig: {
+            PostConfirmation: this.newUserRegisterFunction.functionArn
+          }
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`${publicUserPoolId}-post-confirmation-trigger`)
+      },
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['cognito-idp:UpdateUserPool', 'cognito-idp:DescribeUserPool'],
+          resources: [`arn:aws:cognito-idp:${this.region}:${this.account}:userpool/${publicUserPoolId}`]
+        })
+      ])
+    });
+
+    // Ensure Custom Resource runs after Lambda is created
+    updateUserPoolTrigger.node.addDependency(this.newUserRegisterFunction);
+
+    logger.info(`POST_CONFIRMATION trigger configured for User Pool: ${publicUserPoolId}`);
   }
 }
 

--- a/lib/transactional-data-stack/transactional-data-stack.js
+++ b/lib/transactional-data-stack/transactional-data-stack.js
@@ -176,8 +176,8 @@ class TransactionalDataStack extends BaseStack {
     // Transactional Data Table ARN
     this.exportReference(this, 'transactionalDataTableArn', this.getTransDataTableArn(), `ARN of the transactional data DynamoDB table in ${this.stackId}`);
 
-    scope.resolveTransDataTableName = this.getTransDataTableName.bind(this);
-    scope.resolveTransDataTableArn = this.getTransDataTableArn.bind(this);
+    scope.resolveTransDataTableName = this.resolveTransDataTableName.bind(this);
+    scope.resolveTransDataTableArn = this.resolveTransDataTableArn.bind(this);
   }
 
   getTransDataTableName() {
@@ -186,6 +186,14 @@ class TransactionalDataStack extends BaseStack {
 
   getTransDataTableArn() {
     return this.transDataTable.tableArn;
+  }
+
+  resolveTransDataTableName(consumerScope) {
+    return this.resolveReference(consumerScope, this.getExportSSMPath('transactionalDataTableName'));
+  }
+
+  resolveTransDataTableArn(consumerScope) {
+    return this.resolveReference(consumerScope, this.getExportSSMPath('transactionalDataTableArn'));
   }
 }
 


### PR DESCRIPTION
Lambda name was too long. Reduce length. 

Update way table name is resolved for nested stacks. 