### PR TITLE
feat: PRDT-165-4 - adding Public ProductDatesGET

### DIFF
--- a/lib/admin-api-stack/product-management-stack/product-management-stack.js
+++ b/lib/admin-api-stack/product-management-stack/product-management-stack.js
@@ -1,5 +1,6 @@
 const { NestedStack } = require('aws-cdk-lib');
 const { ProductDatesConstruct } = require('../../../src/handlers/productDates/constructs');
+const { InventoryConstruct } = require('../../../src/handlers/inventory/constructs');
 
 class ProductManagementNestedStack extends NestedStack {
   constructor(scope, id, props) {
@@ -19,6 +20,15 @@ class ProductManagementNestedStack extends NestedStack {
       authorizer: props.authorizer,
       handlerPrefix: props.handlerPrefix,
     });
+
+    // Initialize InventoryConstruct
+    this.inventoryConstruct = new InventoryConstruct(this, 'InventoryConstruct', {
+      environment: props.environment,
+      layers: props.layers,
+      api: props.api,
+      authorizer: props.authorizer,
+      handlerPrefix: props.handlerPrefix,
+    })
 
   }
 }

--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -16,6 +16,7 @@ const { PublicBookingsConstruct } = require('../../src/handlers/bookings/constru
 const { TransactionsConstruct } = require('../../src/handlers/transactions/constructs');
 const { WorldlineNotificationConstruct } = require('../../src/handlers/worldlineNotification/constructs');
 const { PublicFeatureFlagsConstruct } = require('../../src/handlers/featureFlags/constructs');
+const { PublicProductDatesConstruct } = require('../../src/handlers/productDates/constructs');
 
 const defaults = {
   description: 'Public API stack providing a public API Gateway, authorization, and Lambda functions for the Reserve Recreation APIs.',
@@ -37,6 +38,9 @@ const defaults = {
     },
     publicBookingsConstruct: {
       name: 'PublicBookingsConstruct',
+    },
+    publicProductDatesConstruct: {
+      name: 'PublicProductDatesConstruct',
     },
     publicConfigLambdas: {
       name: 'PublicConfigLambdas'
@@ -356,6 +360,21 @@ class PublicApiStack extends BaseStack {
         awsUtilsLayer,
       ],
       api: this.publicApi,
+    });
+
+    // ProductDates Lambdas
+    this.publicProductDatesConstruct = new PublicProductDatesConstruct(this, this.getConstructId('publicProductDatesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'public',
     });
 
     // Export References

--- a/src/common/data-utils.js
+++ b/src/common/data-utils.js
@@ -593,12 +593,22 @@ function resolveTemporalAnchor(temporalAnchor, timezone, refStore = {}) {
 
 }
 
+function formatProjectionsForQuery(projections) {
+  if (!projections || projections?.length === 0) {
+    return null;
+  }
+  let projectionsMap = {};
+  projections.map((proj) => projectionsMap[`#${proj}`] = proj);
+  return projectionsMap;
+}
+
 module.exports = {
   buildCompKeysFromSkField,
   getAndAttachNestedProperties,
   getNextIdentifier,
   generateGlobalId,
   formatForQuickApi,
+  formatProjectionsForQuery,
   quickApiPutHandler,
   quickApiUpdateHandler,
   resolveTemporalAnchor,

--- a/src/handlers/productDates/_productId/GET/public.js
+++ b/src/handlers/productDates/_productId/GET/public.js
@@ -1,0 +1,83 @@
+
+const { fetchProductDates } = require("../../methods");
+const { PUBLIC_PRODUCTDATE_PROJECTIONS } = require("../../configs");
+const { getRequestClaimsFromEvent, logger, sendResponse, Exception } = require("/opt/base");
+/**
+ * Fetches available ProductDates from a public user perspective. This means that discovery rules will ALWAYS be applied to the query, and only ProductDates that are discoverable to the user will be returned.
+ */
+
+exports.handler = async (event, context) => {
+  logger.info("GET Product Dates - Public Handler", event);
+  try {
+
+    const user = getRequestClaimsFromEvent(event);
+
+    console.log('user:', user);
+
+    if (!user) {
+      throw new Exception("Unauthorized.", { code: 401 });
+    }
+
+    const collectionId = event?.pathParameters?.collectionId;
+    const activityType = event?.pathParameters?.activityType;
+    const activityId = event?.pathParameters?.activityId;
+    const productId = event?.pathParameters?.productId;
+
+    if (!collectionId || !activityType || !activityId || !productId) {
+      throw new Exception("collectionId, activityType, activityId, and productId are required in the path", { code: 400 });
+    }
+
+    let startDate = event?.queryStringParameters?.startDate || null;
+    let endDate = event?.queryStringParameters?.endDate || null;
+
+    // If startDate and endDate are not provided, we will return the next two weeks of ProductDates for the Product by default. This is to prevent accidentally returning a huge amount of data if someone forgets to provide a date range.
+
+
+    if (!startDate) {
+      const today = new Date();
+      const twoWeeksFromToday = new Date(today);
+      twoWeeksFromToday.setDate(today.getDate() + 14);
+      startDate = today.toISOString().split('T')[0];
+      endDate = twoWeeksFromToday.toISOString().split('T')[0];
+    } else if (!endDate) {
+      endDate = startDate;
+    }
+
+    // Also enforce a maximum date range of 1 month to prevent excessively large queries.
+
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    const maxEndDate = new Date(start);
+    maxEndDate.setMonth(maxEndDate.getMonth() + 1);
+
+    if (end > maxEndDate) {
+      logger.warn(`End date ${endDate} is more than 1 month after start date ${startDate}. Adjusting end date to 1 month ahead maximum.`);
+      endDate = maxEndDate.toISOString().split('T')[0];
+    }
+
+    const props = {
+      collectionId: collectionId,
+      activityType: activityType,
+      activityId: activityId,
+      productId: productId,
+      startDate: startDate,
+      endDate: endDate,
+      bypassDiscoveryRules: false, // Discovery rules are ALWAYS applied for the public handler
+      projectionFields: PUBLIC_PRODUCTDATE_PROJECTIONS, // We will only return a limited set of fields for the public handler to minimize data exposure
+    }
+
+    const productDates = await fetchProductDates(props);
+
+    return sendResponse(200, productDates, "Success", null, context);
+
+  } catch (error) {
+    logger.error("Error fetching Product Dates", error);
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error",
+      error?.error || error,
+      context
+    );
+  }
+};

--- a/src/handlers/productDates/configs.js
+++ b/src/handlers/productDates/configs.js
@@ -9,6 +9,22 @@ const ALLOWED_FILTERS = [
   { name: "productId", type: "string" },
 ];
 
+const PUBLIC_PRODUCTDATE_PROJECTIONS = [
+  "pk",
+  "sk",
+  "collectionId",
+  "assetList",
+  "activityType",
+  "activityId",
+  "productId",
+  "date",
+  "availabilitySignal",
+  "displayName",
+  "reservationContext",
+  "version",
+  "schema"
+]
+
 // TODO complete later (remove developerMode)
 const PRODUCTDATE_API_PUT_CONFIG = {
   failOnError: true,
@@ -62,4 +78,5 @@ const AVAILABILITYSIGNAL_API_PUT_CONFIG = {
 module.exports = {
   PRODUCTDATE_API_PUT_CONFIG,
   AVAILABILITYSIGNAL_API_PUT_CONFIG,
+  PUBLIC_PRODUCTDATE_PROJECTIONS,
 };

--- a/src/handlers/productDates/constructs.js
+++ b/src/handlers/productDates/constructs.js
@@ -90,6 +90,42 @@ class ProductDatesConstruct extends LambdaConstruct {
   }
 }
 
+class PublicProductDatesConstruct extends LambdaConstruct {
+  constructor(scope, id, props) {
+    super(scope, id, {
+      ...props,
+      defaults: defaults
+    });
+
+    const handlerPrefix = props?.handlerPrefix || 'admin';
+    const handlerName = `${handlerPrefix}.handler`;
+
+    // Add /public/product-dates/{collectionId}/{activityType}/{activityId}/{productId} resource
+    // Add /product-dates resource
+    this.productDatesResource = this.resolveApi().root.addResource('product-dates');
+
+    this.productDatesByProductResource = this.productDatesResource.addResource('{collectionId}').addResource('{activityType}').addResource('{activityId}').addResource('{productId}');
+
+    // // ProductDates GET by Product ID Lambda Function
+    this.productDatesGetByDatesFunction = this.generateBasicLambdaFn(
+      scope,
+      'productDatesGetFunction',
+      'src/handlers/productDates/_productId/GET',
+      handlerName,
+      {
+        basicRead: true,
+      }
+    );
+
+    // GET /product-dates/{collectionId}/{activityType}/{activityId}/{productId}
+    this.productDatesByProductResource.addMethod('GET', new apigw.LambdaIntegration(this.productDatesGetByDatesFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+  }
+}
+
 module.exports = {
   ProductDatesConstruct,
+  PublicProductDatesConstruct
 };

--- a/src/handlers/productDates/methods.js
+++ b/src/handlers/productDates/methods.js
@@ -3,7 +3,7 @@ const { getOne, batchTransactData, runQuery, REFERENCE_DATA_TABLE_NAME } = requi
 const { getProductById } = require("../products/methods");
 const { buildDateRange } = require("/opt/base");
 const { DateTime } = require("luxon");
-const { resolveTemporalAnchor, resolveTemporalWindow } = require("../../common/data-utils");
+const { formatProjectionsForQuery, resolveTemporalAnchor, resolveTemporalWindow } = require("../../common/data-utils");
 
 async function fetchProductDates(props) {
   try {
@@ -15,7 +15,8 @@ async function fetchProductDates(props) {
       productId,
       startDate,
       endDate,
-      bypassDiscoveryRules = false
+      bypassDiscoveryRules = false,
+      projectionFields = null
     } = props;
 
 
@@ -42,7 +43,13 @@ async function fetchProductDates(props) {
       query.ExpressionAttributeValues[':currentDateTime'] = { S: queryTime };
     }
 
-    logger.info(`Querying ProductDates for Product ${productId} with activity '${activityType} ${activityId}' between dates ${startDate} and ${endDate}. Bypass discovery rules: ${bypassDiscoveryRules}`, { query });
+    if (projectionFields) {
+      const projectionsMap = formatProjectionsForQuery(projectionFields);
+      query.ExpressionAttributeNames = { ...query.ExpressionAttributeNames, ...projectionsMap };
+      query.ProjectionExpression = Object.keys(projectionsMap).join(', ');
+    }
+
+    logger.debug(`Querying ProductDates for Product ${productId} with activity '${activityType} ${activityId}' between dates ${startDate} and ${endDate}. Bypass discovery rules: ${bypassDiscoveryRules}`, { query });
 
     const result = await runQuery(query);
 


### PR DESCRIPTION
Relates to [#165](https://github.com/bcgov/reserve-rec-admin/issues/165) Public can query ProductDates now. The query will ALWAYS enforce discovery rules - if the ProductDate is not discoverable OR the `queryTime` is not within the discoveryWindow, the item will not be returned in a query.