### PR TITLE
PRDT-121/150 - Facility and Product page updates

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -360,6 +360,21 @@ class AdminApiStack extends BaseStack {
       handlerPrefix: 'admin',
     });
 
+    // Policies Lambdas
+    this.policiesConstruct = new PoliciesConstruct(this, this.getConstructId('policiesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.adminApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'admin',
+    });
+
     // Users Lambdas
     // Use NestedStack for AWS deployments (to avoid 500 resource limit)
     // Use direct Construct for local development (SAM doesn't support NestedStacks)

--- a/src/common/relationship-utils.js
+++ b/src/common/relationship-utils.js
@@ -1,6 +1,13 @@
 const { logger, Exception } = require("/opt/base");
-const { batchWriteData, REFERENCE_DATA_TABLE_NAME, ENTITY_RELATIONSHIP_INDEX, batchTransactData, runQuery, marshall } = require("/opt/dynamodb");
-const { quickApiPutHandler } = require("./data-utils");
+const { 
+  batchWriteData,
+  REFERENCE_DATA_TABLE_NAME,
+  ENTITY_RELATIONSHIP_INDEX,
+  batchTransactData,
+  runQuery,
+  marshall
+ } = require("/opt/dynamodb");
+const { quickApiPutHandler, quickApiUpdateHandler } = require("./data-utils");
 
 /*
   * Helper function to determine if schemas should be swapped
@@ -146,6 +153,117 @@ function createRelationshipItem(pk1, sk1, pk2, sk2) {
   return relationshipItem;
 }
 
+// Canonical mapping from plural field names to singular schema names
+const FIELD_TO_SCHEMA = {
+  facilities: 'facility',
+  geozones: 'geozone',
+  activities: 'activity',
+  products: 'product',
+};
+
+/**
+ * Queries existing relationship items for a given source entity + target schema.
+ * Automatically selects the forward table scan or GSI based on the hierarchy.
+ *
+ * @param {string} sourcePk - e.g. 'facility::bcparks_15'
+ * @param {string} sourceSk - e.g. 'accessPoint::1'
+ * @param {string} targetSchema - e.g. 'activity'
+ * @param {string} tableName
+ * @returns {Promise<Array>} Unmarshalled relationship items
+ */
+async function queryRelationshipsBySchema(sourcePk, sourceSk, targetSchema, tableName = REFERENCE_DATA_TABLE_NAME) {
+  const sourceSchema = sourcePk.split('::')[0];
+  const relationshipPk = `rel::${sourcePk}::${sourceSk}`;
+
+  // If source is lower in hierarchy it was stored as pk2; query via GSI.
+  // Otherwise it was stored as pk1; query the main table directly.
+  if (shouldSwapSchemas(sourceSchema, targetSchema)) {
+    const query = {
+      TableName: tableName,
+      IndexName: ENTITY_RELATIONSHIP_INDEX,
+      KeyConditionExpression: 'gsipk = :gsipk',
+      FilterExpression: 'schema1 = :schema1',
+      ExpressionAttributeValues: {
+        ':gsipk': { S: relationshipPk },
+        ':schema1': { S: targetSchema }
+      }
+    };
+    const result = await runQuery(query, null, null, false);
+    return result.items || [];
+  } else {
+    const query = {
+      TableName: tableName,
+      KeyConditionExpression: 'pk = :pk',
+      FilterExpression: 'schema2 = :schema2',
+      ExpressionAttributeValues: {
+        ':pk': { S: relationshipPk },
+        ':schema2': { S: targetSchema }
+      }
+    };
+    const result = await runQuery(query, null, null, false);
+    return result.items || [];
+  }
+}
+
+/**
+ * Diffs existing DB relationships against the incoming entity list.
+ * Returns relationship items to add and delete transactions to execute.
+ *
+ * @param {Array}  existingItems   - Unmarshalled relationship items from the DB
+ * @param {Array}  incomingEntities - Entities from the request body (each has pk + sk)
+ * @param {string} sourcePk
+ * @param {string} sourceSk
+ * @param {string} targetSchema
+ * @param {string} tableName
+ * @returns {{ toAdd: Array, toDelete: Array }}
+ */
+function diffRelationships(existingItems, incomingEntities, sourcePk, sourceSk, targetSchema, tableName) {
+  const sourceSchema = sourcePk.split('::')[0];
+  const useGSI = shouldSwapSchemas(sourceSchema, targetSchema);
+
+  // Extract the target entity's pk/sk from a stored relationship item
+  const getTargetKey = (item) => useGSI
+    ? { pk: item.pk1, sk: item.sk1 }  // source was pk2, so target is pk1
+    : { pk: item.pk2, sk: item.sk2 }; // source was pk1, so target is pk2
+
+  const incomingSet = new Set((incomingEntities || []).map(e => `${e.pk}::${e.sk}`));
+  const existingByTarget = new Map(
+    existingItems.map(item => {
+      const t = getTargetKey(item);
+      return [`${t.pk}::${t.sk}`, item];
+    })
+  );
+
+  const toAdd = [];
+  const toDelete = [];
+
+  // Incoming entities not yet in the DB → create relationship items
+  for (const entity of (incomingEntities || [])) {
+    if (!existingByTarget.has(`${entity.pk}::${entity.sk}`)) {
+      let pk1 = sourcePk, sk1 = sourceSk, pk2 = entity.pk, sk2 = entity.sk;
+      if (useGSI) {
+        [pk1, sk1, pk2, sk2] = [pk2, sk2, pk1, sk1];
+      }
+      toAdd.push({ PutRequest: { Item: createRelationshipItem(pk1, sk1, pk2, sk2) } });
+    }
+  }
+
+  // Existing relationships whose target is absent from incoming → delete
+  for (const [key, item] of existingByTarget) {
+    if (!incomingSet.has(key)) {
+      toDelete.push({
+        action: 'Delete',
+        data: {
+          TableName: tableName,
+          Key: marshall({ pk: item.pk, sk: item.sk })
+        }
+      });
+    }
+  }
+
+  return { toAdd, toDelete };
+}
+
 /**
  * Batch writes relationship items to DynamoDB
  * Uses the existing batchWriteData function from the dynamodb layer
@@ -180,7 +298,8 @@ async function batchWriteRelationships(relationshipItems, tableName) {
  * @param {string} config.schema - Entity schema (e.g., 'activity', 'facility', 'geozone')
  * @param {string} config.collectionId - Collection ID
  * @param {Object} config.body - Request body with entity data
- * @param {string} config.entityType - Entity type for parseRequest (e.g., activityType, facilityType)
+ * @param {Array} [config.parseArgs=[]] - Extra args spread into parseRequest after the method, e.g. [facilityType, facilityId]
+ * @param {string} [config.requestMethod='POST'] - HTTP verb forwarded to parseRequest (e.g. 'POST', 'PUT')
  * @param {Array<string>} config.relationshipFields - Fields to extract as relationships
  * @param {Object} config.putConfig - PUT configuration for quickApiPutHandler
  * @param {Function} config.parseRequest - The parseRequest function from entity methods
@@ -198,7 +317,8 @@ async function createEntityWithRelationships(config) {
     schema,
     collectionId,
     body,
-    entityType,
+    parseArgs = [],
+    requestMethod = 'POST',
     relationshipFields,
     putConfig,
     parseRequest,
@@ -210,29 +330,20 @@ async function createEntityWithRelationships(config) {
   let success = false;
   let attempt = 1;
   let allRelationshipItems = [];
+  let allDeleteTransactions = [];
 
   while (attempt <= maxRetries && !success) {
     // Parse the request to get entity items
-    postRequests = await parseRequest(collectionId, body, "POST", entityType);
+    postRequests = await parseRequest(collectionId, body, requestMethod, ...parseArgs);
 
-    // Extract relationship fields for each entity in the batch
-    allRelationshipItems = [];
-    for (let i = 0; i < postRequests.length; i++) {
-      const postRequest = postRequests[i];
-      if (postRequest.key && postRequest.data) {
-        const result = extractAndCreateRelationships(
-          schema,
-          postRequest.key.pk,
-          postRequest.key.sk,
-          postRequest.data,
-          relationshipFields
-        );
-
-        // Use cleaned data without relationship fields
-        postRequests[i].data = result.cleanedData;
-        allRelationshipItems.push(...result.relationshipItems);
-      }
-    }
+    // For each entity item in the batch, process relationship fields
+    ({ postRequests, allRelationshipItems, allDeleteTransactions } = await searchAndDeleteRelationshipsForBatch(
+      postRequests,
+      schema,
+      relationshipFields,
+      tableName,
+      requestMethod
+    ));
 
     if (allRelationshipItems.length > 0) {
       logger.info(
@@ -240,18 +351,34 @@ async function createEntityWithRelationships(config) {
       );
     }
 
-    // Use quickApiPutHandler to create the put items
-    const putItems = await quickApiPutHandler(
-      tableName,
-      postRequests,
-      putConfig
-    );
+    let updateRequest;
+    if (requestMethod === 'POST') {
+      // For POST requests, we create new items
+      updateRequest = await quickApiPutHandler(
+        tableName,
+        postRequests,
+        putConfig
+      );
+    } else if (requestMethod === 'PUT') {
+      // If it's a PUT request, we need to update the item
+      updateRequest = await quickApiUpdateHandler(
+        tableName,
+        postRequests,
+        putConfig
+      );
+    };
 
     try {
-      // Attempt to create the entity
-      await batchTransactData(putItems);
+      // Write the entity itself
+      await batchTransactData(updateRequest);
 
-      // After successfully creating the entity, create the relationships
+      // Delete stale relationship records (PUT only)
+      if (allDeleteTransactions.length > 0) {
+        logger.info(`Deleting ${allDeleteTransactions.length} stale relationships`);
+        await batchTransactData(allDeleteTransactions);
+      }
+
+      // Write new relationship records
       if (allRelationshipItems.length > 0) {
         logger.info('Writing relationship items to database');
         await batchWriteRelationships(allRelationshipItems, tableName);
@@ -271,13 +398,66 @@ async function createEntityWithRelationships(config) {
     }
   }
 
-  return {
-    success,
-    postRequests,
-    relationshipCount: allRelationshipItems.length,
-    attempts: attempt
-  };
+  return postRequests;
 }
+
+/*
+ * Helper function to process a batch of entity requests and handle relationship extraction and diffing
+ * This is used within the createEntityWithRelationships workflow to keep the main function cleaner
+ * 
+ * @param {Array} postRequests - Array of entity requests with data to be created/updated
+ * @param {string} schema - Entity schema (e.g., 'activity', 'facility', 'geozone')
+ * @param {Array<string>} relationshipFields - Fields to extract as relationships
+ * @param {string} tableName - DynamoDB table name
+ * @param {string} requestMethod - HTTP verb forwarded to parseRequest (e.g. 'POST', 'PUT')
+ * 
+ * @returns {Promise<Object>} Object with:
+ *   - postRequests: Updated array of entity requests with relationship fields removed
+ *   - allRelationshipItems: Array of relationship items to be written to DynamoDB
+ *   allDeleteTransactions: Array of delete transactions for stale relationships (PUT only)
+ */
+async function searchAndDeleteRelationshipsForBatch(postRequests, schema, relationshipFields, tableName, requestMethod) {
+  let allRelationshipItems = [];
+  let allDeleteTransactions = [];
+
+  for (let i = 0; i < postRequests.length; i++) {
+    const postRequest = postRequests[i];
+    if (!postRequest.key || !postRequest.data) continue;
+
+    const { pk, sk } = postRequest.key;
+
+    if (requestMethod === 'PUT') {
+      // PUT: diff against the DB so we can add new and remove stale relationships
+      for (const field of relationshipFields) {
+        const targetSchema = FIELD_TO_SCHEMA[field] || field;
+        const incomingEntities = postRequest.data[field] || [];
+        const existingItems = await queryRelationshipsBySchema(pk, sk, targetSchema, tableName);
+
+        logger.info(`Relationship sync for ${pk}::${sk} [${field}]: ${existingItems.length} existing, ${incomingEntities.length} incoming`);
+
+        const { toAdd, toDelete } = diffRelationships(existingItems, incomingEntities, pk, sk, targetSchema, tableName);
+
+        logger.info(`  → ${toAdd.length} to add, ${toDelete.length} to delete`);
+
+        allRelationshipItems.push(...toAdd);
+        allDeleteTransactions.push(...toDelete);
+      }
+
+      // Strip relationship fields from data before passing to the update handler
+      for (const field of relationshipFields) {
+        delete postRequests[i].data[field];
+      }
+    } else {
+      // POST: no existing relationships to worry about, just extract and create
+      const result = extractAndCreateRelationships(schema, pk, sk, postRequest.data, relationshipFields);
+      postRequests[i].data = result.cleanedData;
+      allRelationshipItems.push(...result.relationshipItems);
+    }
+  }
+
+  return { postRequests, allRelationshipItems, allDeleteTransactions };
+}
+  
 
 /**
  * Deletes all relationships associated with an entity (both forward and reverse)
@@ -386,5 +566,7 @@ module.exports = {
   createEntityWithRelationships,
   createRelationshipItem,
   deleteEntityRelationships,
+  diffRelationships,
   extractAndCreateRelationships,
+  queryRelationshipsBySchema,
 };

--- a/src/handlers/facilities/configs.js
+++ b/src/handlers/facilities/configs.js
@@ -101,6 +101,18 @@ const FACILITY_API_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
+    isOpen: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    passesRequired: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
     timezone: {
       isMandatory: true,
       rulesFn: ({ value, action }) => {
@@ -130,6 +142,12 @@ const FACILITY_API_PUT_CONFIG = {
       }
     },
     imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    agreements: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
@@ -198,6 +216,18 @@ const FACILITY_API_UPDATE_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
+    isOpen: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    passesRequired: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
     timezone: {
       rulesFn: ({ value, action }) => {
         rf.expectValueInList(value, TIMEZONE_ENUMS);
@@ -223,6 +253,12 @@ const FACILITY_API_UPDATE_CONFIG = {
       }
     },
     imageUrl: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    agreements: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);

--- a/src/handlers/facilities/methods.js
+++ b/src/handlers/facilities/methods.js
@@ -251,6 +251,7 @@ async function processItem(
     delete item.sk;
     delete item.facilityType;
     delete item.facilityId;
+
   } else if (requestType == "POST") {
     // Throw an error if facilityId is passed in POST request, as we only allow auto increment for POST requests
     if (facilityId) {

--- a/src/handlers/policies/GET/admin.js
+++ b/src/handlers/policies/GET/admin.js
@@ -1,5 +1,5 @@
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { getPolicyById, getPolicyByIdVersion, getAllPoliciesByProduct } = require("../methods");
+const { getPolicyById, getPolicyByIdVersion, getAllPolicies, getAllPoliciesByProduct } = require("../methods");
 const { getByGSI, REFERENCE_DATA_TABLE_NAME } = require("/opt/dynamodb");
 
 /**
@@ -33,14 +33,9 @@ exports.handler = async (event, context) => {
       return sendResponse(200, res, "Success", null, context);
     }
 
-    
-    if (!policyType) {
-      throw new Exception("Policy Type (policyType) is required", { code: 400 });
-    }
-
-    // If we don't have a policyId or policyIdVersion
-    if (!policyId && !policyIdVersion) {
-      const res = await getByGSI('gsipk', `policy::${policyType}`, REFERENCE_DATA_TABLE_NAME, 'entityRelationship-index');
+    // Get all policies if no policyType or policyId is provided
+    if (!policyType && !policyId) {
+      const res = await getAllPolicies();
       return sendResponse(200, res, "Success", null, context);
     }
 

--- a/src/handlers/policies/methods.js
+++ b/src/handlers/policies/methods.js
@@ -2,7 +2,7 @@
  * Functionality for policies
  */
 
