### PR TITLE
PRDT-172: Roles and Permissions

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -1,5 +1,6 @@
 const { Duration } = require('aws-cdk-lib');
 const apigw = require('aws-cdk-lib/aws-apigateway');
+const iam = require('aws-cdk-lib/aws-iam');
 const ssm = require('aws-cdk-lib/aws-ssm');
 const { logger } = require("../helpers/utils");
 const { StackPrimer } = require("../helpers/stack-primer");
@@ -200,12 +201,23 @@ class AdminApiStack extends BaseStack {
         ADMIN_USER_POOL_CLIENT_ID: this.getConfigValue('adminUserPoolClientId') || null,
         API_STAGE: this.getConfigValue('adminApiStageName'),
         IS_OFFLINE: scope.isOffline() ? 'true' : 'false',
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
       },
       layers: [
         baseLayer,
         awsUtilsLayer,
       ]
     });
+
+    // Grant authorizer read access to the reference data table
+    const refDataTableArn = scope.resolveRefDataTableArn(this);
+    this.adminAuthorizerConstruct.adminAuthorizerFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        'dynamodb:GetItem',
+        'dynamodb:BatchGetItem'
+      ],
+      resources: [refDataTableArn, `${refDataTableArn}/index/*`],
+    }));
 
     const requestAuthorizer = this.adminAuthorizerConstruct.getRequestAuthorizer();
 

--- a/lib/admin-identity-stack/admin-identity-stack.js
+++ b/lib/admin-identity-stack/admin-identity-stack.js
@@ -1,4 +1,5 @@
 const { RemovalPolicy, CfnJson } = require('aws-cdk-lib');
+const { Function, Runtime, Code } = require('aws-cdk-lib/aws-lambda');
 const { logger } = require("../helpers/utils");
 const { StackPrimer } = require("../helpers/stack-primer");
 const cognito = require('aws-cdk-lib/aws-cognito');
@@ -42,6 +43,9 @@ const defaults = {
     },
     parkOperatorGroup: {
       name: 'ParkOperators',
+    },
+    unauthorizedUserGroup: {
+      name: 'UnauthorizedUsers',
     },
     adminIdentityPoolRoleAttachment: {
       name: 'AdminIdentityPoolRoleAttachment',
@@ -134,6 +138,9 @@ class AdminIdentityStack extends BaseStack {
       if (this.overrides.parkOperatorRoleArn) {
         this.exportReference(this, 'parkOperatorRoleArn', this.overrides.parkOperatorRoleArn, `ARN of the parkOperator role in ${this.stackId} (imported)`);
       }
+      if (this.overrides.unauthorizedUserRoleArn) {
+        this.exportReference(this, 'unauthorizedUserRoleArn', this.overrides.unauthorizedUserRoleArn, `ARN of the unauthorizedUser role in ${this.stackId} (imported)`);
+      }
 
       // Bind resolve functions to scope for other stacks to consume
       scope.resolveAdminUserPoolId = this.resolveAdminUserPoolId.bind(this);
@@ -153,6 +160,9 @@ class AdminIdentityStack extends BaseStack {
       }
       if (this.overrides.parkOperatorRoleArn) {
         scope.addRole('parkOperator', iam.Role.fromRoleArn(this, 'ImportedParkOperatorRole', this.overrides.parkOperatorRoleArn));
+      }
+      if (this.overrides.unauthorizedUserRoleArn) {
+        scope.addRole('unauthorizedUser', iam.Role.fromRoleArn(this, 'ImportedUnauthorizedUserRole', this.overrides.unauthorizedUserRoleArn));
       }
 
       logger.info('Import mode: Admin Identity Stack configured with imported resources');
@@ -388,6 +398,27 @@ class AdminIdentityStack extends BaseStack {
       roleMappings: this.adminRoleMappingJson
     });
 
+    // Create Post Confirmation Lambda Trigger to add new users to default group (unauthorizedUserGroup)
+    const postConfirmationFn = new Function(this, 'PostConfirmationTrigger', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'postConfirmation.handler',
+      code: Code.fromAsset('src/handlers/cognito'),
+      environment: {
+        UNAUTHORIZED_USER_GROUP_NAME: primer.createConstructId({ name: adminRoles.unauthorizedUser.groupName }),
+      },
+    });
+
+    // Grant permission to add users to groups
+    postConfirmationFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['cognito-idp:AdminAddUserToGroup'],
+      resources: [this.adminUserPool.userPoolArn],
+    }));
+
+    // Attach the trigger
+    this.adminUserPool.addTrigger(
+      cognito.UserPoolOperation.POST_CONFIRMATION,
+      postConfirmationFn
+    );
 
     // Export References
 

--- a/lib/admin-identity-stack/admin-roles.json
+++ b/lib/admin-identity-stack/admin-roles.json
@@ -16,5 +16,11 @@
     "roleName": "ParkOperatorRole",
     "description": "Role for park operators with access to park management features",
     "groupName": "ParkOperatorGroup"
