### PR TITLE
feat: PRDT-165-2 - adding productDate bulk operations (GET, POST, DELETE)

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -23,6 +23,7 @@ const { VerifyConstruct } = require('../../src/handlers/verify/constructs');
 const { ReportsConstruct } = require('../../src/handlers/reports/constructs');
 const { RelationshipsConstruct } = require('../../src/handlers/relationships/constructs');
 const { AdminFeatureFlagsConstruct } = require('../../src/handlers/featureFlags/constructs');
+const { ProductManagementNestedStack } = require('./product-management-stack/product-management-stack');
 
 
 const defaults = {
@@ -94,6 +95,12 @@ const defaults = {
     featureFlagsConstruct: {
       name: 'FeatureFlagsConstruct',
     },
+    productManagementStack: {
+      name: 'ProductManagementStack',
+    },
+    productDatesConstruct: {
+      name: 'ProductDatesConstruct',
+    }
   },
   config: {
     corsPreflightAllowHeaders: [
@@ -332,7 +339,7 @@ class AdminApiStack extends BaseStack {
     // Use NestedStack for AWS deployments (to avoid 500 resource limit)
     // Use direct Construct for local development (SAM doesn't support NestedStacks)
     const isLocal = this.node.tryGetContext('@context') === 'local';
-    
+
     const usersProps = {
       environment: {
         LOG_LEVEL: this.getConfigValue('logLevel'),
@@ -360,8 +367,7 @@ class AdminApiStack extends BaseStack {
       this.usersConstruct = this.usersNestedStack.usersConstruct;
     }
 
-    // Policies Lambdas
-    this.policiesConstruct = new PoliciesConstruct(this, this.getConstructId('policiesConstruct'), {
+    const productManagementProps = {
       environment: {
         LOG_LEVEL: this.getConfigValue('logLevel'),
         REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
@@ -372,8 +378,12 @@ class AdminApiStack extends BaseStack {
       ],
       api: this.adminApi,
       authorizer: requestAuthorizer,
-      handlerPrefix: 'admin',
-    });
+      openSearchDomainArn: opensearchDomainArn,
+    };
+
+    logger.info('Deploying ProductManagementStack (nested)');
+    this.productManagementStack = new ProductManagementNestedStack(this, this.getConstructId('productManagementStack'), productManagementProps);
+    this.productDatesConstruct = this.productManagementStack.productDatesConstruct;
 
     // Bookings Lambdas
     // Use NestedStack for AWS deployments (to avoid 500 resource limit)

--- a/lib/admin-api-stack/product-management-stack/product-management-stack.js
+++ b/lib/admin-api-stack/product-management-stack/product-management-stack.js
@@ -1,0 +1,26 @@
+const { NestedStack } = require('aws-cdk-lib');
+const { ProductDatesConstruct } = require('../../../src/handlers/productDates/constructs');
+
+class ProductManagementNestedStack extends NestedStack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    // Provide a concrete identifier for child constructs to use (instead of token-based stackId)
+    // This is used by LambdaConstruct for building resource IDs
+    this.concreteStackId = `${scope.stackId}-Pmgmt`;
+    this.createScopedId = scope.createScopedId?.bind(scope);
+    this.appScope = scope.appScope;
+
+    // Initialize ProductDatesConstruct
+    this.productDatesConstruct = new ProductDatesConstruct(this, 'ProductDatesConstruct', {
+      environment: props.environment,
+      layers: props.layers,
+      api: props.api,
+      authorizer: props.authorizer,
+      handlerPrefix: props.handlerPrefix,
+    });
+
+  }
+}
+
+module.exports = { ProductManagementNestedStack };

--- a/src/common/data-utils.js
+++ b/src/common/data-utils.js
@@ -242,9 +242,6 @@ async function quickApiPutHandler(tableName, createList, config) {
         // set the api config for the item
         let itemConfig = item?.config ? item.config : config;
         let itemData = item?.data;
-        
-        logger.debug(`[quickApiPutHandler] itemData keys: ${Object.keys(itemData).join(', ')}`);
-        logger.debug(`[quickApiPutHandler] itemData.collectionId: ${itemData.collectionId}`);
 
         if (Object.keys(itemData).length === 0) {
           throw new Exception(`No field data provided with item.`, { code: 400, error: `Item data should be of the form: {field: <value>}` });
@@ -253,14 +250,11 @@ async function quickApiPutHandler(tableName, createList, config) {
         // If overwrites are allowed, check if the item already exists
         let existingItem = null;
         if (itemConfig?.allowOverwrite) {
-          existingItem = await getOne(itemData.pk, itemData.sk);
+          existingItem = await getOne(itemData?.pk, itemData?.sk);
         }
 
         // Build the validation request
         let dataToValidate = buildValidationRequest(itemData, itemConfig?.fields);
-        
-        logger.debug(`[quickApiPutHandler] dataToValidate keys: ${Object.keys(dataToValidate).join(', ')}`);
-        logger.debug(`[quickApiPutHandler] dataToValidate.collectionId: ${JSON.stringify(dataToValidate.collectionId)}`);
 
         // validate the request data using the config
         validateRequestData(dataToValidate, itemConfig);
@@ -293,6 +287,7 @@ async function quickApiPutHandler(tableName, createList, config) {
 
         createItems.push(createCommand);
       } catch (error) {
+        console.log(`error with ${JSON.stringify(item, null, 2)}`);
         if (config?.failOnError) {
           throw error;
         }
@@ -506,8 +501,96 @@ async function getAndAttachNestedProperties(item, properties) {
   }
 }
 
+function formatForQuickApi(itemArray) {
+  return itemArray.map((item) => {
+    return {
+      key: {
+        pk: item.pk,
+        sk: item.sk,
+      },
+      data: item,
+    };
+  });
+}
+
 function generateGlobalId() {
   return crypto.randomUUID();
+}
+
+function resolveTemporalWindow(temporalWindow, timezone, refStore = {}) {
+  const resolvedWindow = {
+    id: temporalWindow?.id,
+    label: temporalWindow?.label,
+    open: resolveTemporalAnchor(temporalWindow?.open, timezone, refStore),
+    close: resolveTemporalAnchor(temporalWindow?.close, timezone, refStore)
+  };
+  refStore[resolvedWindow.id] = {
+    open: resolvedWindow.open,
+    close: resolvedWindow.close
+  };
+  return resolvedWindow;
+}
+
+function resolveTemporalAnchor(temporalAnchor, timezone, refStore = {}) {
+  // Get calendar date
+  let anchorRef = null;
+  if (temporalAnchor?.anchorRef) {
+    let refComponents = temporalAnchor?.anchorRef?.split('.');
+    function getNestedRef(refObj, refComponents, idx = 0) {
+      if (!refObj || idx >= refComponents.length) return refObj;
+      return getNestedRef(refObj[refComponents[idx]], refComponents, idx + 1);
+    }
+    anchorRef = getNestedRef(refStore, refComponents);
+  } else if (temporalAnchor?.fixedDateTime) {
+    anchorRef = temporalAnchor.fixedDateTime;
+  }
+
+
+  if (!anchorRef) {
+    throw new Exception(`Unable to resolve temporal anchor with id ${temporalAnchor?.id}. No anchorRef or fixedDateTime provided, or anchorRef is invalid (fixedDateTime=${temporalAnchor?.fixedDateTime}, anchorRef=${temporalAnchor?.anchorRef}). `, { code: 400 });
+  }
+
+  // Split anchorRef into calendar date and time components (if time component is not provided, we only care about calendardate.)
+  // If time is not provided, and timeOfDay is not set, and keepInputTime is not set, then input time will not be considered.
+  const expectDateTimeFormat = Boolean(temporalAnchor?.timeOfDay || temporalAnchor?.keepInputTime);
+  let [calendarDate, time] = splitDateTime(anchorRef, true);
+
+  // Apply duration offset
+  if (temporalAnchor?.duration) {
+    let initDate = DateTime.fromISO(`${calendarDate}T00:00:00`, { zone: timezone });
+    const direction = temporalAnchor.duration?.direction || 'before';
+    const durObj = { ...temporalAnchor.duration };
+    delete durObj.direction;
+    const duration = Duration.fromObject(durObj);
+    let adjustedDate = direction === 'before' ? initDate.minus(duration) : initDate.plus(duration);
+    calendarDate = splitDateTime(adjustedDate.toISO(), false);
+  }
+
+  // Set final time of day if provided.
+
+  if (temporalAnchor?.timeOfDay) {
+    const { hour, minute, second } = temporalAnchor.timeOfDay;
+    let adjustedDate = DateTime.fromISO(`${calendarDate}T00:00:00`, { zone: timezone }).set({ hour, minute, second });
+    [calendarDate, time] = splitDateTime(adjustedDate.toISO(), true);
+  } else if (temporalAnchor?.keepInputTime && time) {
+    let adjustedDate = DateTime.fromISO(`${calendarDate}T${time}`, { zone: timezone });
+    [calendarDate, time] = splitDateTime(adjustedDate.toISO(), true);
+  }
+
+
+  if (expectDateTimeFormat) {
+    if (!time) {
+      throw new Exception(`Temporal anchor with id ${temporalAnchor?.id} is expected to resolve to a date-time format, but no time component could be resolved. Please ensure that the anchorRef resolves to a date-time string, or that timeOfDay or keepInputTime is set on the temporal anchor.`, { code: 400 });
+    }
+    const finalDateTime = `${calendarDate}T${time}`;
+    refStore[temporalAnchor?.id] = finalDateTime;
+    return finalDateTime;
+  }
+
+  refStore[temporalAnchor?.id] = calendarDate;
+
+  return calendarDate;
+
 }
 
 module.exports = {
@@ -515,6 +598,9 @@ module.exports = {
   getAndAttachNestedProperties,
   getNextIdentifier,
   generateGlobalId,
+  formatForQuickApi,
   quickApiPutHandler,
   quickApiUpdateHandler,
+  resolveTemporalAnchor,
+  resolveTemporalWindow
 };

--- a/src/handlers/productDates/_productId/DELETE/admin.js
+++ b/src/handlers/productDates/_productId/DELETE/admin.js
@@ -1,0 +1,36 @@
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { deleteProductDates } = require("../../methods");
+
+exports.handler = async (event, context) => {
+  logger.info("DELETE Product Dates", event);
+  try {
+
+    const body = JSON.parse(event?.body);
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("collectionId, activityType, activityId, and productId are required in the path", { code: 400 });
+    }
+
+    const startDate = body?.startDate || null;
+    const endDate = body?.endDate || null;
+
+    const deletedItemCount = await deleteProductDates(collectionId, activityType, activityId, productId, startDate, endDate);
+
+    return sendResponse(200, null, `Product Dates deleted successfully. Total deleted: ${deletedItemCount}`, null, context);
+
+  } catch (error) {
+    logger.error("Error deleting Product Dates", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+}

--- a/src/handlers/productDates/_productId/GET/admin.js
+++ b/src/handlers/productDates/_productId/GET/admin.js
@@ -1,0 +1,50 @@
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { fetchProductDates } = require("../../methods");
+
+exports.handler = async (event, context) => {
+  logger.info("GET Product Dates", event);
+  try {
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("collectionId, activityType, activityId, and productId are required in the path", { code: 400 });
+    }
+
+    let startDate = event?.queryStringParameters?.startDate || null;
+    let endDate = event?.queryStringParameters?.endDate || null;
+
+    let bypassDiscoveryRules = event?.queryStringParameters?.bypassDiscoveryRules === 'true' ? true : false;
+
+    // If startDate and endDate are not provided, we will return the next two weeks of ProductDates for the Product by default. This is to prevent accidentally returning a huge amount of data if someone forgets to provide a date range.
+
+    if (!startDate) {
+      const today = new Date();
+      const twoWeeksFromToday = new Date(today);
+      twoWeeksFromToday.setDate(today.getDate() + 14);
+      startDate = today.toISOString().split('T')[0];
+      endDate = twoWeeksFromToday.toISOString().split('T')[0];
+    } else if (!endDate) {
+      endDate = startDate;
+    }
+
+    logger.debug(`Fetching Product Dates for Product ${collectionId}::${activityType}::${activityId}::${productId} with startDate ${startDate} and endDate ${endDate}. Bypass discovery rules: ${bypassDiscoveryRules}`);
+
+    const productDates = await fetchProductDates(collectionId, activityType, activityId, productId, startDate, endDate, bypassDiscoveryRules);
+
+    return sendResponse(200, productDates, "Success", null, context);
+
+  } catch (error) {
+    logger.error("Error fetching Product Dates", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/src/handlers/productDates/_productId/POST/admin.js
+++ b/src/handlers/productDates/_productId/POST/admin.js
@@ -1,0 +1,101 @@
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { initializeProductDates } = require("../../methods");
+const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+const { quickApiPutHandler, formatForQuickApi } = require("../../../../common/data-utils");
+const { PRODUCTDATE_API_PUT_CONFIG, AVAILABILITYSIGNAL_API_PUT_CONFIG } = require("../../configs");
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 100;
+
+exports.handler = async (event, context) => {
+  logger.info("POST Product Dates", event);
+  try {
+
+    // Validate required parameters from body.
+    // We need a Product and a date range to create ProductDates
+    // We need a collectionId, activityType, activityId, and productId to identify the Product
+    // These should all come from the event path
+
+    const body = JSON.parse(event?.body);
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    // Start and end dates make up the date range and should optionally from the event body
+    // If not provided, we will use the Product's rangeStart and rangeEnd properties.
+
+    const startDate = body?.startDate || null;
+    const endDate = body?.endDate || null;
+
+    // Initialize ProductDates
+
+    const { productDates, availabilitySignals } = await initializeProductDates(collectionId, activityType, activityId, productId, startDate, endDate);
+
+    console.log('productDates.length:', productDates.length);
+    console.log('availabilitySignals.length:', availabilitySignals.length);
+
+    // Use quickApiPutHandler to create the put items
+
+    // TODO Turn off developerMode and properly vet the incoming data before writing to DynamoDB. For now, developerMode allows us to skip some validation and write directly to DynamoDB for faster testing.
+    const productDatesPutItems = await quickApiPutHandler(
+      REFERENCE_DATA_TABLE_NAME,
+      formatForQuickApi(productDates),
+      PRODUCTDATE_API_PUT_CONFIG
+    );
+
+    // TODO Turn off developerMode and properly vet the incoming data before writing to DynamoDB. For now, developerMode allows us to skip some validation and write directly to DynamoDB for faster testing.
+    const availabilitySignalsPutItems = await quickApiPutHandler(
+      REFERENCE_DATA_TABLE_NAME,
+      formatForQuickApi(availabilitySignals),
+      AVAILABILITYSIGNAL_API_PUT_CONFIG
+    );
+
+    // Shuffle them together like Shaggy would shuffle a loaf of bread and an entire salami - one from each at a time
+    // We want to write them in the same transaction to ensure they are always in sync. If we wrote all ProductDates first and then all AvailabilitySignals, there is an increased risk that something could go wrong in between and we would end up with ProductDates but no AvailabilitySignals, which could cause issues for our application.
+
+    const itemCount = productDatesPutItems.length;
+
+    const allPutItems = [];
+    while (productDatesPutItems.length > 0) {
+      allPutItems.push(productDatesPutItems.shift());
+      allPutItems.push(availabilitySignalsPutItems.shift());
+    }
+
+    logger.info(`Prepared ${allPutItems.length} items for batch writing to DynamoDB (ProductDates and AvailabilitySignals)`);
+
+    // Batch write them to DynamoDB
+    let attempt = 0;
+    let success = false;
+    while (attempt <= MAX_RETRIES && !success) {
+      attempt++;
+      try {
+        await batchTransactData(allPutItems);
+        success = true;
+        logger.info(`Successfully wrote ProductDates and AvailabilitySignals to DynamoDB on attempt ${attempt}`);
+      }
+      catch (error) {
+        if (attempt > MAX_RETRIES) {
+          logger.error(`Failed to write ProductDates and AvailabilitySignals after ${MAX_RETRIES} attempts`, error);
+          throw error;
+        }
+        logger.warn(`Attempt ${attempt} failed to write ProductDates and AvailabilitySignals. Retrying in ${RETRY_DELAY_MS}ms...`, error);
+        await new Promise(resolve => setTimeout(resolve, attempt * RETRY_DELAY_MS));
+      }
+    }
+
+    return sendResponse(200, [], `Successfully initialized ${itemCount} ProductDates for Product ${productId} with activity ${activityType} ${activityId}`, null, context);
+
+  } catch (error) {
+    logger.error("Error in POST Product Dates", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || error.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};
+

--- a/src/handlers/productDates/configs.js
+++ b/src/handlers/productDates/configs.js
@@ -1,0 +1,65 @@
+const { rulesFns } = require('../../common/validation-rules');
+const { ACTIVITY_TYPE_ENUMS, SUB_ACTIVITY_TYPE_ENUMS } = require('../../common/data-constants');
+
+const rf = new rulesFns();
+
+const ALLOWED_FILTERS = [
+  { name: "isVisible", type: "boolean" },
+  { name: "activityType", type: "list" },
+  { name: "productId", type: "string" },
+];
+
+// TODO complete later (remove developerMode)
+const PRODUCTDATE_API_PUT_CONFIG = {
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  developerMode: true,
+  autoGlobalId: true,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+  }
+};
+
+// TODO complete later (remove developerMode)
+const AVAILABILITYSIGNAL_API_PUT_CONFIG = {
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  developerMode: true,
+
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    }
+  }
+};
+
+module.exports = {
+  PRODUCTDATE_API_PUT_CONFIG,
+  AVAILABILITYSIGNAL_API_PUT_CONFIG,
+};

--- a/src/handlers/productDates/constructs.js
+++ b/src/handlers/productDates/constructs.js
@@ -1,0 +1,95 @@
+const { Duration } = require("aws-cdk-lib");
+const { LambdaConstruct } = require("../../../lib/helpers/base-lambda");
+const apigw = require("aws-cdk-lib/aws-apigateway");
+
+const defaults = {
+  resources: {
+    productDatesGetFunction: {
+      name: 'ProductDatesGET',
+    },
+    productDatesPostFunction: {
+      name: 'ProductDatesPOST',
+    },
+    productDatesPutFunction: {
+      name: 'ProductDatesPUT',
+    },
+    productDatesDeleteFunction: {
+      name: 'ProductDatesDELETE',
+    }
+  }
+};
+
+class ProductDatesConstruct extends LambdaConstruct {
+  constructor(scope, id, props) {
+    super(scope, id, {
+      ...props,
+      defaults: defaults
+    });
+
+    const handlerPrefix = props?.handlerPrefix || 'admin';
+    const handlerName = `${handlerPrefix}.handler`;
+
+    // Add /product-dates resource
+    this.productDatesResource = this.resolveApi().root.addResource('product-dates');
+
+    // Add /product-dates/{collectionId}/{activityType}/{activityId}/{productId} resource
+    this.productDatesByProductResource = this.productDatesResource.addResource('{collectionId}').addResource('{activityType}').addResource('{activityId}').addResource('{productId}');
+
+    // // ProductDates GET by Product ID Lambda Function
+    this.productDatesGetByDatesFunction = this.generateBasicLambdaFn(
+      scope,
+      'productDatesGetFunction',
+      'src/handlers/productDates/_productId/GET',
+      handlerName,
+      {
+        basicRead: true,
+      }
+    );
+
+    // ProductDates POST by Product ID & dates Lambda Function
+    this.productDatesPostByDatesFunction = this.generateBasicLambdaFn(
+      scope,
+      'productDatesPostFunction',
+      'src/handlers/productDates/_productId/POST',
+      handlerName,
+      {
+        basicReadWrite: true,
+        timeout: Duration.minutes(1),
+      }
+    );
+
+    // ProductDates DELETE by Product ID & dates Lambda Function
+    this.productDatesDeleteByDatesFunction = this.generateBasicLambdaFn(
+      scope,
+      'productDatesDeleteFunction',
+      'src/handlers/productDates/_productId/DELETE',
+      handlerName,
+      {
+        basicReadWrite: true,
+        timeout: Duration.minutes(1),
+      }
+    );
+
+    // GET /product-dates/{collectionId}/{activityType}/{activityId}/{productId}
+    this.productDatesByProductResource.addMethod('GET', new apigw.LambdaIntegration(this.productDatesGetByDatesFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+
+    // POST /product-dates/{collectionId}/{activityType}/{activityId}/{productId}
+    this.productDatesByProductResource.addMethod('POST', new apigw.LambdaIntegration(this.productDatesPostByDatesFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+
+    // DELETE /product-dates/{collectionId}/{activityType}/{activityId}/{productId}
+    this.productDatesByProductResource.addMethod('DELETE', new apigw.LambdaIntegration(this.productDatesDeleteByDatesFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+  }
+}
+
+module.exports = {
+  ProductDatesConstruct,
+};

--- a/src/handlers/productDates/methods.js
+++ b/src/handlers/productDates/methods.js
@@ -1,0 +1,286 @@
+const { logger, Exception } = require("/opt/base");
+const { getOne, batchTransactData, runQuery, REFERENCE_DATA_TABLE_NAME } = require("/opt/dynamodb");
+const { getProductById } = require("../products/methods");
+const { buildDateRange } = require("/opt/base");
+const { DateTime } = require("luxon");
+const { resolveTemporalAnchor, resolveTemporalWindow } = require("../../common/data-utils");
+
+async function fetchProductDates(queryTime = null, collectionId, activityType, activityId, productId, startDate, endDate, bypassDiscoveryRules = false) {
+  try {
+
+    if (!queryTime) {
+      queryTime = new Date().toISOString();
+    }
+
+    const productDatePK = `productDate::${collectionId}::${activityType}::${activityId}::${productId}`;
+
+    // create query to fetch ProductDates within the specified date range
+    let query = {
+      TableName: REFERENCE_DATA_TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk AND sk BETWEEN :startDate AND :endDate',
+      ExpressionAttributeValues: {
+        ':pk': { S: productDatePK },
+        ':startDate': { S: startDate },
+        ':endDate': { S: endDate }
+      }
+    };
+
+    if (!bypassDiscoveryRules) {
+      query.FilterExpression = 'reservationContext.isDiscoverable = :isDiscoverable AND reservationContext.temporalWindows.discoveryWindow.#open <= :currentDateTime AND reservationContext.temporalWindows.discoveryWindow.#close >= :currentDateTime';
+      query.ExpressionAttributeNames = {
+        '#open': 'open',
+        '#close': 'close'
+      };
+      query.ExpressionAttributeValues[':isDiscoverable'] = { BOOL: true };
+      query.ExpressionAttributeValues[':currentDateTime'] = { S: queryTime };
+    }
+
+    logger.info(`Querying ProductDates for Product ${productId} with activity '${activityType} ${activityId}' between dates ${startDate} and ${endDate}. Bypass discovery rules: ${bypassDiscoveryRules}`, { query });
+
+    const result = await runQuery(query);
+
+    return result;
+
+  } catch (error) {
+    logger.error("Error in fetchProductDates", error);
+    throw error;
+  }
+}
+
+async function initializeProductDates(collectionId, activityType, activityId, productId, startDate = null, endDate = null) {
+  try {
+
+    // Fetch the parent product
+    const product = await getProductById(collectionId, activityType, activityId, productId);
+
+    if (!product) {
+      throw new Exception(`Product not found for collectionId: ${collectionId}, activityType: ${activityType}, activityId: ${activityId}, productId: ${productId}`, { code: 404 });
+    }
+
+    // Ensure correct date range is being used. Default to Product rangeStart and rangeEnd if startDate and endDate are not provided
+
+    let effectiveStartDate = startDate || product?.rangeStart;
+    let effectiveEndDate = endDate || product?.rangeEnd;
+
+    // effectiveStartDate is mandatory, but effectiveEndDate is optional (if not provided, ProductDates will be created for a single date rather than a date range)
+
+    if (!effectiveStartDate) {
+      throw new Exception(`Start date is required for ProductDates initialization`, { code: 400 });
+    }
+
+    if (!effectiveEndDate) {
+      effectiveEndDate = effectiveStartDate;
+    }
+
+    // Get the policies associated with the Product
+
+    let reservationPolicy = await getOne(product?.reservationPolicy?.primaryKey?.pk, product?.reservationPolicy?.primaryKey?.sk);
+    let partyPolicy = await getOne(product?.partyPolicy?.primaryKey?.pk, product?.partyPolicy?.primaryKey?.sk);
+    let changePolicy = await getOne(product?.changePolicy?.primaryKey?.pk, product?.changePolicy?.primaryKey?.sk);
+    let feePolicy = await getOne(product?.feePolicy?.primaryKey?.pk, product?.feePolicy?.primaryKey?.sk);
+
+    // initialize array of ProductDates
+
+    let productDates = [];
+    let availabilitySignals = [];
+
+    // Build the date range for the ProductDates to be created for
+
+    const dates = buildDateRange(effectiveStartDate, effectiveEndDate);
+
+    // Loop through the date range and create a ProductDate for each date
+
+    for (const date of dates) {
+
+      // Initialize availability signal for the ProductDate
+      let availabilitySignal = initializeAvailabilitySignal(product, date);
+      availabilitySignals.push(availabilitySignal);
+
+      // Initialize the ProductDate
+
+      let productDate = {
+        pk: `productDate::${collectionId}::${activityType}::${activityId}::${productId}`,
+        sk: date,
+        collectionId: collectionId,
+        schema: 'productDate',
+        activityType: activityType,
+        activityId: activityId,
+        productId: productId,
+        date: date,
+        displayName: `${product?.displayName} - ${date}`,
+        availabilitySignal: {
+          pk: availabilitySignal.pk,
+          sk: availabilitySignal.sk,
+        },
+        // No need to store allDatesBookedIntervalIds for now - there will be none for DUP.
+        // allDatesBookedIntervalIds: getAllDatesBookedIntervalIds(product, date),
+        assetList: product?.assetList || [],
+        reservationPolicy: reservationPolicy?.productDateRules,
+        reservationContext: resolveProductDateReservationContext(product, date, reservationPolicy),
+        partyPolicy: partyPolicy,
+        changePolicy: changePolicy,
+        feePolicy: feePolicy,
+        // No need to store feeContext for now - DUP is free.
+        // feeContext: resolveProductDateFeeContext(product, date, feePolicy)
+      };
+      productDates.push(productDate);
+    }
+
+    logger.debug(`Initialized ${productDates?.length} ProductDates and corresponding AvailabilitySignals for Product ${productId} with activity '${activityType} ${activityId}' between dates ${effectiveStartDate} and ${effectiveEndDate}`);
+
+
+    return { productDates, availabilitySignals };
+
+  } catch (error) {
+    logger.error("Error in initializeProductDates", error);
+    throw error;
+  }
+}
+
+function initializeAvailabilitySignal(product, date) {
+  let availabilitySignal = {
+    pk: `availabilitySignal::${product.collectionId}::${product.activityType}::${product.activityId}::${product.productId}`,
+    sk: date,
+    schema: "availabilitySignal",
+    value: "high", // this will be updated by the availability signal process
+    availabilityEstimationPattern: product?.availabilityEstimationPattern,
+    expiry: getExpiryForAvailabilitySignal(date, product?.timezone || 'America/Vancouver') // set expiry based on the ProductDate date
+  };
+  return availabilitySignal;
+}
+
+function getExpiryForAvailabilitySignal(date, timezone = 'UTC') {
+  // Availability signals should expire when the ProductDate date has passed. For simplicity, this will be midnight on the ProductDate date.
+  const productDate = DateTime.fromISO(date, { zone: timezone });
+  const expiryDate = productDate.endOf('day'); // set expiry to the end of the ProductDate day (i.e. when the date has passed)
+  return expiryDate.toISO(); // return expiry as a Unix timestamp
+}
+
+function getAllDatesBookedIntervalIds(product, date) {
+  let ids = [];
+  // for every AllDatesBookedInterval in the Product, check if the date falls within the interval. If so, add the interval id to the ProductDate's allDatesBookedIntervalIds array
+  for (const interval of product?.allDatesBookedIntervals || []) {
+    if (interval.startDate <= date && interval.endDate >= date) {
+      ids.push(interval?.id);
+    }
+  }
+  return ids;
+}
+
+function resolveProductDateReservationContext(product, date, reservationPolicy) {
+  const productDateReservationPolicy = reservationPolicy?.productDateRules;
+  let temporalAnchors = productDateReservationPolicy?.temporalAnchors || {};
+  let resolvedTemporalAnchors = {};
+  let temporalWindows = productDateReservationPolicy?.temporalWindows || {};
+  let resolvedTemporalWindows = {};
+  let refStore = {
+    productDate: date
+  };
+
+  for (const anchor of temporalAnchors) {
+    resolvedTemporalAnchors[anchor?.id] = resolveTemporalAnchor(anchor, product?.timezone, refStore);
+  }
+
+  for (const window of temporalWindows) {
+    resolvedTemporalWindows[window?.id] = resolveTemporalWindow(window, product?.timezone, refStore);
+  }
+  const policy = {
+    isDiscoverable: productDateReservationPolicy?.isDiscoverable || true,
+    isReservable: productDateReservationPolicy?.isReservable || true,
+    minDailyInventory: productDateReservationPolicy?.minDailyInventory || 1,
+    maxDailyInventory: productDateReservationPolicy?.maxDailyInventory || 1,
+    temporalWindows: resolvedTemporalWindows
+  };
+  return policy;
+}
+
+
+
+function splitDateTime(dateTime, includeTime = false) {
+
+  let calendarDate, time;
+
+  if (includeTime) {
+    if (dateTime.includes('T')) {
+      [calendarDate, time] = dateTime.split('T');
+    } else {
+      calendarDate = dateTime;
+      time = '00:00:00';
+    }
+    return [calendarDate, time];
+  } else {
+    if (dateTime.includes('T')) {
+      calendarDate = dateTime.split('T')[0];
+    } else {
+      calendarDate = dateTime;
+    }
+    return calendarDate;
+  }
+
+}
+
+async function deleteProductDates(collectionId, activityType, activityId, productId, startDate = null, endDate = null) {
+
+  try {
+    // if date range not provided, try to pull it from the Product
+    if (!startDate) {
+      const product = await getProductById(collectionId, activityType, activityId, productId);
+      startDate = startDate || product?.rangeStart;
+      endDate = endDate || product?.rangeEnd;
+    }
+
+    if (!startDate) {
+      throw new Exception(`Start date and end date are required to delete ProductDates. If not provided in the request, they will be pulled from the Product. Please ensure that the Product has rangeStart and rangeEnd properties if not providing startDate and endDate in the request.`, { code: 400 });
+    }
+
+    // create bulk delete requests
+
+    if (!endDate) {
+      endDate = startDate;
+    }
+
+    let deleteItems = [];
+    const dates = buildDateRange(startDate, endDate);
+
+    let productDatePK = `productDate::${collectionId}::${activityType}::${activityId}::${productId}`;
+
+    // we have to delete the availability signals too
+
+    let availabilitySignalPK = `availabilitySignal::${collectionId}::${activityType}::${activityId}::${productId}`;
+
+    for (const date of dates) {
+      deleteItems.push({
+        TableName: REFERENCE_DATA_TABLE_NAME,
+        Key: {
+          pk: {S: productDatePK},
+          sk: {S: date}
+        }
+      });
+      deleteItems.push({
+        TableName: REFERENCE_DATA_TABLE_NAME,
+        Key: {
+          pk: {S: availabilitySignalPK},
+          sk: {S: date}
+        }
+      });
+    }
+
+    logger.info(`Deleting ${deleteItems.length} ProductDate items for Product ${productId} with activity '${activityType} ${activityId}' between dates ${startDate} and ${endDate}`);
+
+    await batchTransactData(deleteItems, 'Delete');
+
+    logger.info(`Successfully deleted ${deleteItems.length} ProductDate items for Product ${productId} with activity '${activityType} ${activityId}' between dates ${startDate} and ${endDate}`);
+    return deleteItems.length / 2; // divide by 2 because we are deleting both ProductDates and AvailabilitySignals
+
+  } catch (error) {
+    logger.error("Error in deleteProductDates", error);
+    throw error;
+  }
+
+}
+
+module.exports = {
+  deleteProductDates,
+  fetchProductDates,
+  initializeProductDates,
+};

--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -76,7 +76,7 @@ async function getProductsByCollectionId(collectionId, activityType, activityId,
     const limit = params?.limit || null;
     const lastEvaluatedKey = params?.lastEvaluatedKey || null;
     const paginated = params?.paginated || true;
-    
+
     let queryObj = {
       TableName: REFERENCE_DATA_TABLE_NAME,
       KeyConditionExpression: "pk = :pk",
@@ -135,7 +135,7 @@ async function getProductsByActivityType(
     const limit = params?.limit || null;
     const lastEvaluatedKey = params?.lastEvaluatedKey || null;
     const paginated = params?.paginated || true;
-    
+
     let queryObj = {
       TableName: REFERENCE_DATA_TABLE_NAME,
       KeyConditionExpression: "pk = :pk",
@@ -176,10 +176,10 @@ async function getProductsByActivityType(
  * @throws {Exception} With code 400 if database operation fails
  */
 async function getProductByProductId(
-  collectionId, 
-  activityType, 
+  collectionId,
+  activityType,
   activityId,
-  productId, 
+  productId,
 ) {
   logger.info("Get Product By ProductId");
   try {
@@ -256,7 +256,7 @@ async function processItem(
   if (!collectionId) {
     throw new Error(`collectionId is required`, { code: 400 });
   }
-  
+
   if (!activityType && !item.activityType) {
     throw new Error(`activityType is not specified in one of the requests.`, { code: 400 });
   }
@@ -422,7 +422,7 @@ async function getProductsByActivity(orcs, activityType, activityId) {
 async function getProductById(orcs, activityType, activityId, productId, fetchObj = null, startDate = null, endDate = null) {
   logger.info('Get Product By Id');
   try {
-    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}::properties`);
+    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}`);
     let promiseObj = {};
     if (fetchObj?.fetchPolicies) {
       POLICY_TYPES.map(policyType => {


### PR DESCRIPTION
Relates to [#165](https://github.com/bcgov/reserve-rec-admin/issues/165) Adding some rudimentary productDate seeding ops.

```
POST .../productDates/{collectionId}/{activityType}/{activityId}/{productId}
?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
```
Looks for a product with the matching collectionId, activityType, activityId, and productId properties. Seed productDates between startDate and endDate if provided, else looks at the rangeStart/rangeEnd values of the product. 

Also creates associated availabilitySignals for each day.

```
DELETE .../productDates/{collectionId}/{activityType}/{activityId}/{productId}
?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
```

Deletes all productDates matching collectionId, activityType, activityId, and productId between startDate and endDate if provided, else uses rangeStart/rangeEnd from product

```
GET .../productDates/{collectionId}/{activityType}/{activityId}/{productId}
?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
&bypassDiscoveryRules=true
```

Fetches all productDates matching collectionId, activityType, activityId, and productId, between startDate and endDate if provided, else uses today's date and 2 weeks into the future as a default.

Respects discovery rules unless bypassDiscoveryRules = false.