### PR TITLE
feat: PRDT-165-3 - adding inventory GET, POST, DELETE

### DIFF
--- a/src/handlers/inventory/DELETE/admin.js
+++ b/src/handlers/inventory/DELETE/admin.js
@@ -1,0 +1,50 @@
+
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { deleteInventory } = require("../methods");
+
+exports.handler = async (event, context) => {
+  logger.info("DELETE Inventory by Product", event);
+  try {
+
+    const body = JSON.parse(event?.body);
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("collectionId, activityType, activityId, and productId are required in the path", { code: 400 });
+    }
+
+    let startDate = event?.queryStringParameters?.startDate || body?.startDate || null;
+    let endDate = event?.queryStringParameters?.endDate || body?.endDate || null;
+
+    if (!endDate) {
+      endDate = startDate;
+    }
+
+    const props = {
+      collectionId,
+      activityType,
+      activityId,
+      productId,
+      startDate,
+      endDate,
+    };
+
+    const deletedItemCount = await deleteInventory(props);
+
+    return sendResponse(200, null, `Inventory deleted successfully. Total deleted: ${deletedItemCount}`, null, context);
+
+  } catch (error) {
+    logger.error("Error deleting Inventory", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/src/handlers/inventory/GET/admin.js
+++ b/src/handlers/inventory/GET/admin.js
@@ -1,0 +1,45 @@
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { fetchInventoryOnDate } = require("../methods");
+
+exports.handler = async (event, context) => {
+  logger.info("GET Inventory by Product on Date", event);
+  try {
+
+    // Validate required parameters from path and queryparams
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+    const date = event?.queryStringParameters?.date;
+
+    if (!collectionId || !activityType || !activityId || !productId || !date) {
+      throw new Exception("Missing required path parameters: collectionId, activityType, activityId, productId, date");
+    }
+
+    // Validate optional parameters
+    const facilityType = event?.queryStringParameters?.facilityType || null;
+    const facilityId = event?.queryStringParameters?.facilityId || null;
+    const assetType = event?.queryStringParameters?.assetType || null;
+    const assetId = event?.queryStringParameters?.assetId || null;
+    const inventoryId = event?.queryStringParameters?.inventoryId || null;
+    const allocationStatus = event?.queryStringParameters?.allocationStatus || null;
+    const limit = event?.queryStringParameters?.limit ? parseInt(event.queryStringParameters.limit) : null;
+
+    const inventory = await fetchInventoryOnDate({ collectionId, activityType, activityId, productId, date, facilityType, facilityId, assetType, assetId, inventoryId, allocationStatus, limit });
+
+    logger.debug(`Fetched inventory for ${collectionId}::${activityType}::${activityId}::${productId} on date ${date}. ${inventory.length} items found.`);
+
+    return sendResponse(200, inventory, "Success", null, context);
+
+  } catch (error) {
+    logger.error("Error fetching Inventory", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/src/handlers/inventory/POST/admin.js
+++ b/src/handlers/inventory/POST/admin.js
@@ -1,0 +1,108 @@
+const { quickApiPutHandler, formatForQuickApi } = require("../../../common/data-utils");
+const { logger, sendResponse, Exception } = require("/opt/base");
+const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+const { INVENTORY_API_PUT_CONFIG } = require("../configs");
+const { initializeInventory } = require("../methods");
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 100;
+
+exports.handler = async (event, context) => {
+  logger.info("POST Inventory by Product", event);
+
+  try {
+    // Validate required parameters from path, queryparams, and body.
+
+    const body = JSON.parse(event?.body);
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    // Start and end dates make up the date range and should optionally from the event body
+    // At least a startdate must be provided.
+
+    let startDate = event?.queryStringParameters?.startDate || body?.startDate || null;
+    let endDate = event?.queryStringParameters?.endDate || body?.endDate || null;
+    const skipWarnings = event?.queryStringParameters?.skipWarnings === 'true' || body?.skipWarnings === true || false;
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("Missing required path parameters: collectionId, activityType, activityId, productId");
+    }
+
+    if (!startDate) {
+      throw new Exception("Missing required query parameter: startDate");
+    }
+
+    if (!endDate) {
+      endDate = startDate; // If no end date is provided, we will just create inventory for the start date
+    }
+
+    const [inventoryToCreate, successes, failures] = await initializeInventory(collectionId, activityType, activityId, productId, startDate, endDate);
+
+    if (failures?.length > 0 && !skipWarnings) {
+      logger.warn(`Failed to initialize inventory for ${failures.length} product dates. Use skipWarnings=true to skip this warning.`, {
+        failures,
+      });
+      return sendResponse(
+        207,
+        {
+          successes: successes?.length || 0,
+          failures: failures?.length || 0,
+          failureData: failures
+        },
+        "Inventory initialization completed with some failures. Check the failureData array for details.",
+        null,
+        context
+      );
+    }
+
+    const inventoryPutItems = await quickApiPutHandler(
+      REFERENCE_DATA_TABLE_NAME,
+      formatForQuickApi(inventoryToCreate),
+      INVENTORY_API_PUT_CONFIG
+    );
+
+    logger.debug(`Creating ${inventoryPutItems.length} inventory records for product ${productId} from ${startDate} to ${endDate}`);
+
+    // Batch write them to DynamoDB
+    let attempt = 0;
+    let success = false;
+    while (attempt <= MAX_RETRIES && !success) {
+      attempt++;
+      try {
+        await batchTransactData(inventoryPutItems);
+        success = true;
+      } catch (error) {
+        if (attempt > MAX_RETRIES) {
+          throw new Exception("Failed to write inventory records to DynamoDB after multiple attempts", {
+            error,
+          });
+        }
+        logger.error(`Error writing inventory records to DynamoDB on attempt ${attempt}`, error);
+        await new Promise(resolve => setTimeout(resolve, attempt * RETRY_DELAY_MS));
+      }
+    }
+
+    logger.info(`Successfully initialized inventory for product ${productId} from ${startDate} to ${endDate}. Created ${inventoryPutItems.length} inventory records.`);
+
+    return sendResponse(
+      200,
+      [],
+      `Successfully initialized ${inventoryPutItems.length} inventory records for product ${productId} from ${startDate} to ${endDate}`,
+      null,
+      context
+    );
+
+  } catch (error) {
+    logger.error("Error in POST Inventory", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || error.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+}

--- a/src/handlers/inventory/configs.js
+++ b/src/handlers/inventory/configs.js
@@ -1,0 +1,36 @@
+const INVENTORY_ALLOCATION_STATUSES = {
+  AVAILABLE: 'available',
+  HELD: 'held',
+  RESERVED: 'reserved',
+  RELEASING: 'releasing',
+};
+
+// TODO: turn off developerMode and properly vet incoming data.
+const INVENTORY_API_PUT_CONFIG = {
+  failOnError: true,
+  autoTimestamp: true,
+  autoVersion: true,
+  developerMode: true,
+  autoGlobalId: true,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+  }
+};
+
+module.exports = {
+  INVENTORY_ALLOCATION_STATUSES,
+  INVENTORY_API_PUT_CONFIG,
+};

--- a/src/handlers/inventory/constructs.js
+++ b/src/handlers/inventory/constructs.js
@@ -1,0 +1,101 @@
+const { Duration } = require("aws-cdk-lib");
+const { LambdaConstruct } = require("../../../lib/helpers/base-lambda");
+const apigw = require("aws-cdk-lib/aws-apigateway");
+
+const defaults = {
+  resources: {
+    inventoryGetFunction: {
+      name: 'InventoryGET',
+    },
+    inventoryPostFunction: {
+      name: 'InventoryPOST',
+    },
+    inventoryPutFunction: {
+      name: 'InventoryPUT',
+    },
+    inventoryDeleteFunction: {
+      name: 'InventoryDELETE',
+    }
+  }
+};
+
+class InventoryConstruct extends LambdaConstruct {
+  constructor(scope, id, props) {
+    super(scope, id, {
+      ...props,
+      defaults: defaults
+    });
+
+    const handlerPrefix = props?.handlerPrefix || 'admin';
+    const handlerName = `${handlerPrefix}.handler`;
+
+    // Add /inventory resource
+    this.inventoryResource = this.resolveApi().root.addResource('inventory');
+
+    // Add /inventory/{collectionId}/{activityType}/{activityId}/{productId} resource
+    this.inventoryByProductResource = this.inventoryResource.addResource('{collectionId}').addResource('{activityType}').addResource('{activityId}').addResource('{productId}');
+
+    // Inventory GET by Product ID and Dates Lambda Function
+
+    this.inventoryGetByProductFunction = this.generateBasicLambdaFn(
+      scope,
+      'inventoryGetFunction',
+      'src/handlers/inventory/GET',
+      handlerName,
+      {
+        basicRead: true,
+      }
+    );
+
+    // Inventory POST by Product ID and Dates Lambda Function
+
+    this.inventoryPostByProductFunction = this.generateBasicLambdaFn(
+      scope,
+      'inventoryPostFunction',
+      'src/handlers/inventory/POST',
+      handlerName,
+      {
+        basicReadWrite: true,
+        timeout: Duration.minutes(1),
+      }
+    );
+
+    // Inventory DELETE by Product ID and Dates Lambda Function
+
+    this.inventoryDeleteByProductFunction = this.generateBasicLambdaFn(
+      scope,
+      'inventoryDeleteFunction',
+      'src/handlers/inventory/DELETE',
+      handlerName,
+      {
+        basicReadWrite: true,
+        timeout: Duration.minutes(1),
+      }
+    );
+
+    // GET /inventory/{collectionId}/{activityType}/{activityId}/{productId}?date=YYYY-MM-DD will be used to fetch Inventory records for a given Product on a specific date.
+
+    this.inventoryByProductResource.addMethod('GET', new apigw.LambdaIntegration(this.inventoryGetByProductFunction, {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    }));
+
+    // POST /inventory/{collectionId}/{activityType}/{activityId}/{productId} will be used to create Inventory records for a given Product and date range. The request body should include the date range and the inventory level for each date in the range. This will allow us to create Inventory records for each date in the range with the appropriate inventory level.
+
+    this.inventoryByProductResource.addMethod('POST', new apigw.LambdaIntegration(this.inventoryPostByProductFunction, {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    }));
+
+    // DELETE /inventory/{collectionId}/{activityType}/{activityId}/{productId} will be used to delete Inventory records for a given Product and date range. The request body should include the date range.
+
+    this.inventoryByProductResource.addMethod('DELETE', new apigw.LambdaIntegration(this.inventoryDeleteByProductFunction, {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    }));
+  }
+}
+
+module.exports = {
+  InventoryConstruct,
+}

--- a/src/handlers/inventory/methods.js
+++ b/src/handlers/inventory/methods.js
@@ -1,0 +1,207 @@
+const { logger, buildDateRange, Exception } = require('/opt/base');
+const { fetchProductDates } = require('../productDates/methods');
+const { REFERENCE_DATA_TABLE_NAME, runQuery, batchTransactData } = require("/opt/dynamodb");
+const { INVENTORY_ALLOCATION_STATUSES } = require('./configs');
+
+async function fetchInventoryOnDate(props) {
+  try {
+    const { collectionId, activityType, activityId, productId, date, facilityType = null, facilityId = null, assetType = null, assetId = null, inventoryId = null, limit = null, allocationStatus = null } = props;
+
+    logger.debug(`Fetching inventory for collectionId: ${collectionId}, activityType: ${activityType}, activityId: ${activityId}, productId: ${productId} on date ${date}`);
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("Missing required parameters: collectionId, activityType, activityId, productId");
+    }
+
+    let query = {
+      TableName: REFERENCE_DATA_TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: {
+        ':pk': { S: `inventory::${collectionId}::${activityType}::${activityId}::${productId}::${date}` }
+      }
+    };
+
+    if (facilityType) {
+      logger.debug(`Adding asset filters to inventory query for facilityType: ${facilityType}, facilityId: ${facilityId}, assetType: ${assetType}, assetId: ${assetId}`);
+
+      // Systematically add filters in order of facilityType, facilityId, assetType, assetId
+      let filters = [facilityType, facilityId, assetType, assetId, inventoryId];
+
+      // Drop all filters including and beyond the first null filter
+      const firstNullIndex = filters.findIndex(filter => filter === null);
+      if (firstNullIndex !== -1) {
+        filters = filters.slice(0, firstNullIndex);
+      }
+
+      const filterString = filters.map(filter => `${filter}`).join('::');
+
+      query.KeyConditionExpression += ' AND begins_with(sk, :skPrefix)';
+      query.ExpressionAttributeValues[':skPrefix'] = { S: `asset::${collectionId}::${filterString}` };
+    }
+
+    if (allocationStatus) {
+      logger.debug(`Adding allocationStatus filter to inventory query: ${allocationStatus}`);
+      query.FilterExpression = 'allocationStatus = :allocationStatus';
+      query.ExpressionAttributeValues[':allocationStatus'] = { S: allocationStatus };
+    }
+
+    // Fetch inventory
+
+    const result = await runQuery(query, limit);
+
+    return result?.items || [];
+
+  } catch (error) {
+    logger.error("Error fetching inventory", error);
+    throw error;
+  }
+}
+
+async function allocateInventoryToUser(props) {
+  try {
+    const { collectionId, activityType, activityId, productId, date, facilityType = null, facilityId = null, assetType = null, assetId = null, limit = null, allocationStatus = null } = props;
+  } catch (error) {
+    logger.error("Error allocating inventory", error);
+    throw error;
+  }
+}
+
+async function initializeInventory(collectionId, activityType, activityId, productId, startDate, endDate) {
+  try {
+    logger.debug(`Initializing inventory for collectionId: ${collectionId}, activityType: ${activityType}, activityId: ${activityId}, productId: ${productId} from ${startDate} to ${endDate}`);
+
+    // Fetch all ProductDates in range.
+    const props = {
+      collectionId: collectionId,
+      activityType: activityType,
+      activityId: activityId,
+      productId: productId,
+      startDate: startDate,
+      endDate: endDate,
+      bypassDiscoveryRules: true
+    };
+    const productDates = await fetchProductDates(props);
+
+    logger.debug(`Fetched ${productDates?.items?.length} product dates for initialization`);
+
+    // For each ProductDate, inspect the assetList and create an Inventory record for each asset.
+
+    let inventoryToCreate = [];
+    let successes = [];
+    let failures = [];
+    for (const productDate of productDates?.items) {
+      // get the assetList from the productDate
+      const assetList = productDate?.assetList || [];
+
+      if (assetList.length === 0) {
+        logger.warn(`No assets found for productDate ${productDate.id}, skipping inventory creation for this date`);
+        failures.push({
+          date: productDate?.date,
+          productDate: productDate,
+          reason: 'No assets found for this product date',
+        });
+        continue;
+      }
+
+      for (const asset of assetList) {
+        // Create an Inventory record for this asset and date. If the quantity is greater than 1, we will create multiple Inventory records for the same flex asset.
+        try {
+          let unitId = 1;
+
+          while (unitId <= asset.quantity) {
+            let inventoryRecord = {
+              pk: `inventory::${collectionId}::${activityType}::${activityId}::${productId}::${productDate.date}`,
+              sk: `${asset.primaryKey.pk}::${asset.primaryKey.sk}::${unitId}`,
+              schema: "inventory",
+              inventoryId: unitId,
+              date: productDate.date,
+              allocationType: asset?.allocationType,
+              assetRef: asset,
+              productDateRef: {
+                pk: productDate.pk,
+                sk: productDate.sk,
+              },
+              productDateVersion: productDate.version,
+              allocationStatus: INVENTORY_ALLOCATION_STATUSES.AVAILABLE,
+            };
+            inventoryToCreate.push(inventoryRecord);
+            successes.push(productDate.date);
+            unitId++;
+          }
+        } catch (error) {
+          logger.error(`Error creating inventory record for asset ${asset?.pk} on date ${productDate?.date}`, error);
+          failures.push({
+            date: productDate?.date,
+            asset: asset,
+            reason: `Error creating inventory record: ${error.message}`,
+          });
+        }
+      }
+    }
+
+    logger.info(`Finished initializing inventory. Successfully prepared ${inventoryToCreate.length} inventory records for ${successes.length} product dates. Failed to prepare inventory records for ${failures.length} product dates.`);
+
+    return [inventoryToCreate, successes, failures];
+
+  } catch (error) {
+    logger.error("Error initializing inventory", error);
+    throw error;
+  }
+}
+
+async function deleteInventory(props) {
+  try {
+    const { collectionId, activityType, activityId, productId, startDate, endDate } = props;
+    props['queryTime'] = props['queryTime'] || new Date().toISOString();
+    props['bypassDiscoveryRules'] = true;
+
+    logger.debug(`Deleting inventory for collectionId: ${collectionId}, activityType: ${activityType}, activityId: ${activityId}, productId: ${productId} from ${startDate} to ${endDate}`);
+
+    // We can infer the partition key for all inventory records based on the collectionId, activityType, activityId, productId, and date range. This allows us to query for all inventory records in the date range and delete them in batches.
+
+    // Unfortunately, we cannot just batch delete based on partition key because DELETE requires both the partition key and sort key, and the sort key includes the asset primary key and unit id, which we do not have. Therefore, we need to first query for all inventory records in the date range to get their sort keys, and then batch delete them.
+
+    const dates = buildDateRange(startDate, endDate);
+
+    let inventoryToDelete = [];
+    for (const date of dates) {
+      const inventoryRecords = await fetchInventoryOnDate({
+        collectionId,
+        activityType,
+        activityId,
+        productId,
+        date
+      });
+      inventoryToDelete = inventoryToDelete.concat(inventoryRecords);
+    }
+
+    logger.debug(`Deleting ${inventoryToDelete.length} inventory records from product ${collectionId}::${activityType}::${activityId}::${productId} from ${startDate} to ${endDate}`);
+
+    // Batch delete them from DynamoDB.
+
+    const deleteRequests = inventoryToDelete.map(record => ({
+      TableName: REFERENCE_DATA_TABLE_NAME,
+      Key: {
+        pk: {S: record.pk},
+        sk: {S: record.sk},
+      }
+    }));
+
+    await batchTransactData(deleteRequests, 'Delete');
+
+    logger.info(`Successfully deleted ${inventoryToDelete.length} inventory records for product ${collectionId}::${activityType}::${activityId}::${productId} from ${startDate} to ${endDate}`);
+
+    return inventoryToDelete.length;
+
+    // Fetch all ProductDates in range.
+  } catch (error) {
+    logger.error("Error deleting inventory", error);
+    throw error;
+  }
+}
+
+module.exports = {
+  deleteInventory,
+  fetchInventoryOnDate,
+  initializeInventory,
+};

--- a/src/handlers/productDates/_productId/GET/admin.js
+++ b/src/handlers/productDates/_productId/GET/admin.js
@@ -33,7 +33,17 @@ exports.handler = async (event, context) => {
 
     logger.debug(`Fetching Product Dates for Product ${collectionId}::${activityType}::${activityId}::${productId} with startDate ${startDate} and endDate ${endDate}. Bypass discovery rules: ${bypassDiscoveryRules}`);
 
-    const productDates = await fetchProductDates(collectionId, activityType, activityId, productId, startDate, endDate, bypassDiscoveryRules);
+    const props = {
+      collectionId: collectionId,
+      activityType: activityType,
+      activityId: activityId,
+      productId: productId,
+      startDate: startDate,
+      endDate: endDate,
+      bypassDiscoveryRules: bypassDiscoveryRules,
+    }
+
+    const productDates = await fetchProductDates(props);
 
     return sendResponse(200, productDates, "Success", null, context);
 

--- a/src/handlers/productDates/_productId/POST/admin.js
+++ b/src/handlers/productDates/_productId/POST/admin.js
@@ -33,9 +33,6 @@ exports.handler = async (event, context) => {
 
     const { productDates, availabilitySignals } = await initializeProductDates(collectionId, activityType, activityId, productId, startDate, endDate);
 
-    console.log('productDates.length:', productDates.length);
-    console.log('availabilitySignals.length:', availabilitySignals.length);
-
     // Use quickApiPutHandler to create the put items
 
     // TODO Turn off developerMode and properly vet the incoming data before writing to DynamoDB. For now, developerMode allows us to skip some validation and write directly to DynamoDB for faster testing.

--- a/src/handlers/productDates/methods.js
+++ b/src/handlers/productDates/methods.js
@@ -5,12 +5,19 @@ const { buildDateRange } = require("/opt/base");
 const { DateTime } = require("luxon");
 const { resolveTemporalAnchor, resolveTemporalWindow } = require("../../common/data-utils");
 
-async function fetchProductDates(queryTime = null, collectionId, activityType, activityId, productId, startDate, endDate, bypassDiscoveryRules = false) {
+async function fetchProductDates(props) {
   try {
+    const {
+      queryTime = new Date().toISOString(),
+      collectionId,
+      activityType,
+      activityId,
+      productId,
+      startDate,
+      endDate,
+      bypassDiscoveryRules = false
+    } = props;
 
-    if (!queryTime) {
-      queryTime = new Date().toISOString();
-    }
 
     const productDatePK = `productDate::${collectionId}::${activityType}::${activityId}::${productId}`;
 


### PR DESCRIPTION
Relates to [#165](https://github.com/bcgov/reserve-rec-admin/issues/165) .Adding administrative ability to GET, POST, DELETE Inventory based on existing ProductDates. 

```
POST .../inventory/{collectionId}/{activityType}/{activityId}/{productId}
?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
```
Seeds inventory for a Product by using the ProductDates between startDate and endDate.
If only startDate provided, will seed inventory for one ProductDate.

```
DELETE .../inventory/{collectionId}/{activityType}/{activityId}/{productId}
?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
```

Deletes all inventory matching collectionId, activityType, activityId, and productId between startDate and endDate.
If only startDate provided, deletes one ProductDate worth of Inventory.

```
GET .../inventory/{collectionId}/{activityType}/{activityId}/{productId}/{date}
&facilityType=<facilityType>
&facilityId =<facilityId>
&assetType=<assetType>
&assetId=<assetId>
&inventoryId=<inventoryId>

&limit=Number
&allocationStatus=<allocationStatus>
```

Fetches a pool of Inventory (one ProductDate). May have multiple assets but will only relate to one day. 

Can further refine search by providing one or more of facilityType=<facilityType>,facilityId =<facilityId>, assetType=<assetType>, assetId=<assetId>, inventoryId=<inventoryId> in that exact order, will be applied to `sk beginsWith()` KeyConditionExpression

Can also provide `limit` to limit results and `allocationStatus` to filter results by status: available, held, reserved, releasing...