+  },
+  "unauthorizedUser":{
+    "key": "unauthorizedUser",
+    "roleName": "UnauthorizedUserRole",
+    "description": "Role for newly added users with no permissions until assigned a specific role",
+    "groupName": "UnauthorizedUserGroup"
   }
 }

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -90,6 +90,7 @@ inject_identity_overrides() {
     SUPER_ADMIN_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/superAdminRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
     ADMINISTRATOR_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/administratorRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
     PARK_OPERATOR_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/parkOperatorRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+    UNAUTHORIZED_USER_ROLE_ARN=$(aws ssm get-parameter --region ${REGION} --name "/${APP_NAME}/${BASE_ENV}/adminIdentityStack/unauthorizedUserRoleArn" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
     
     OVERRIDES_JSON=$(cat <<EOF
 {
@@ -103,7 +104,8 @@ inject_identity_overrides() {
   "cognitoUnauthRoleArn": "${COGNITO_UNAUTH_ROLE_ARN}",
   "superAdminRoleArn": "${SUPER_ADMIN_ROLE_ARN}",
   "administratorRoleArn": "${ADMINISTRATOR_ROLE_ARN}",
-  "parkOperatorRoleArn": "${PARK_OPERATOR_ROLE_ARN}"
+  "parkOperatorRoleArn": "${PARK_OPERATOR_ROLE_ARN}",
+  "unauthorizedUserRoleArn": "${UNAUTHORIZED_USER_ROLE_ARN}"
 }
 EOF
 )

--- a/src/handlers/activities/_collectionId/DELETE/admin.js
+++ b/src/handlers/activities/_collectionId/DELETE/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { REFERENCE_DATA_TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
 const { deleteEntityRelationships } = require("../../../../common/relationship-utils");
 
@@ -8,7 +8,10 @@ const { deleteEntityRelationships } = require("../../../../common/relationship-u
  */
 exports.handler = async (event, context) => {
   logger.info(`DELETE Activities: ${event}`);
+  
   try {
+    const authContext = checkAuthContext(event, 'superadmin');
+
     const collectionId = event?.pathParameters?.collectionId;
     const activityType = event?.pathParameters?.activityType;
     const activityId = event?.pathParameters?.activityId;

--- a/src/handlers/activities/_collectionId/GET/admin.js
+++ b/src/handlers/activities/_collectionId/GET/admin.js
@@ -3,7 +3,7 @@ const {
   getActivitiesByActivityType,
   getActivityByActivityId,
 } = require("../../methods");
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("../../configs");
 
 /**
@@ -16,8 +16,10 @@ exports.handler = async (event, context) => {
   if (event?.httpMethod === "OPTIONS") {
     return sendResponse(200, null, "Success", null, context);
   }
-
+  
   try {
+    const authContext = checkAuthContext(event);
+
     const collectionId = event?.pathParameters?.collectionId;
     if (!collectionId) {
       throw new Exception("Activity Collection ID (collectionId) is required", { code: 400 });
@@ -61,6 +63,12 @@ exports.handler = async (event, context) => {
         filters,
         event?.queryStringParameters || null
       );
+    }
+
+    // If the user isn't a superadmin, remove adminNotes from the response
+    if (res && authContext.permissions !== 'superadmin') {
+      const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
+      res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }
 
     return sendResponse(200, res, "Success", null, context);

--- a/src/handlers/activities/_collectionId/POST/admin.js
+++ b/src/handlers/activities/_collectionId/POST/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { quickApiPutHandler } = require("../../../../common/data-utils");
 const { ACTIVITY_API_PUT_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -9,10 +9,12 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
  * Create Activities
  */
 exports.handler = async (event, context) => {
-  logger.info(`POST Activities - START`);
+  logger.info(`POST Activities: ${event}`);
   
   try {
-    const collectionId = String(event?.pathParameters?.collectionId);
+    const authContext = checkAuthContext(event, 'staff');
+
+    const collectionId = event?.pathParameters?.collectionId;
     if (!collectionId) {
       throw new Exception("collectionId is required", { code: 400 });
     }

--- a/src/handlers/activities/_collectionId/PUT/admin.js
+++ b/src/handlers/activities/_collectionId/PUT/admin.js
@@ -10,8 +10,11 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
  */
 exports.handler = async (event, context) => {
   logger.info(`PUT Activities: ${event}`);
+
   try {
-    const collectionId = event?.pathParameters?.collectionId;
+    const authContext = checkAuthContext(event, 'staff');
+
+    const collectionId = event?.pathParameters?.collectionId;    
     const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType || null;
     const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId || null;
 

--- a/src/handlers/authorizers/admin.js
+++ b/src/handlers/authorizers/admin.js
@@ -1,8 +1,8 @@
 // Authorizer for admin API access
 
-const { authorizeAll, generatePolicy, getDenyPolicy, parseToken, validateToken } = require('./methods');
+const { authorizeAll, generatePolicy, getDenyPolicy, parseToken, validateToken, queryAndGenerateResources } = require('./methods');
 const { logger } = require('/opt/base');
-const { getOne, USER_ID_PARTITION } = require('/opt/dynamodb');
+const { getOne, USER_ID_PARTITION, batchGetData } = require('/opt/dynamodb');
 const { CognitoJwtVerifier } = require('aws-jwt-verify');
 
 /**
@@ -93,7 +93,12 @@ exports.handler = async function (event, context, callback) {
     if (!dbConfig) {
       throw new Error("No config found for admin authorizer.");
     }
-    config = { ...dbConfig, ...config };
+    // DB values are the fallback; non-empty env vars take priority
+    config = {
+      ...dbConfig,
+      ADMIN_USER_POOL_ID: dbConfig.ADMIN_USER_POOL_ID || process.env.ADMIN_USER_POOL_ID,
+      ADMIN_USER_POOL_CLIENT_ID: dbConfig.ADMIN_USER_POOL_CLIENT_ID || process.env.ADMIN_USER_POOL_CLIENT_ID
+    };
   }
 
   // default admin verifier
@@ -106,6 +111,13 @@ exports.handler = async function (event, context, callback) {
   try {
     const headers = normalizedEvent.headers;
     const authorization = getAuthorizationToken(normalizedEvent);
+
+    // Compute the ARN prefix once
+    // e.g. arn:aws:execute-api:ca-central-1:123456789012:abc123
+    //      arn:aws:execute-api:ca-central-1: <arnParts> :<apiId>
+    const arnParts = normalizedEvent.methodArn.split(':');
+    const arnPrefix = arnParts.slice(0, 5).join(':');
+    const apiId = arnParts[5].split('/')[0];
 
     // Parse the input for methodArn
     logger.debug(`event.methodArn, ${normalizedEvent.methodArn}`);
@@ -128,42 +140,103 @@ exports.handler = async function (event, context, callback) {
 
     logger.info("Parse Token");
     const tokenData = await parseToken(headers, authorization);
-    logger.debug(`tokenData: ${tokenData}`);
+    logger.debug(`tokenData: ${JSON.stringify(tokenData)}`);
     if (tokenData?.valid && tokenData?.valid === true) {
       const payload = await validateToken(verifier, tokenData.token);
-      logger.debug(`payload: ${payload}`);
-
-      // For now, so long as the token is valid, we will allow the user.
-      // Later we will check group membership.
-
-      return await authorizeAll(event);
+      logger.debug(`payload: ${JSON.stringify(payload)}`);
 
       const sub = payload.sub;
-      logger.debug("sub:", sub);
+      logger.debug(`sub: ${sub}`);
 
-      // Grab the user's groups and inject into the context.
-      const userData = await getOne(USER_ID_PARTITION, sub);
-      logger.debug("userData:", userData);
+      // User hasn't been assigned a group in Cognito (yet)
+      if (payload?.["cognito:groups"].some(group => group === 'unauthorized' || group.length === 0)) {
+        console.log("Deny, user is in unauthorized group");
+        return generatePolicy(sub, 'Deny', normalizedEvent.methodArn);
+      } else if (payload?.["cognito:groups"].some(group => {
+        // Any users that have been manually added to the SuperAdmin group in Cognito are granted everything
+        return (group === 'ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup' ||
+                group === 'ReserveRecApi-Test-AdminIdentityStack-SuperAdminGroup');
+      })) {
+        return {
+          principalId: sub,
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [{
+              Action: 'execute-api:Invoke',
+              Effect: 'Allow',
+              Resource: `${arnPrefix}:${apiId}/*`
+            }]
+          },
+          context: {
+            isAuthenticated: 'true',
+            isAdmin: 'true',
+            permissions: JSON.stringify({ superadmin: 'superadmin' }),
+            cognitoSub: sub,
+            username: payload.username || '',
+          }
+        };
+      }
 
-      // Generate the methodArn for the user to access the API
-      if (userData.claims?.includes('sysadmin')) {
-        const arnPrefix = normalizedEvent.methodArn.split(':').slice(0, 6);
-        const joinedArnPrefix = arnPrefix.slice(0, 5).join(':');
-        const apiIDString = arnPrefix[5];
-        const apiString = apiIDString.split('/')[0];
-        const fullAPIMethods = joinedArnPrefix + ':' + apiString + '/' + process.env.STAGE_NAME + '/*';
-        console.log("fullAPIMethods:", fullAPIMethods);
-        return generatePolicy(sub, 'Allow', fullAPIMethods);
-      } else {
-        console.log("Deny");
+      // Grab the user's groups and the available staff.
+      const userData = await getOne(`${USER_ID_PARTITION}::${sub}`, 'base');
+      logger.debug(`userData: ${JSON.stringify(userData)}`);
+
+      // If no permissions, user's sub still needs to be added to database
+      if (!userData || !userData.permissions) {
+        console.log("Deny, no permissions found for user - please add user sub to database with appropriate permissions");
         return generatePolicy(sub, 'Deny', normalizedEvent.methodArn);
       }
+
+      // Get permissions as { bcparks_7: 'limited', bcparks_363: 'staff' } etc.
+      const permissions = userData.permissions
+
+      const allowedARNs = new Set();
+      const stage = process.env.STAGE_NAME || '*';
+      const basePath = `${arnPrefix}:${apiId}/${stage}`;
+
+      // Get the unique tiers this user has, e.g., "staff", "limited"
+      const userTiers = [...new Set(Object.values(permissions))];
+
+      // Get the resource maps for each tier
+      // e.g. "staff" => ["GET/facilities/*", "POST/facilities/*"]
+      //      "limited" => ["GET/facilities/*"]
+      const resourceMaps = await batchGetData(userTiers.map(tier => ({ pk: `resourceMap::${tier}`, sk: 'latest' })));
+
+      for (const resource of resourceMaps) {
+        for (const path of resource.allowedPaths) {
+          // Add the path as a wildcarded ARN
+          // e.g. "arn:.../GET/facilities/*"
+          allowedARNs.add(`${basePath}/${path}`);
+        }
+      }
+
+      // Always allow any authenticated user to retrieve their own permissions
+      allowedARNs.add(`${basePath}/GET/users/me`);
+
+      const policy = {
+        principalId: sub,
+        policyDocument: {
+          Statement: [{
+            Action: 'execute-api:Invoke',
+            Effect: 'Allow',
+            Resource: Array.from(allowedARNs)
+          }]
+        },
+        context: {
+          isAuthenticated: 'true',
+          permissions: JSON.stringify(permissions),
+          cognitoSub: sub,
+          username: payload.username || '',
+        }
+      };
+
+      return policy
     } else {
       console.log("Invalid token");
       return await getDenyPolicy(normalizedEvent.methodArn);
     }
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error("Error in admin authorizer:", e);
   }
 
   console.log("Deny");

--- a/src/handlers/authorizers/constructs.js
+++ b/src/handlers/authorizers/constructs.js
@@ -44,9 +44,8 @@ class AdminAuthorizerConstruct extends Construct {
       authorizerName: requestAuthorizerId,
       handler: this.adminAuthorizerFunction,
       identitySources: [apigw.IdentitySource.header('Authorization')],
-      // TODO: Adjust the TTL values as needed.
-      // TTL is currently disabled to ensure each request is freshly authorized.
-      resultsCacheTtl: Duration.seconds(0),
+      // TTL is currently set to 5 mins to not hit authorizer on every request
+      resultsCacheTtl: Duration.minutes(5),
     });
 
   }

--- a/src/handlers/authorizers/methods.js
+++ b/src/handlers/authorizers/methods.js
@@ -1,3 +1,4 @@
+const { getOne } = require('/opt/dynamodb');
 const { logger } = require('/opt/base');
 
 const API_STAGE = process.env.API_STAGE || 'api';
@@ -56,6 +57,11 @@ async function getUserData(sub) {
     logger.error('Error fetching user data:', error);
     throw error;
   }
+}
+
+async function queryAndGenerateResources(tier) {
+  const resources = await getOne(`resourceMap::${tier}`, `latest`);
+  return resources ? resources?.allowedResources || {} : {};
 }
 
 async function getDenyPolicy(methodArn) {
@@ -136,5 +142,6 @@ module.exports = {
   getUserData,
   handleContextAndAPIKey,
   parseToken,
-  validateToken,
+  queryAndGenerateResources,
+  validateToken,  
 };

--- a/src/handlers/cognito/postConfirmation.js
+++ b/src/handlers/cognito/postConfirmation.js
@@ -1,0 +1,20 @@
+const { CognitoIdentityProviderClient, AdminAddUserToGroupCommand } = require('@aws-sdk/client-cognito-identity-provider');
+
+const client = new CognitoIdentityProviderClient();
+
+exports.handler = async (event) => {
+  const { userPoolId, userName } = event;
+
+  // Only run for AdminCreateUser confirmations (not other trigger sources)
+  if (event.triggerSource === 'PostConfirmation_ConfirmForgotPassword') {
+    return event;
+  }
+
+  await client.send(new AdminAddUserToGroupCommand({
+    UserPoolId: userPoolId,
+    Username: userName,
+    GroupName: process.env.UNAUTHORIZED_USER_GROUP_NAME,
+  }));
+
+  return event; // Lambda triggers must return the event
+};

--- a/src/handlers/facilities/_collectionId/GET/admin.js
+++ b/src/handlers/facilities/_collectionId/GET/admin.js
@@ -3,7 +3,7 @@ const {
   getFacilitiesByFacilityType,
   getFacilityByFacilityId,
 } = require("../../methods");
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("../../configs");
 
 /**
@@ -18,6 +18,8 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    const authContext = checkAuthContext(event);
+
     const collectionId = event?.pathParameters?.collectionId;
     const facilityType = event?.pathParameters?.facilityType || event?.queryStringParameters?.facilityType || null;
     const facilityId = event?.pathParameters?.facilityId || event?.queryStringParameters?.facilityId || null;
@@ -65,6 +67,12 @@ exports.handler = async (event, context) => {
         filters,
         event?.queryStringParameters || null
       );
+    }
+
+    // If the user isn't a superadmin, remove adminNotes from the response
+    if (res && authContext.permissions?.['superadmin'] !== 'superadmin') {
+      const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
+      res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }
 
     return sendResponse(200, res, "Success", null, context);

--- a/src/handlers/facilities/_collectionId/POST/admin.js
+++ b/src/handlers/facilities/_collectionId/POST/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { quickApiPutHandler } = require("../../../../common/data-utils");
 const { FACILITY_API_PUT_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -11,6 +11,8 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
 exports.handler = async (event, context) => {
   logger.info(`POST Facilities: ${event}`);
   try {
+    const authContext = checkAuthContext(event, 'staff');
+
     const collectionId = String(event?.pathParameters?.collectionId);
     const facilityType = event?.pathParameters?.facilityType || event?.queryStringParameters?.facilityType || null;
     if (!collectionId) {

--- a/src/handlers/facilities/_collectionId/PUT/admin.js
+++ b/src/handlers/facilities/_collectionId/PUT/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { quickApiUpdateHandler } = require("../../../../common/data-utils");
 const { FACILITY_API_UPDATE_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -11,6 +11,8 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
 exports.handler = async (event, context) => {
   logger.info(`PUT Facilities: ${event}`);
   try {
+    const authContext = checkAuthContext(event, 'staff');
+
     const collectionId = event?.pathParameters?.collectionId;
     const facilityType = event?.pathParameters?.facilityType || event?.queryStringParameters?.facilityType || null;
     const facilityId = event?.pathParameters?.facilityId || event?.queryStringParameters?.facilityId || null;

--- a/src/handlers/featureFlags/GET/admin.js
+++ b/src/handlers/featureFlags/GET/admin.js
@@ -1,5 +1,5 @@
 const { getOne, REFERENCE_DATA_TABLE_NAME } = require('/opt/dynamodb');
-const { sendResponse, logger } = require('/opt/base');
+const { sendResponse, logger, checkAuthContext } = require('/opt/base');
 
 exports.handler = async (event, context) => {
   logger.debug('Get Feature Flags (admin)', event);
@@ -10,6 +10,8 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const configItem = await getOne('config', 'featureFlags', REFERENCE_DATA_TABLE_NAME);
     
     // Return full record including metadata

--- a/src/handlers/featureFlags/PUT/admin.js
+++ b/src/handlers/featureFlags/PUT/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse, validateSuperAdminAuth, writeAuditLog, getNowISO } = require('/opt/base');
+const { Exception, logger, sendResponse, checkAuthContext, writeAuditLog, getNowISO } = require('/opt/base');
 const { getOne, marshall, batchWriteData, REFERENCE_DATA_TABLE_NAME, AUDIT_TABLE_NAME, PutItemCommand } = require('/opt/dynamodb');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 
@@ -14,7 +14,7 @@ exports.handler = async (event, context) => {
 
   try {
     // Enforce superadmin authorization
-    const claims = validateSuperAdminAuth(event, 'update feature flags');
+    const authContext = checkAuthContext(event, 'superadmin');
     
     const body = JSON.parse(event?.body);
     if (!body || !body.flags) {
@@ -40,8 +40,8 @@ exports.handler = async (event, context) => {
       flags: body.flags,
       metadata: {
         lastUpdated: timestamp,
-        updatedBy: claims.sub,
-        updatedByEmail: claims.email || 'unknown'
+        updatedBy: authContext.cognitoSub || 'unknown',
+        updatedByUsername: authContext.username || 'unknown'
       },
       version: (currentConfig?.version || 0) + 1
     };
@@ -55,13 +55,13 @@ exports.handler = async (event, context) => {
 
     // Write audit log
     await writeAuditLog(
-      claims.sub,
+      authContext.cognitoSub,
       'featureFlags',
       'FEATURE_FLAGS_UPDATE',
       {
         previousFlags,
         newFlags: body.flags,
-        changedBy: claims.email || claims.sub,
+        changedBy: authContext.username || authContext.cognitoSub,
         timestamp
       },
       marshall,
@@ -69,7 +69,7 @@ exports.handler = async (event, context) => {
       AUDIT_TABLE_NAME
     );
 
-    logger.info('Feature flags updated successfully', { updatedBy: claims.sub, newFlags: body.flags });
+    logger.info('Feature flags updated successfully', { updatedBy: authContext.cognitoSub, newFlags: body.flags });
 
     return sendResponse(200, {
       flags: updatedConfig.flags,

--- a/src/handlers/geozones/_collectionId/DELETE/admin.js
+++ b/src/handlers/geozones/_collectionId/DELETE/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { REFERENCE_DATA_TABLE_NAME, marshall, batchTransactData, getOne } = require("/opt/dynamodb");
 const { deleteEntityRelationships } = require("../../../../common/relationship-utils.js");
 
@@ -9,6 +9,8 @@ const { deleteEntityRelationships } = require("../../../../common/relationship-u
 exports.handler = async (event, context) => {
   logger.info("DELETE Geozones", event);
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const collectionId = event?.pathParameters?.collectionId;
     const geozoneId = event?.pathParameters?.geozoneId;
     const body = event?.body ? JSON.parse(event.body) : null;

--- a/src/handlers/geozones/_collectionId/GET/admin.js
+++ b/src/handlers/geozones/_collectionId/GET/admin.js
@@ -2,7 +2,7 @@ const {
   getGeozonesByCollectionId,
   getGeozonesByGeozoneId,
 } = require("../../methods");
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("../../configs");
 
 /**
@@ -17,6 +17,8 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    const authContext = checkAuthContext(event);
+
     const collectionId = event?.pathParameters?.collectionId;
     const geozoneId = event?.pathParameters?.geozoneId || event?.queryStringParameters?.geozoneId || null;
 
@@ -58,6 +60,12 @@ exports.handler = async (event, context) => {
         filters,
         event?.queryStringParameters || null
       );
+    }
+
+    // If the user isn't a superadmin, remove adminNotes from the response
+    if (res && authContext.permissions !== 'superadmin') {
+      const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
+      res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }
 
     return sendResponse(200, res, "Success", null, context);

--- a/src/handlers/geozones/_collectionId/POST/admin.js
+++ b/src/handlers/geozones/_collectionId/POST/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext} = require("/opt/base");
 const { quickApiPutHandler } = require("../../../../common/data-utils");
 const { GEOZONE_API_PUT_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -11,6 +11,8 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
 exports.handler = async (event, context) => {
   logger.info("POST Geozones", event);
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const collectionId = String(event?.pathParameters?.collectionId);
 
     if (!collectionId) {

--- a/src/handlers/geozones/_collectionId/PUT/admin.js
+++ b/src/handlers/geozones/_collectionId/PUT/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { quickApiUpdateHandler } = require("../../../../common/data-utils");
 const { GEOZONE_API_UPDATE_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -11,6 +11,8 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
 exports.handler = async (event, context) => {
   logger.info("PUT Geozones", event);
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const collectionId = event?.pathParameters?.collectionId;
     const geozoneId = event?.pathParameters?.geozoneId || event?.queryStringParameters?.geozoneId || null;
 

--- a/src/handlers/products/_collectionId/DELETE/admin.js
+++ b/src/handlers/products/_collectionId/DELETE/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { REFERENCE_DATA_TABLE_NAME, marshall, batchTransactData } = require("/opt/dynamodb");
 const { deleteEntityRelationships } = require("../../../../common/relationship-utils");
 
@@ -9,6 +9,8 @@ const { deleteEntityRelationships } = require("../../../../common/relationship-u
 exports.handler = async (event, context) => {
   logger.info(`DELETE Products: ${event}`);
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const collectionId = event?.pathParameters?.collectionId;
     const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType;
     const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId;

--- a/src/handlers/products/_collectionId/GET/admin.js
+++ b/src/handlers/products/_collectionId/GET/admin.js
@@ -1,9 +1,8 @@
 const {
   getProductsByCollectionId,
-  getProductsByActivityType,
   getProductByProductId,
 } = require("../../methods");
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("../../configs");
 
 /**
@@ -18,6 +17,8 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    const authContext = checkAuthContext(event);
+
     const collectionId = event?.pathParameters?.collectionId;
     if (!collectionId) {
       throw new Exception("Product Collection ID (collectionId) is required", { code: 400 });
@@ -66,6 +67,12 @@ exports.handler = async (event, context) => {
         filters,
         event?.queryStringParameters || null
       );
+    }
+
+    // If the user isn't a superadmin, remove adminNotes from the response
+    if (res && authContext.permissions !== 'superadmin') {
+      const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
+      res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }
 
     return sendResponse(200, res, "Success", null, context);

--- a/src/handlers/products/_collectionId/POST/admin.js
+++ b/src/handlers/products/_collectionId/POST/admin.js
@@ -1,4 +1,4 @@
-const { logger, sendResponse } = require("/opt/base");
+const { logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { PRODUCT_API_PUT_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
 const { createEntityWithRelationships } = require("../../../../common/relationship-utils.js");
@@ -11,6 +11,8 @@ const { createEntityWithRelationships } = require("../../../../common/relationsh
 exports.handler = async (event, context) => {
   logger.info("POST Products", event);
   try {
+    const authContext = checkAuthContext(event, "superadmin");
+
     const body = JSON.parse(event?.body);
     const collectionId = String(event?.pathParameters?.collectionId);
     const activityType = event?.queryStringParameters?.activityType || event.pathParameters?.activityType || body?.activityType;

--- a/src/handlers/products/_collectionId/PUT/admin.js
+++ b/src/handlers/products/_collectionId/PUT/admin.js
@@ -1,4 +1,4 @@
-const { Exception, logger, sendResponse } = require("/opt/base");
+const { Exception, logger, sendResponse, checkAuthContext } = require("/opt/base");
 const { quickApiUpdateHandler } = require("../../../../common/data-utils");
 const { PRODUCT_API_UPDATE_CONFIG } = require("../../configs");
 const { parseRequest } = require("../../methods");
@@ -11,6 +11,8 @@ const { REFERENCE_DATA_TABLE_NAME, batchTransactData } = require("/opt/dynamodb"
 exports.handler = async (event, context) => {
   logger.info("PUT Products", event);
   try {
+    const authContext = checkAuthContext(event, "staff");
+
     const collectionId = event?.pathParameters?.collectionId;
     const activityType = event?.pathParameters?.activityType || event?.queryStringParameters?.activityType || null;
     const activityId = event?.pathParameters?.activityId || event?.queryStringParameters?.activityId || null;

--- a/src/handlers/reports/GET/admin.js
+++ b/src/handlers/reports/GET/admin.js
@@ -10,7 +10,7 @@
  *   - facilityId (optional): Filter by specific activity/facility ID
  */
 
-const { logger, sendResponse, handleCORS, Exception, validateSuperAdminAuth } = require("/opt/base");
+const { logger, sendResponse, handleCORS, Exception, checkAuthContext } = require("/opt/base");
 const { runQuery, getOne, TRANSACTIONAL_DATA_TABLE_NAME, REFERENCE_DATA_TABLE_NAME } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {
@@ -30,6 +30,10 @@ exports.handler = async (event, context) => {
     if (!collectionId) {
       throw new Exception("collectionId is required", { code: 400 });
     }
+
+    // Require at least 'staff' tier for this collection; superadmins always pass
+    checkAuthContext(event, 'staff', collectionId);
+
     if (!arrivalDate) {
       throw new Exception("arrivalDate is required", { code: 400 });
     }

--- a/src/handlers/users/constructs.js
+++ b/src/handlers/users/constructs.js
@@ -8,6 +8,9 @@ const defaults = {
     getUsersFunction: {
       name: 'GetUsersFunction',
     },
+    getMeFunction: {
+      name: 'GetMeFunction',
+    },
     searchUsersFunction: {
       name: 'SearchUsersFunction',
     }
@@ -23,6 +26,9 @@ class UsersConstruct extends LambdaConstruct {
 
     // Add /users resource
     this.usersResource = this.resolveApi().root.addResource('users');
+
+    // GET /users/me
+    this.meResource = this.usersResource.addResource('me');
 
     // Add /UserPool identifier resource
     this.userPoolIdResource = this.usersResource.addResource('{userPoolId}');
@@ -63,6 +69,20 @@ class UsersConstruct extends LambdaConstruct {
       ],
       resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
     }));
+
+    // GET /users/me returns the calling user's permissions from the authorizer context
+    this.getMeFunction = this.generateBasicLambdaFn(
+      scope,
+      'getMeFunction',
+      'src/handlers/users/me/GET',
+      'index.handler',
+      {} // no DynamoDB access needed — reads from authorizer context only
+    );
+
+    this.meResource.addMethod('GET', new apigateway.LambdaIntegration(this.getMeFunction), {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
 
     // POST /users/search - Search users in OpenSearch
     this.searchResource = this.usersResource.addResource('search');

--- a/src/handlers/users/me/GET/index.js
+++ b/src/handlers/users/me/GET/index.js
@@ -1,0 +1,20 @@
+const { sendResponse, logger } = require('/opt/base');
+
+
+// GET /users/me
+// Returns the calling user's sub and permissions object
+exports.handler = async function (event, context) {
+  logger.debug('User GET /me', JSON.stringify(event));
+
+  const authorizer = event?.requestContext?.authorizer;
+  const sub = authorizer?.principalId || null;
+  let permissions = {};
+
+  try {
+    permissions = JSON.parse(authorizer?.permissions || '{}');
+  } catch (e) {
+    logger.warn('Could not parse permissions from authorizer context');
+  }
+
+  return sendResponse(200, { sub, permissions }, 'User retrieved successfully', null, context);
+};

--- a/src/layers/base/base.js
+++ b/src/layers/base/base.js
@@ -199,6 +199,61 @@ async function sendMessage(targetConnectionId, domainName, stage, message) {
   }
 }
 
+function checkAuthContext(event, requiredTier = null, collectionId = null) {
+  // Accept explicit collectionId (e.g. from query params) or fall back to path parameter
+  const colId = collectionId || event?.pathParameters?.collectionId;
+  
+  try {
+    const authContext = {
+      sub: event.requestContext?.authorizer?.principalId || event.requestContext?.claims?.sub,
+    };
+
+    authContext.permissions = JSON.parse(event?.requestContext?.authorizer?.permissions || '{}');
+    const isSuperAdmin = authContext.permissions['superadmin'] === 'superadmin';
+
+    if (isSuperAdmin) {
+      return authContext; // SuperAdmin has access to everything, don't need to check further
+    }
+
+    // If a collectionId is specified, check authContext.permissions for that collection
+    if (colId) {
+      if (!authContext.permissions[colId]) {
+        throw new Exception(
+          "Unauthorized: User does not have access to this specific collection.",
+          { code: 403 },
+        );
+      }
+
+      // If a requiredTier is specified e.g. 'staff' for POST/PUT,
+      // verify the user's tier for this collection matches
+      if (requiredTier && authContext.permissions[colId] !== requiredTier) {
+        throw new Exception(
+          `Unauthorized: User does not have the required permission tier for this operation.`,
+          { code: 403 },
+        );
+      }
+
+    // No collectionId — check that the user holds the required tier in at least one collection
+    } else {
+      if (requiredTier && !Object.values(authContext.permissions).includes(requiredTier)) {
+        throw new Exception(
+          `Unauthorized: User does not have the required permission tier for this operation.`,
+          { code: 403 },
+        );
+      }
+    }
+
+    return authContext;
+  } catch (e) {
+    // Let errors bubble up
+    if (e instanceof Exception) {
+      throw e;
+    }
+    logger.warn('Could not parse permissions from authorizer context');
+    throw new Exception("Unauthorized - Invalid permissions format", { code: 401 });
+  }
+}
+
 function getRequestClaimsFromEvent(event) {
   try {
     // Check Authorization header for JWT token
@@ -368,6 +423,7 @@ module.exports = {
   getNow,
   getNowEpoch,
   getNowISO,
+  checkAuthContext,
   getRequestClaimsFromEvent,
   isoToEpoch,
   logger,


### PR DESCRIPTION
### Ticket:

PRDT-172

### Ticket URL:

[#172](https://github.com/bcgov/reserve-rec-admin/issues/172)

### Description:
- Update the `admin` authorizer to provide a fulsome policy and auth context based on queries from the database
  - Queries the user's `sub` and finds their `userid::<sub>` record which contains their `permissions` attribute, e.g. `{ bcparks_7: "staff" }`
  - Uses the permissions attribute to find the `resourceMap::<tier>` which contains allowable endpoints and methods for that tier (e.g. `allowedPaths: [ "GET/facilities*", ... ]`)
  - Creates a policy statement with this information:
  
  ```json
  {
    "principalId": <sub>,
    "policyDocument": {
        "Statement": [
            {
                "Action": "execute-api:Invoke",
                "Effect": "Allow",
                "Resource": [
                    "arn:aws:execute-api:ca-central-1:<aws-id>:<api-id>/*/GET/facilities*",
                    ...
                ]
            }
        ]
    },
    "context": {
        "isAuthenticated": "true",
        "permissions": "{\"bcparks_7\":\"staff\"}",
        "cognitoSub": <sub>,
        "username": "<username>"
    }

- Users added to the Cognito group for `superadmin` are granted full permissions.
- Users are unable to make requests to endpoints based on the `Resource` statement, they are blocked without the `execute-api:Invoke` action.

- Created an `checkAuthContext` to parse users based on their roles and permissions.
  - `superadmin` are given full access
  - Checks if a user has permissions to the collectionId
  - Checks if a user has the required tier (e.g. 'staff') for the collectionId
  - Throws errors if these permissions do not match what's required by `checkAuthContext`
  
- Also added preliminary permission checks to `geozones`, `facilities`, `activities`, and `products` to ensure permissions work as expected

- Added a `users/me` endpoint for authenticating users in the admin and providing a permissions object based on the user's allowed permissions

- Also added a `postConfirmation` lambda that _should_ sort users into an `unauthorizedUser` group where they will need to wait until they're manually removed before being given permissions. Wasn't able to test in sandbox, so this might take a few more PRs.