### PR TITLE
Add missing names for nested stacks

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -79,6 +79,12 @@ const defaults = {
     usersConstruct: {
       name: 'UsersConstruct',
     },
+    usersNestedStack: {
+      name: 'UsersNestedStack',
+    },
+    bookingsNestedStack: {
+      name: 'BookingsNestedStack',
+    },
     verifyConstruct: {
       name: 'VerifyConstruct',
     },


### PR DESCRIPTION
There was two missing names for nested stacks causing errors in deployment.