### PR TITLE
PRDT-333: Parks/Facilities Landing Page Endpoint Updates

### DIFF
--- a/src/handlers/facilities/methods.js
+++ b/src/handlers/facilities/methods.js
@@ -164,11 +164,20 @@ async function getFacilityByFacilityId(collectionId, facilityType, facilityId, f
       `facility::${collectionId}`,
       `${facilityType}::${facilityId}`
     );
-    if (fetchActivities && res?.activities?.length) {
-      logger.debug(`Fetching activities: ${JSON.stringify(res.activities, null, 2)}`);
-      // Batch get the activities and staple them to the response
-      res.activities = await batchGetData(res.activities, REFERENCE_DATA_TABLE_NAME);
+    if (fetchActivities && res) {
+      const activityRelationships = await runQuery({
+        TableName: REFERENCE_DATA_TABLE_NAME,
+        KeyConditionExpression: "pk = :pk AND begins_with(sk, :sk)",
+        ExpressionAttributeValues: {
+          ":pk": { S: `rel::facility::${collectionId}::${facilityType}::${facilityId}` },
+          ":sk": { S: `activity::` },
+        },
+      });
+
+      const activityKeys = activityRelationships.items.map(rel => ({ pk: rel.pk2, sk: rel.sk2 }));
+      res.activities = await batchGetData(activityKeys, REFERENCE_DATA_TABLE_NAME);
     }
+    
     logger.debug(`Facility: ${JSON.stringify(res, null, 2)}`);
     return res;
   } catch (error) {


### PR DESCRIPTION
PRDT-333

### Ticket URL:

[#333 ](https://github.com/bcgov/reserve-rec-public/issues/333)

### Description:
- Update facilities endpoint for the `fetchActivities` query parameter - now grabs all activities related to a facility using the entityRelationship pk and `begins_with` sk.