-const { REFERENCE_DATA_TABLE_NAME, batchTransactData, batchGetData, getOne, incrementCounter, runQuery } = require('/opt/dynamodb');
+const { REFERENCE_DATA_TABLE_NAME, batchTransactData, batchGetData, getOne, incrementCounter, runQuery, getByGSI, ENTITY_RELATIONSHIP_INDEX } = require('/opt/dynamodb');
 const { Exception, logger } = require('/opt/base');
 const { quickApiPutHandler, quickApiUpdateHandler } = require("../../common/data-utils");
 const {
@@ -52,6 +52,19 @@ async function getPolicyById(policyType, policyId, params = null) {
   } catch (error) {
     throw new Exception('Error getting policy', { code: 400, error: error });
   }
+}
+
+// TODO: this is currently how I decided to fetchi all the policies, but this will need to be
+//       updated in the future to support some type of filtering or pagination, as there
+//       could be a shload of policies in the system and we don't want to fetch them all at once
+async function getAllPolicies() {
+  const policyTypes = ['reservation', 'change', 'party', 'fee'];
+  const results = await Promise.all(
+    policyTypes.map(policyType =>
+      getByGSI('gsipk', `policy::${policyType}`, REFERENCE_DATA_TABLE_NAME, ENTITY_RELATIONSHIP_INDEX)
+    )
+  );
+  return results.flatMap(r => r?.items ?? []);
 }
 
 async function getPolicyByIdVersion(policyType, policyId, policyIdVersion = 'latest') {
@@ -340,6 +353,7 @@ async function getAllPoliciesByProduct(productPk, productSk) {
 module.exports = {
   handlePolicyPost,
   handlePolicyPut,
+  getAllPolicies,
   getAllPoliciesByProduct,
   getPolicyByIdVersion,
   getPolicyById

--- a/src/handlers/products/_collectionId/POST/admin.js
+++ b/src/handlers/products/_collectionId/POST/admin.js
@@ -1,8 +1,8 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
-const { quickApiPutHandler } = require("../../../../common/data-utils");
+const { logger, sendResponse } = require("/opt/base");
 const { PRODUCT_API_PUT_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
-const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+const { createEntityWithRelationships } = require("../../../../common/relationship-utils.js");
+
 
 /**
  * @api {post} /products/{collectionId} POST
@@ -40,40 +40,16 @@ exports.handler = async (event, context) => {
     body['collectionId'] = collectionId;
     body['schema'] = "product";
 
-    // Attempt to batch create a product.
-    // If it fails, reset the counter on reserve-rec-counter table and try again.
-    let postRequests;
-    let success = false;
-    let attempt = 0;
-    const MAX_RETRIES = 3;
-    while (attempt <= MAX_RETRIES && !success) {
-      // Create the productId / identifier
-      postRequests = await parseRequest(collectionId, body, "POST", activityType, activityId);
-
-      // Use quickApiPutHandler to create the put items
-      const putItems = await quickApiPutHandler(
-        REFERENCE_DATA_TABLE_NAME,
-        postRequests,
-        PRODUCT_API_PUT_CONFIG
-      );
-
-      try {
-        attempt++;
-        await batchTransactData(putItems);
-        success = true;
-        logger.info(`Transaction succeeded on attempt ${attempt}`);
-      } catch (error) {
-        if (attempt >= MAX_RETRIES) {
-          logger.error(`Failed after ${MAX_RETRIES} attempts.`);
-          throw error;
-        }
-
-        // Short pause before attempting again
-        await new Promise((r) => setTimeout(r, attempt * 100));
-      }
-    }
-
-    logger.info(`Created product successfully`);
+    // Create product with relationships using consolidated workflow
+    let postRequests = await createEntityWithRelationships({
+      schema: 'product',
+      collectionId,
+      body,
+      parseArgs: [body.activityType, body.activityId],
+      relationshipFields: ['activities'],
+      putConfig: PRODUCT_API_PUT_CONFIG,
+      parseRequest
+    });
 
     return sendResponse(200, postRequests, "Success", null, context);
   } catch (error) {

--- a/src/handlers/products/configs.js
+++ b/src/handlers/products/configs.js
@@ -97,20 +97,19 @@ const PRODUCT_API_PUT_CONFIG = {
       }
     },
     rangeStart: {
-      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectISODateObjFormat(value)
         rf.expectAction(action, ['set']);
       }
     },
     rangeEnd: {
-      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectISODateObjFormat(value)
         rf.expectAction(action, ['set']);
       }
     },
     timezone: {
+      isMandatory: true,
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
@@ -178,6 +177,18 @@ const PRODUCT_API_PUT_CONFIG = {
       }
     },
     isVisible: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    passesRequired: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    qrCodeEnabled: {
       rulesFn: ({ value, action }) => {
         rf.expectType(value, ['boolean']);
         rf.expectAction(action, ['set']);
@@ -287,7 +298,43 @@ const PRODUCT_API_UPDATE_CONFIG = {
         rf.expectType(value, ['string']);
         rf.expectAction(action, ['set']);
       }
-    }
+    },
+    reservationPolicy: {
+      rulesFn: ({ value, action }) => {
+        rf.expectPrimaryKey(value, true);
+        rf.expectAction(action, ['set', 'remove']);
+      }
+    },
+    partyPolicy: {
+      rulesFn: ({ value, action }) => {
+        rf.expectPrimaryKey(value, true);
+        rf.expectAction(action, ['set', 'remove']);
+      }
+    },
+    feePolicy: {
+      rulesFn: ({ value, action }) => {
+        rf.expectPrimaryKey(value, true);
+        rf.expectAction(action, ['set', 'remove']);
+      }
+    },
+    changePolicy: {
+      rulesFn: ({ value, action }) => {
+        rf.expectPrimaryKey(value, true);
+        rf.expectAction(action, ['set', 'remove']);
+      }
+    },
+    passesRequired: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    qrCodeEnabled: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['boolean']);
+        rf.expectAction(action, ['set']);
+      }
+    },
   }
 };
 


### PR DESCRIPTION
### Ticket:

PRDT-121, PRDT-150

### Ticket URL:

[#121](https://github.com/bcgov/reserve-rec-admin/issues/121)
[#150](https://github.com/bcgov/reserve-rec-admin/issues/150)

### Description:
- Added `queryRelationshipsBySchema()` and `diffRelationships()` helpers to support syncing relationships on PUT. Refactored `createEntityWithRelationships()` to handle both POST and PUT flows. Extracted batch processing into a new `searchAndDeleteRelationshipsForBatch()` helper.
- Added `isOpen`, `passesRequired`, and `agreements` fields to both the PUT and UPDATE configs.
- Removed the hard requirement for `policyType`. If no type or ID is provided, falls back to `getAllPolicies()`.
- Added `getAllPolicies()` which fetches all 4 policy types (reservation, change, party, fee) in parallel and flattens the results. This should be updated later
- Swapped out the manual retry loop for a call to `createEntityWithRelationships()`, with activities as a relationship field.
- Dropped mandatory flag from `rangeStart`/`rangeEnd`, made `timezone` mandatory, added `passesRequired` and `qrCodeEnabled` to PUT config, and added all 4 policy reference fields to the UPDATE config.