### PR TITLE
PRDT-73: Allow public identity stack dynamo Get operations

### DIFF
--- a/lib/public-identity-integration-stack/public-identity-integration-stack.js
+++ b/lib/public-identity-integration-stack/public-identity-integration-stack.js
@@ -63,6 +63,7 @@ class PublicIdentityIntegrationStack extends BaseStack {
     this.newUserRegisterFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [
+        'dynamodb:GetItem',
         'dynamodb:PutItem',
         'dynamodb:UpdateItem',
       ],


### PR DESCRIPTION
Congnito trigger needs permissions to get from dynamo. 