### PR TITLE
fix:PRDT-326-5 - temporal anchors to now use Unix epoch

### DIFF
--- a/src/common/data-utils.js
+++ b/src/common/data-utils.js
@@ -1,5 +1,5 @@
 const { getOne, marshall, runQuery, batchGetData, REFERENCE_DATA_TABLE_NAME } = require("/opt/dynamodb");
-const { Exception, getNowISO, logger } = require("/opt/base");
+const { Exception, getNowISO, logger, epochToISO, isoToEpoch } = require("/opt/base");
 const { DEFAULT_API_UPDATE_CONFIG } = require("../common/data-constants");
 const crypto = require("crypto");
 const { DateTime, Duration } = require('luxon');
@@ -524,13 +524,20 @@ function generateGlobalId() {
 }
 
 function resolveTemporalWindow(temporalWindow, timezone, refStore = {}) {
+  const open = resolveTemporalAnchor(temporalWindow?.open, timezone, refStore);
+  const close = resolveTemporalAnchor(temporalWindow?.close, timezone, refStore);
   const resolvedWindow = {
     id: temporalWindow?.id,
     label: temporalWindow?.label,
-    open: resolveTemporalAnchor(temporalWindow?.open, timezone, refStore),
-    close: resolveTemporalAnchor(temporalWindow?.close, timezone, refStore)
+    ts: {
+      open: open.ts,
+      close: close.ts,
+    },
+    open: open.millis,
+    close: close.millis
   };
   refStore[resolvedWindow.id] = {
+    ts: resolvedWindow.ts,
     open: resolvedWindow.open,
     close: resolvedWindow.close
   };
@@ -578,6 +585,11 @@ function resolveTemporalAnchor(temporalAnchor, timezone, refStore = {}) {
     throw new Exception(`Unable to resolve temporal anchor with id ${temporalAnchor?.id}. No anchorRef or fixedDateTime provided, or anchorRef is invalid (fixedDateTime=${temporalAnchor?.fixedDateTime}, anchorRef=${temporalAnchor?.anchorRef}). `, { code: 400 });
   }
 
+  if (typeof anchorRef !== 'string') {
+    anchorRef = epochToISO(anchorRef); // Normalize the anchorRef to ISO format to handle cases where time component may be missing or in different formats.
+  }
+
+
   // Split anchorRef into calendar date and time components (if time component is not provided, we only care about calendardate.)
   // If time is not provided, and timeOfDay is not set, and keepInputTime is not set, then input time will not be considered.
   const expectDateTimeFormat = Boolean(temporalAnchor?.timeOfDay || temporalAnchor?.keepInputTime);
@@ -612,13 +624,18 @@ function resolveTemporalAnchor(temporalAnchor, timezone, refStore = {}) {
     }
     const finalDateTime = `${calendarDate}T${time}`;
     refStore[temporalAnchor?.id] = finalDateTime;
-    return finalDateTime;
+    return {
+      ts: finalDateTime,
+      millis: isoToEpoch(finalDateTime)
+    };
   }
 
   refStore[temporalAnchor?.id] = calendarDate;
 
