### PR TITLE
feat:PRDT-326 public booking POST checks for inventorypool availability

### DIFF
--- a/src/common/data-utils.js
+++ b/src/common/data-utils.js
@@ -69,7 +69,7 @@ async function quickApiUpdateHandler(tableName, updateList, config = DEFAULT_API
         }
 
         // Build update expression
-        const { updateExpression, expressionAttributeNames, expressionAttributeValues } = updateExpressionBuilder(itemData);
+        const { updateExpression, expressionAttributeNames, expressionAttributeValues } = updateExpressionBuilder(itemData, item);
 
         // Create updateObject
         const updateObj = {
@@ -80,9 +80,16 @@ async function quickApiUpdateHandler(tableName, updateList, config = DEFAULT_API
             UpdateExpression: updateExpression,
             ExpressionAttributeNames: expressionAttributeNames,
             ExpressionAttributeValues: expressionAttributeValues,
-            ConditionExpression: 'attribute_exists(pk)',
           }
         };
+
+        // Add ConditionalExpression if provided in config
+        if (itemConfig?.conditionExpression) {
+          updateObj.data.ConditionExpression = itemConfig.conditionExpression;
+        } else {
+          // By default, prevent updates to non-existent items
+          updateObj.data.ConditionExpression = 'attribute_exists(pk)';
+        }
 
         // remove ExpressionAttributeValues if empty (possible if action is remove only)
         if (Object.keys(expressionAttributeValues).length === 0) {

--- a/src/handlers/bookings/POST/public.js
+++ b/src/handlers/bookings/POST/public.js
@@ -1,6 +1,6 @@
 // Create new booking
 const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
-const { createBooking } = require("../methods");
+const { createBooking, initInventoryPoolCheckRequest } = require("../methods");
 const { BOOKING_PUT_CONFIG } = require("../configs");
 const { quickApiPutHandler } = require("../../../common/data-utils");
 const { TRANSACTIONAL_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
@@ -12,6 +12,10 @@ exports.handler = async (event, context) => {
   logger.info("Bookings POST:", event);
 
   try {
+    // Get the query time
+
+    const queryTime = new Date().toISOString();
+
     // Get relevant data from the event
 
     const body = JSON.parse(event?.body);
@@ -19,19 +23,28 @@ exports.handler = async (event, context) => {
       throw new Exception("Body is required", { code: 400 });
     }
 
-  const collectionId = event?.pathParameters?.collectionId || event?.queryStringParameters?.collectionId || body?.collectionId;
-  const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType || body?.activityType;
-  const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId || body?.activityId;
-  const startDate = event?.pathParameters?.startDate || event?.queryStringParameters?.startDate || body?.startDate;
+    const collectionId = event?.pathParameters?.collectionId || event?.queryStringParameters?.collectionId || body?.collectionId;
+    const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType || body?.activityType;
+    const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId || body?.activityId;
+    const productId = event?.pathParameters?.productId || event?.queryStringParameters?.productId || body?.productId;
+    const startDate = event?.pathParameters?.startDate || event?.queryStringParameters?.startDate || body?.startDate;
 
-  const claims = getRequestClaimsFromEvent(event);
-  
-  // Reject unauthenticated users - authentication required for booking creation
-  if (!claims || !claims.sub) {
-    throw new Exception("Authentication required to create a booking", { code: 401 });
-  }
-  
-  body['userId'] = claims.sub;
+    let endDate = event?.queryStringParameters?.endDate || body?.endDate;
+    const quantity = event?.queryStringParameters?.quantity || body?.quantity;
+
+    if (!endDate) {
+      endDate = startDate;
+    }
+
+    const claims = getRequestClaimsFromEvent(event);
+
+    // Reject unauthenticated users - authentication required for booking creation
+    if (!claims || !claims.sub) {
+      throw new Exception("Authentication required to create a booking", { code: 401 });
+    }
+
+    body['userId'] = claims.sub;
+    body['endDate'] = endDate;
 
     // Validate required parameters
     const missingParams = [];
@@ -41,6 +54,8 @@ exports.handler = async (event, context) => {
     if (!activityType) missingParams.push("activityType");
     if (!activityId) missingParams.push("activityId");
     if (!startDate) missingParams.push("startDate");
+    if (!productId) missingParams.push("productId");
+    if (!quantity) missingParams.push("quantity");
 
     if (missingParams.length > 0) {
       throw new Exception(
@@ -128,31 +143,60 @@ exports.handler = async (event, context) => {
       }
     }
 
-    let postRequests = await createBooking(collectionId, activityType, activityId, startDate, body);
+    let postRequest = await createBooking(collectionId, activityType, activityId, startDate, body);
 
-    const putItems = await quickApiPutHandler(
+    let putItems = await quickApiPutHandler(
       TRANSACTIONAL_DATA_TABLE_NAME,
-      postRequests,
+      postRequest,
       BOOKING_PUT_CONFIG
     );
+
+    // === Check the relevant InventoryPools ===
+
+    // Review for availability and decrement by the appropriate quantity. The initInventoryPoolCheckRequest method prepares the necessary data for this check without using quickApiPutHandler since the logic is more complex than a standard put operation, and may involve conditional checks and updates based on current inventory levels.
+
+    // TODO: Go back and refactor the booking creation process to integrate the inventory pool check more seamlessly. It is currently added after the booking has already been initialized to avoid changing the current booking logic.
+
+    let inventoryRequests = await initInventoryPoolCheckRequest({
+      collectionId,
+      activityType,
+      activityId,
+      productId,
+      startDate,
+      endDate,
+      queryTime,
+      invQuantity: quantity
+    });
+
+    putItems = putItems.concat(inventoryRequests);
 
     const res = await batchTransactData(putItems);
 
     const response = {
       res: res,
-      booking: postRequests,
-    }
+      booking: postRequest,
+      inventoryRequests: inventoryRequests
+    };
 
     return sendResponse(200, response, "Success", null, context);
 
   } catch (error) {
     logger.error("Booking creation error:", error);
+    if (error?.name === "TransactionCanceledException") {
+      // 1. Inspect the error object
+      error.CancellationReasons.forEach((reason, index) => {
+        // 2. Identify failed items
+        if (reason.Code !== "None") {
+          console.log(`Item[${index}] Code: ${reason.Code}, Message: ${reason.Message}`);
+        }
+      });
+    }
     return sendResponse(
       Number(error?.code) || 400,
       error?.data || null,
       error?.message,
-      error?.error || error,
+      error,
       context
     );
   }
-}
+};

--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -4,6 +4,30 @@ const { ACTIVITY_TYPE_ENUMS, BOOKING_STATUS_ENUMS, SUB_ACTIVITY_TYPE_ENUMS, TIME
 const rf = new rulesFns();
 
 const BOOKING_PUT_CONFIG = {
+  developerMode: true,
+  failOnError: true,
+  autoTimeStamp: true,
+  autoVersion: true,
+  allowOverwrite: false,
+  fields: {
+    pk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    sk: {
+      isMandatory: true,
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    }
+  }
+};
+
+const BOOKING_PUT_CONFIG_TEMP = {
   failOnError: true,
   autoTimeStamp: true,
   autoVersion: true,

--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -161,6 +161,7 @@ class PublicBookingsConstruct extends LambdaConstruct {
       'src/handlers/bookings/POST',
       'public.handler',
       {
+        basicReadWrite: true,
         transDataBasicReadWrite: true,
       }
     );

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -4,12 +4,14 @@ const {
   getByGSI,
   marshall,
   runQuery,
+  getOne,
+  REFERENCE_DATA_TABLE_NAME,
   TRANSACTIONAL_DATA_TABLE_NAME,
   USERID_INDEX_NAME,
   USERID_PROPERTY_NAME,
 } = require("/opt/dynamodb");
 const { snsPublishCommand, snsPublishSend } = require("/opt/sns");
-const { Exception, logger } = require("/opt/base");
+const { Exception, logger, getNowISO } = require("/opt/base");
 const {
   getActivityByActivityId,
   getActivitiesByCollectionId,
@@ -23,6 +25,9 @@ const {
   DEFAULT_MAX_OCCUPANTS,
   DEFAULT_MAX_VEHICLES
 } = require("../../common/data-constants");
+const { PUBLIC_PRODUCTDATE_PROJECTIONS } = require("../productDates/configs");
+const { fetchProductDates } = require("../productDates/methods");
+const { DateTime } = require("luxon");
 
 /**
  * Helper: Get start of day in UTC for a date string
@@ -268,6 +273,224 @@ async function getBookingsByActivityDetails(
   }
 }
 
+async function initInventoryPoolCheckRequest(props) {
+
+  try {
+    // ==== Validate props ====
+
+    props['bypassDiscoveryRules'] = false;
+    props['projectionFields'] = PUBLIC_PRODUCTDATE_PROJECTIONS;
+
+    await validateInventoryPoolCheckProps(props);
+
+    // ==== Get Product ====
+    const productPK = `product::${props.collectionId}::${props.activityType}::${props.activityId}`;
+    const product = await getOne(productPK, props?.productId);
+
+    if (!product) {
+      throw new Exception(`Product not found (CollectionID: ${props.collectionId}, Type: ${props.activityType}, ID: ${props.activityId}, ProductID: ${props.productId})`, { code: 404 });
+    }
+
+    // ==== Get QueryTime ====
+
+    if (!product?.timezone) {
+      throw new Exception("Product timezone is required for inventory pool check", { code: 400 });
+    }
+
+    props['queryTime']= getNowISO(product?.timezone);
+
+    // ==== Get Product Dates ====
+    const productDates = await fetchProductDates(props);
+
+    logger.debug('productDates', productDates);
+
+    if (!productDates?.items || productDates.items.length === 0) {
+      throw new Exception(`No ProductDates found for Product (CollectionID: ${props.collectionId}, Type: ${props.activityType}, ID: ${props.activityId}, ProductID: ${props.productId})`, { code: 404 });
+    }
+
+    // ==== Validate Booking request against Product/ProductDate data ====
+
+    await validateBookingRequest(product, productDates, props);
+
+    // ==== At this point, the booking request is valid ====
+
+    // We can now proceed with checking Inventory. If the Inventory exists and is available, it will be allocated to the user. If enough Inventory is not available, the request will be rejected.
+
+    // ==== Get Asset Reference ====
+
+    // Note: If no AssetRef is provided in the query, we will check each ProductDate. If each ProductDate has only one AssetRef in its AssetList, we will presume that is the AssetRef to use. If there are multiple AssetRefs across ProductDates, we will throw an error and require the client to specify which AssetRef they want to book against.
+
+    // Recall that each Booking must be against exactly one Asset. Bookings against multiple Assets are not supported by the data model - To support multiple Assets, create multiple Bookings - one for each Asset.
+
+    let assetRef = props.assetRef;
+
+    if (!assetRef) {
+      for (const productDate of productDates.items) {
+        if (productDate?.assetList.length === 1) {
+          assetRef = productDate.assetList[0];
+        } else {
+          throw new Exception("Multiple AssetRefs found, please specify which AssetRef to use", { code: 400 });
+        }
+      }
+      if (!assetRef) {
+        throw new Exception("No AssetRef found for booking", { code: 404 });
+      }
+    }
+
+    // ==== Create Inventory Request ====
+
+    // Get the InventoryPool SK by assetRef
+
+    const inventorySK = [assetRef.primaryKey.pk, assetRef.primaryKey.sk].join("::");
+
+    // Iterate through the dates and generate InventoryPool PUT requests for each day against the specified Asset.
+
+    const inventoryRequests = [];
+
+    for (const productDate of productDates.items) {
+
+      // Get the InventoryPool PK from the relevant properties
+
+      const inventoryPK = `inventoryPool::${props.collectionId}::${props.activityType}::${props.activityId}::${props.productId}::${productDate.date}`;
+
+      const inventoryRequest = {
+        action: 'Update',
+        data: {
+          TableName: REFERENCE_DATA_TABLE_NAME,
+          Key: {
+            pk: marshall(inventoryPK),
+            sk: marshall(inventorySK)
+          },
+          UpdateExpression: "SET #availability = #availability - :quantity",
+          ExpressionAttributeNames: {
+            "#availability": "availability"
+          },
+          ExpressionAttributeValues: {
+            ":quantity": marshall(props?.invQuantity)
+          },
+          ConditionExpression: "attribute_exists(pk) AND #availability >= :quantity"
+        }
+      };
+
+      inventoryRequests.push(inventoryRequest);
+    }
+
+    logger.debug("Generated inventory requests for booking:", inventoryRequests);
+
+    return inventoryRequests;
+
+  } catch (error) {
+    logger.error('Failure initializing Booking:', error);
+    throw new Exception('Error initializing booking', {
+      code: 400,
+      error: error,
+    });
+
+  }
+}
+
+async function validateInventoryPoolCheckProps(props) {
+  try {
+    const requiredProps = ["collectionId", "activityType", "activityId", "productId", "startDate", "queryTime", "invQuantity"];
+    for (const prop of requiredProps) {
+      if (!props[prop]) {
+        throw new Exception(`Missing required property: ${prop}`, { code: 400 });
+      }
+    }
+  } catch (error) {
+    throw new Exception("Error validating inventory pool check properties", {
+      code: 400,
+      error: error.message || String(error),
+    });
+  }
+}
+
+async function validateBookingRequest(product, productDates, props) {
+  try {
+
+    // ===== Validate Product data ====
+
+    // Is the Product reservable?
+    if (!product?.reservationContext?.isReservable) {
+      throw "Product is not reservable";
+    }
+
+    // Are the min/max number of days allowed for booking respected?
+    const numberOfDays = productDates?.items?.length;
+
+    logger.debug(`Number of days requested: ${numberOfDays}`);
+
+    if (product.reservationContext?.minBookingDays && numberOfDays < product.reservationContext.minBookingDays) {
+      throw `Minimum ${product.reservationContext.minBookingDays} booking days required`;
+    }
+
+
+    if (product.reservationContext?.maxBookingDays && numberOfDays > product.reservationContext.maxBookingDays) {
+      throw `Maximum ${product.reservationContext.maxBookingDays} booking days allowed`;
+    }
+
+    // === Calculate queryTime in the timezone of the product for accurate reservation window validation ===
+
+    // Get the timezone from the product metadata (default to UTC if not specified)
+    const timezone = product.timezone;
+
+    // Convert the queryTime to the product's timezone
+
+    // ==== Validate ProductDate data on each day ====
+    logger.debug(`Query time: ${props.queryTime.ts}`);
+    logger.debug(`Inventory quantity requested: ${props.invQuantity}`);
+
+    for (const productDate of productDates.items) {
+
+      console.log('productDate', productDate);
+
+      // Is the ProductDate reservable?
+      if (!productDate?.reservationContext?.isReservable) {
+        throw `ProductDate ${productDate.date} is not reservable`;
+      }
+
+      // Is the queryTime within the reservation window for the ProductDate?
+      const resWindow = productDate?.reservationContext?.temporalWindows?.reservationWindow;
+
+      if (resWindow.open > props.queryTime || resWindow.close < props.queryTime) {
+        throw `It is outside the reservation window for ProductDate ${productDate.date}`;
+      }
+
+      // Is the min/max daily inventory limit respected for the ProductDate?
+
+      if (productDate?.reservationContext?.maxDailyInventory < props?.invQuantity) {
+        throw `Maximum daily inventory limit exceeded for ProductDate ${productDate.date}`;
+      }
+
+      if (productDate?.reservationContext?.minDailyInventory > props?.invQuantity) {
+        throw `Minimum daily inventory limit not met for ProductDate ${productDate.date}`;
+      }
+
+    }
+
+    // ==== Booking request is valid at this point, we can proceed with booking creation ====
+
+    return true;
+
+  } catch (error) {
+    logger.error('Error validating booking request:', error);
+    throw new Exception("Error validating booking request:", {
+      code: 400,
+      error: error,
+    });
+  }
+}
+
+
+/**
+ * This function is outdated.
+ * @param {*} collectionId
+ * @param {*} activityType
+ * @param {*} activityId
+ * @param {*} startDate
+ * @param {*} body
+ * @returns
+ */
 async function createBooking(
   collectionId,
   activityType,
@@ -305,21 +528,16 @@ async function createBooking(
     const end = getStartOfDayUTC(body.endDate);
     const today = getStartOfDayUTC(now.toISOString().split('T')[0]);
 
+    console.log('start', start);
+    console.log('end', end);
+    console.log('today', today);
+
     if (isNaN(start.getTime())) {
       throw new Exception("Invalid start date format", { code: 400 });
     }
 
     if (isNaN(end.getTime())) {
       throw new Exception("Invalid end date format", { code: 400 });
-    }
-
-    // No past dates allowed (compare start of day)
-    if (start < today) {
-      throw new Exception("Cannot book dates in the past", { code: 400 });
-    }
-
-    if (end <= start) {
-      throw new Exception("End date must be after start date", { code: 400 });
     }
 
     // Validate booking window (default: max 2 days in future, may vary by activity type)
@@ -436,55 +654,55 @@ async function createBooking(
       // Sanitized named occupant information
       namedOccupant: body.namedOccupant
         ? {
-            firstName: sanitizeString(body.namedOccupant.firstName, 100),
-            lastName: sanitizeString(body.namedOccupant.lastName, 100),
-            contactInfo: {
-              email: sanitizeString(body.namedOccupant.contactInfo?.email, 200),
-              mobilePhone: sanitizeString(
-                body.namedOccupant.contactInfo?.mobilePhone,
-                20
-              ),
-              homePhone: sanitizeString(
-                body.namedOccupant.contactInfo?.homePhone,
-                20
-              ),
-              streetAddress: sanitizeString(
-                body.namedOccupant.contactInfo?.streetAddress,
-                200
-              ),
-              unitNumber: sanitizeString(
-                body.namedOccupant.contactInfo?.unitNumber,
-                20
-              ),
-              postalCode: sanitizeString(
-                body.namedOccupant.contactInfo?.postalCode,
-                20
-              ),
-              city: sanitizeString(body.namedOccupant.contactInfo?.city, 100),
-              province: sanitizeString(
-                body.namedOccupant.contactInfo?.province,
-                50
-              ),
-              country: sanitizeString(
-                body.namedOccupant.contactInfo?.country,
-                50
-              ),
-            },
-          }
+          firstName: sanitizeString(body.namedOccupant.firstName, 100),
+          lastName: sanitizeString(body.namedOccupant.lastName, 100),
+          contactInfo: {
+            email: sanitizeString(body.namedOccupant.contactInfo?.email, 200),
+            mobilePhone: sanitizeString(
+              body.namedOccupant.contactInfo?.mobilePhone,
+              20
+            ),
+            homePhone: sanitizeString(
+              body.namedOccupant.contactInfo?.homePhone,
+              20
+            ),
+            streetAddress: sanitizeString(
+              body.namedOccupant.contactInfo?.streetAddress,
+              200
+            ),
+            unitNumber: sanitizeString(
+              body.namedOccupant.contactInfo?.unitNumber,
+              20
+            ),
+            postalCode: sanitizeString(
+              body.namedOccupant.contactInfo?.postalCode,
+              20
+            ),
+            city: sanitizeString(body.namedOccupant.contactInfo?.city, 100),
+            province: sanitizeString(
+              body.namedOccupant.contactInfo?.province,
+              50
+            ),
+            country: sanitizeString(
+              body.namedOccupant.contactInfo?.country,
+              50
+            ),
+          },
+        }
         : null,
 
       // Sanitized vehicle information (max 5 vehicles)
       vehicleInformation: Array.isArray(body.vehicleInformation)
         ? body.vehicleInformation.slice(0, 5).map((v) => ({
-            licensePlate: sanitizeString(v.licensePlate, 20),
-            licensePlateRegistrationRegion: sanitizeString(
-              v.licensePlateRegistrationRegion,
-              50
-            ),
-            vehicleMake: sanitizeString(v.vehicleMake, 50),
-            vehicleModel: sanitizeString(v.vehicleModel, 50),
-            vehicleColour: sanitizeString(v.vehicleColour, 30),
-          }))
+          licensePlate: sanitizeString(v.licensePlate, 20),
+          licensePlateRegistrationRegion: sanitizeString(
+            v.licensePlateRegistrationRegion,
+            50
+          ),
+          vehicleMake: sanitizeString(v.vehicleMake, 50),
+          vehicleModel: sanitizeString(v.vehicleModel, 50),
+          vehicleColour: sanitizeString(v.vehicleColour, 30),
+        }))
         : [],
 
       // Sanitized equipment information
@@ -496,11 +714,22 @@ async function createBooking(
       location: body.location,
     };
 
+    for (const key in bookingRequest?.contactInfo) {
+      if (!bookingRequest.contactInfo || bookingRequest.contactInfo[key] === "") {
+        delete bookingRequest.contactInfo[key];
+      }
+    }
+
+    for (const key in bookingRequest) {
+      if (!bookingRequest || bookingRequest[key] === "" || !bookingRequest[key]?.length) {
+        delete bookingRequest[key];
+      }
+    }
+
     logger.info(
       `Booking created with server-calculated price: $${feeInformation.total}`
     );
 
-    // TODO: change later to potentially support bulk bookings
     return [
       {
         key: {
@@ -510,6 +739,7 @@ async function createBooking(
         data: bookingRequest,
       },
     ];
+
   } catch (error) {
     // Re-throw Exception instances as-is
     if (error instanceof Exception) {
@@ -1044,7 +1274,7 @@ async function fetchBookingsSortedByActivity(
       // Use the activityLastKey only if we're resuming from the exact same activity
       const lastKey =
         collectionIdx === currentCollectionIndex &&
-        activityIdx === currentActivityIndex
+          activityIdx === currentActivityIndex
           ? activityLastKey
           : null;
 
@@ -1317,12 +1547,12 @@ async function fetchBookingsSortedByDate(
   const nextPageKey =
     hasMore && items.length > 0
       ? {
-          sortBy: sortBy,
-          lastItemDate: items[items.length - 1][sortBy],
-          lastItemBookedAt: items[items.length - 1].bookedAt,
-          collectionIndex: 0,
-          activityIndex: 0,
-        }
+        sortBy: sortBy,
+        lastItemDate: items[items.length - 1][sortBy],
+        lastItemBookedAt: items[items.length - 1].bookedAt,
+        collectionIndex: 0,
+        activityIndex: 0,
+      }
       : null;
 
   return {
@@ -1440,6 +1670,7 @@ module.exports = {
   getBookingsByActivityDetails,
   getBookingByBookingId,
   getBookingsByUserId,
+  initInventoryPoolCheckRequest,
   refundPublishCommand,
   sanitizeString,
   validateAdminRequirements,


### PR DESCRIPTION
relates to #326 

Some additions towards completing this ticket.

This code surgically adds `inventoryPool` checks to the existing POST bookings `createBookings` code. It will need to be revisited soon to be integrated a little better.

There is an existing DynamoDB `batchTransactWrite` operation that puts a new booking into the transactional data table when created. This code adds more items to that operation: for each day, there is an inventoryPool check operation that decrements the inventoryPool for that day by the requested amount, if possible. If there is insufficient remaining quantity or the pool does not exist, the entire `batchTransactWrite` operation fails. This allows the inventory allocation to happen at the same time the booking is created, and the creation of that booking is dependent on the exact state of inventory in the system at that time.

Several validation checks between the booking item and the inventoryPool check items are duplicated across both methods so there is ample room for cleanup.

I have to switch gears and investigate moving some time related operations to use Unix epochs instead of timestamps for improved time-checking robustness - I will return to make the cleanup changes once the epoch change is completed, since many of the cleanup changes are dependent on a functioning epoch.