-  return calendarDate;
-
+  return {
+    ts: calendarDate,
+    millis: isoToEpoch(calendarDate)
+  };
 }
 
 function formatProjectionsForQuery(projections) {

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -280,8 +280,11 @@ async function initInventoryPoolCheckRequest(props) {
 
     props['bypassDiscoveryRules'] = false;
     props['projectionFields'] = PUBLIC_PRODUCTDATE_PROJECTIONS;
+    props['queryTime'] = new Date().getTime();
 
     await validateInventoryPoolCheckProps(props);
+
+    logger.debug(`Inventory Request Props validated successfully: ${props}`);
 
     // ==== Get Product ====
     const productPK = `product::${props.collectionId}::${props.activityType}::${props.activityId}`;
@@ -290,14 +293,6 @@ async function initInventoryPoolCheckRequest(props) {
     if (!product) {
       throw new Exception(`Product not found (CollectionID: ${props.collectionId}, Type: ${props.activityType}, ID: ${props.activityId}, ProductID: ${props.productId})`, { code: 404 });
     }
-
-    // ==== Get QueryTime ====
-
-    if (!product?.timezone) {
-      throw new Exception("Product timezone is required for inventory pool check", { code: 400 });
-    }
-
-    props['queryTime']= getNowISO(product?.timezone);
 
     // ==== Get Product Dates ====
     const productDates = await fetchProductDates(props);
@@ -437,7 +432,7 @@ async function validateBookingRequest(product, productDates, props) {
     // Convert the queryTime to the product's timezone
 
     // ==== Validate ProductDate data on each day ====
-    logger.debug(`Query time: ${props.queryTime.ts}`);
+    logger.debug(`Query time: ${props.queryTime}`);
     logger.debug(`Inventory quantity requested: ${props.invQuantity}`);
 
     for (const productDate of productDates.items) {
@@ -527,10 +522,6 @@ async function createBooking(
     const start = getStartOfDayUTC(startDate);
     const end = getStartOfDayUTC(body.endDate);
     const today = getStartOfDayUTC(now.toISOString().split('T')[0]);
-
-    console.log('start', start);
-    console.log('end', end);
-    console.log('today', today);
 
     if (isNaN(start.getTime())) {
       throw new Exception("Invalid start date format", { code: 400 });

--- a/src/handlers/productDates/_productId/GET/admin.js
+++ b/src/handlers/productDates/_productId/GET/admin.js
@@ -3,12 +3,12 @@ const { fetchProductDates } = require("../../methods");
 
 exports.handler = async (event, context) => {
   logger.info("GET Product Dates", event);
-  
+
    // Allow CORS
     if (event.httpMethod === "OPTIONS") {
       return sendResponse(200, {}, "Success", null, context);
     }
-  
+
   try {
 
     const collectionId = event?.pathParameters?.collectionId;
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
     let startDate = event?.queryStringParameters?.startDate || null;
     let endDate = event?.queryStringParameters?.endDate || null;
 
-    let bypassDiscoveryRules = event?.queryStringParameters?.bypassDiscoveryRules === 'true' ? true : false;
+    let bypassDiscoveryRules = event?.queryStringParameters?.bypassDiscoveryRules && event.queryStringParameters.bypassDiscoveryRules === 'true' ? true : false;
 
     // If startDate and endDate are not provided, we will return the next two weeks of ProductDates for the Product by default. This is to prevent accidentally returning a huge amount of data if someone forgets to provide a date range.
 

--- a/src/handlers/productDates/methods.js
+++ b/src/handlers/productDates/methods.js
@@ -1,5 +1,5 @@
 const { logger, Exception } = require("/opt/base");
-const { getOne, batchTransactData, runQuery, REFERENCE_DATA_TABLE_NAME } = require("/opt/dynamodb");
+const { getOne, batchTransactData, runQuery, REFERENCE_DATA_TABLE_NAME, marshall } = require("/opt/dynamodb");
 const { getProductById } = require("../products/methods");
 const { buildDateRange } = require("/opt/base");
 const { DateTime } = require("luxon");
@@ -8,7 +8,7 @@ const { formatProjectionsForQuery, resolveTemporalAnchor, resolveTemporalWindow 
 async function fetchProductDates(props) {
   try {
     const {
-      queryTime = new Date().toISOString(),
+      queryTime = new Date().getTime(),
       collectionId,
       activityType,
       activityId,
@@ -18,7 +18,6 @@ async function fetchProductDates(props) {
       bypassDiscoveryRules = false,
       projectionFields = null
     } = props;
-
 
     const productDatePK = `productDate::${collectionId}::${activityType}::${activityId}::${productId}`;
 
@@ -40,7 +39,7 @@ async function fetchProductDates(props) {
         '#close': 'close'
       };
       query.ExpressionAttributeValues[':isDiscoverable'] = { BOOL: true };
-      query.ExpressionAttributeValues[':currentDateTime'] = { S: queryTime };
+      query.ExpressionAttributeValues[':currentDateTime'] = { N: String(queryTime) };
     }
 
     if (projectionFields) {
@@ -194,7 +193,7 @@ function resolveProductDateReservationContext(product, date, reservationPolicy) 
   };
 
   for (const anchor of temporalAnchors) {
-    resolvedTemporalAnchors[anchor?.id] = resolveTemporalAnchor(anchor, product?.timezone, refStore);
+    resolvedTemporalAnchors[anchor?.id] = resolveTemporalAnchor(anchor, product?.timezone, refStore).millis;
   }
 
   for (const window of temporalWindows) {

--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -352,21 +352,21 @@ async function processItem(
  */
 async function resolvePolicyReferences(item) {
   const policyFields = ['reservationPolicy', 'partyPolicy', 'feePolicy', 'changePolicy'];
-  
+
   for (const policyField of policyFields) {
     if (item[policyField]) {
       const policyRef = item[policyField];
-      
+
       // If it's just a primaryKey object, fetch and resolve the full policy
       if (policyRef.pk && policyRef.sk) {
         try {
           // Fetch the full policy from the database
           const fullPolicy = await getOne(policyRef.pk, policyRef.sk, REFERENCE_DATA_TABLE_NAME);
-          
+
           if (!fullPolicy) {
             throw new Error(`Policy not found: ${policyRef.pk}::${policyRef.sk}`);
           }
-          
+
           // Resolve policy according to Product schema
           const resolvedPolicy = {
             primaryKey: {
@@ -374,7 +374,7 @@ async function resolvePolicyReferences(item) {
               sk: policyRef.sk
             }
           };
-          
+
           // Extract Product-level fields based on policy type
           if (policyField === 'reservationPolicy') {
             resolvedPolicy.isDiscoverable = fullPolicy.isDiscoverable ?? true;
@@ -411,7 +411,7 @@ async function resolvePolicyReferences(item) {
               resolvedPolicy.rules = fullPolicy.rules;
             }
           }
-          
+
           item[policyField] = resolvedPolicy;
         } catch (error) {
           logger.error(`Error resolving ${policyField}:`, error);
@@ -421,7 +421,7 @@ async function resolvePolicyReferences(item) {
       // If it already has a primaryKey property, assume it's already resolved (for PUT requests)
     }
   }
-  
+
   return item;
 }
 
@@ -508,7 +508,7 @@ async function getProductsByActivity(orcs, activityType, activityId) {
 async function getProductById(orcs, activityType, activityId, productId, fetchObj = null, startDate = null, endDate = null) {
   logger.info('Get Product By Id');
   try {
-    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}::base`);
+    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}`);
     let promiseObj = {};
     if (fetchObj?.fetchPolicies) {
       POLICY_TYPES.map(policyType => {

--- a/src/layers/base/base.js
+++ b/src/layers/base/base.js
@@ -61,7 +61,7 @@ const sendResponse = function (code, data, message, error, context, other = null
     error: error,
     context: context
   };
-  
+
   // Prepare headers
   const headers = {
     "Content-Type": "application/json",
@@ -71,12 +71,12 @@ const sendResponse = function (code, data, message, error, context, other = null
     "Access-Control-Allow-Methods": "OPTIONS,GET,POST,PUT",
     "Access-Control-Allow-Credentials": true
   };
-  
+
   // If other fields are present, add them to body
   if (other) {
     body = Object.assign(body, other);
   }
-  
+
   const response = {
     statusCode: code,
     headers: headers,
@@ -110,13 +110,24 @@ const getNowISO = function (tz = null) {
   return getNow(tz).toISO();
 };
 
-
 const getNow = function (tz = null) {
   if (!tz) {
     tz = 'UTC';
   }
   return DateTime.now().setZone(tz);
 };
+
+const getNowEpoch = function () {
+  return DateTime.now().toMillis();
+}
+
+const epochToISO = function (epochMillis, tz = DEFAULT_TIMEZONE) {
+  return DateTime.fromMillis(epochMillis).setZone(tz).toISO();
+}
+
+const isoToEpoch = function (isoString) {
+  return DateTime.fromISO(isoString).toMillis();
+}
 
 async function httpGet(url, params = null, headers = null) {
   try {
@@ -211,22 +222,22 @@ function getRequestClaimsFromEvent(event) {
 
     // First check if this is an authenticated request via authorizer context
     const authContext = event.requestContext?.authorizer;
-    
+
     if (authContext) {
       // Check if user is authenticated (new public authorizer format)
       const isAuthenticated = authContext.isAuthenticated === 'true' || authContext.isAuthenticated === true;
-      
+
       if (!isAuthenticated) {
         // Unauthenticated user - no guest access allowed for bookings
         logger.info('Unauthenticated user detected from authorizer context - no claims available');
         return null;
       }
-      
+
       // Authenticated user - return claims from context or claims object
       if (authContext.claims) {
         return authContext.claims;
       }
-      
+
       // New context format - construct claims object from individual fields
       if (authContext.userId && authContext.userId !== 'guest') {
         return {
@@ -273,7 +284,7 @@ const VALIDATION_PATTERNS = {
  */
 const calculatePartySize = function(partyInformation) {
   if (!partyInformation) return 0;
-  return (partyInformation.adult || 0) + 
+  return (partyInformation.adult || 0) +
          (partyInformation.senior || 0) +
          (partyInformation.youth || 0) +
          (partyInformation.child || 0);
@@ -292,7 +303,7 @@ const calculatePartySize = function(partyInformation) {
 async function writeAuditLog(user, entityId, operation, metadata = {}, marshallFn, batchWriteFn, auditTableName) {
   try {
     const timestamp = new Date().toISOString();
-    
+
     const auditRecord = {
       pk: marshallFn(user),
       sk: marshallFn(timestamp),
@@ -305,7 +316,7 @@ async function writeAuditLog(user, entityId, operation, metadata = {}, marshallF
         timestamp
       })
     };
-    
+
     await batchWriteFn([auditRecord], 25, auditTableName);
     logger.debug('Audit log written', { user, entityId, operation });
   } catch (error) {
@@ -324,15 +335,15 @@ async function writeAuditLog(user, entityId, operation, metadata = {}, marshallF
 function validateSuperAdminAuth(event, operationContext = 'operation') {
   // Extract claims from authorizer context
   const claims = event.requestContext?.authorizer?.claims || getRequestClaimsFromEvent(event);
-  
+
   if (!claims) {
     logger.warn('No authorization claims found in request');
     throw new Exception("Unauthorized - Authentication required", { code: 401 });
   }
-  
+
   // Check if user is a SuperAdmin
   const cognitoGroups = claims['cognito:groups'] || [];
-  const isSuperAdmin = cognitoGroups.some(group => 
+  const isSuperAdmin = cognitoGroups.some(group =>
     group.includes('SuperAdminGroup')
   );
 
@@ -352,10 +363,13 @@ module.exports = {
   buildDateRange,
   calculatePartySize,
   checkWarmup,
+  epochToISO,
   handleCORS,
   getNow,
+  getNowEpoch,
   getNowISO,
   getRequestClaimsFromEvent,
+  isoToEpoch,
   logger,
   sendMessage,
   sendResponse,


### PR DESCRIPTION
Relates to #326 

Refer to ticket for reasoning - moving temporal anchors to use Unix epoch as opposed to ISO timestamps - this will prevent any timezone mixups between server, user, and actual park location.

Items GETs that return  results based on query time have been updated to supply epoch time.