### PR TITLE
fix:PRDT-56 confirmation email to use account email rather than named occupant email

### DIFF
--- a/lib/handlers/emailDispatch/utils.js
+++ b/lib/handlers/emailDispatch/utils.js
@@ -63,6 +63,7 @@ async function sendReceiptEmail(params) {
  */
 async function sendConfirmationEmail(params) {
   const {
+    email,
     bookingData,
     customerData,
     locationData,
@@ -76,7 +77,7 @@ async function sendConfirmationEmail(params) {
   const emailPayload = createEmailPayload({
     messageType: 'confirmation',
     templateName: templateName,
-    recipientEmail: customerData.email,
+    recipientEmail: email,
     recipientName: `${customerData.firstName} ${customerData.lastName}`,
     subject: `Booking Confirmation - ${locationData.parkName}`,
     locale: locale,

--- a/lib/helpers/base-lambda.js
+++ b/lib/helpers/base-lambda.js
@@ -227,11 +227,14 @@ class LambdaConstruct extends Construct {
       });
       if (props?.basicRead) {
         this.grantBasicRefDataTableRead(fn);
-      } else if (props?.basicReadWrite) {
+      }
+      if (props?.basicReadWrite) {
         this.grantBasicRefDataTableReadWrite(fn);
-      } else if (props?.transDataBasicRead) {
+      }
+      if (props?.transDataBasicRead) {
         this.grantBasicTransDataTableRead(fn);
-      } else if (props?.transDataBasicReadWrite) {
+      }
+      if (props?.transDataBasicReadWrite) {
         this.grantBasicTransDataTableReadWrite(fn);
       }
       return fn;

--- a/src/handlers/authorizers/public.js
+++ b/src/handlers/authorizers/public.js
@@ -137,6 +137,7 @@ exports.handler = async function (event, context, callback) {
   }
 
   // Create verifier only if we have valid config
+  // TODO: Consider using tokenUse 'id' instead of 'access' if the frontend can be updated to use ID tokens for auth (more standard for Cognito)
   let verifier = null;
   if (config.PUBLIC_USER_POOL_ID && config.PUBLIC_USER_POOL_CLIENT_ID) {
     verifier = CognitoJwtVerifier.create({
@@ -150,6 +151,23 @@ exports.handler = async function (event, context, callback) {
     const headers = normalizedEvent.headers;
     const authorization = getAuthorizationToken(normalizedEvent);
 
+    // DEBUG: Log authorization status
+    logger.info("==== AUTHORIZATION DEBUG ====");
+    logger.info(`Authorization header present: ${!!authorization}`);
+    logger.info(`Verifier created: ${!!verifier}`);
+    if (authorization) {
+      logger.info(`Authorization header value (first 30 chars): ${authorization.substring(0, 30)}...`);
+    }
+    if (verifier) {
+      logger.info(`User Pool ID: ${config.PUBLIC_USER_POOL_ID}`);
+      logger.info(`Client ID: ${config.PUBLIC_USER_POOL_CLIENT_ID}`);
+    } else {
+      logger.error(`❌ Verifier NOT created!`);
+      logger.error(`USER_POOL_ID set: ${!!config.PUBLIC_USER_POOL_ID}`);
+      logger.error(`CLIENT_ID set: ${!!config.PUBLIC_USER_POOL_CLIENT_ID}`);
+    }
+    logger.info("============================");
+
     // Parse the methodArn to construct wildcard policy
     const arnPrefix = normalizedEvent.methodArn.split(':').slice(0, 6);
     const joinedArnPrefix = arnPrefix.slice(0, 5).join(':');
@@ -161,23 +179,42 @@ exports.handler = async function (event, context, callback) {
     let payload = null;
     let isAuthenticated = false;
 
-    if (authorization && verifier) {
-      logger.info("Attempting to parse and validate token");
-      const tokenData = await parseToken(headers, authorization);
-      
-      if (tokenData?.valid && tokenData?.valid === true) {
-        try {
-          payload = await validateToken(verifier, tokenData.token);
-          isAuthenticated = true;
-          logger.info("Token is valid - authenticated user");
-          logger.debug(`payload: ${JSON.stringify(payload)}`);
-        } catch (error) {
-          logger.info("Token validation failed - treating as guest");
-          logger.debug(`Token validation error: ${error}`);
-        }
-      }
+    if (!authorization) {
+      logger.info("❌ No authorization header - defaulting to guest");
+    } else if (!verifier) {
+      logger.error("❌ Verifier not available - cannot validate token - defaulting to guest");
     } else {
-      logger.info("No authorization token present - guest access");
+      logger.info("✓ Authorization header present and verifier ready - attempting validation");
+
+      try {
+        const tokenData = await parseToken(headers, authorization);
+        logger.info(`Token parse result: valid=${tokenData?.valid}, hasToken=${!!tokenData?.token}`);
+
+        if (tokenData?.valid && tokenData?.valid === true) {
+          try {
+            logger.info("Attempting token validation with Cognito...");
+            payload = await validateToken(verifier, tokenData.token);
+            isAuthenticated = true;
+            logger.info("✓✓ TOKEN VALIDATED SUCCESSFULLY - User authenticated");
+            logger.info(`User sub: ${payload?.sub}`);
+            logger.info(`Username: ${payload?.username || 'N/A'}`);
+            logger.debug(`Full payload: ${JSON.stringify(payload)}`);
+          } catch (error) {
+            logger.error("❌ Token validation failed - treating as guest");
+            logger.error(`Validation error: ${error.message}`);
+            logger.error(`Error name: ${error.name}`);
+            logger.debug(`Error stack: ${error.stack}`);
+          }
+        } else {
+          logger.warn("❌ Token parse returned invalid - check token format");
+          logger.warn(`Expected format: 'Authorization: Bearer <token>'`);
+          logger.debug(`Parsed token data: ${JSON.stringify(tokenData)}`);
+        }
+      } catch (parseError) {
+        logger.error("❌ Error during token parsing:");
+        logger.error(`Parse error: ${parseError.message}`);
+        logger.debug(`Parse error stack: ${parseError.stack}`);
+      }
     }
 
     // Generate policy with appropriate context

--- a/src/handlers/bookings/_bookingId/complete/POST/public.js
+++ b/src/handlers/bookings/_bookingId/complete/POST/public.js
@@ -1,7 +1,8 @@
 // Create new transaction
-const { Exception, logger, sendResponse } = require("/opt/base");
-const { completeBooking } = require("../../../methods")
+const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
+const { completeBooking, sendBookingConfirmationEmail } = require("../../../methods");
 const { batchTransactData } = require("/opt/dynamodb");
+
 
 exports.handler = async (event, context) => {
   logger.info("POST Complete Booking:", event);
@@ -20,9 +21,15 @@ exports.handler = async (event, context) => {
       throw new Exception("Session ID is required", { code: 400 });
     }
 
-    const updateRequests = await completeBooking(bookingId, sessionId, body);
+    const claims = getRequestClaimsFromEvent(event);
+
+    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body);
 
     const res = await batchTransactData(updateRequests);
+
+    logger.info('Booking completion updates applied. Sending confirmation email.');
+
+    await sendBookingConfirmationEmail(emailParams, claims?.username);
 
     const response = {
       res: res,

--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -183,8 +183,17 @@ class PublicBookingsConstruct extends LambdaConstruct {
       'public.handler',
       {
         transDataBasicReadWrite: true,
+        basicRead: true,
       }
     );
+
+    // Add permissions for Lambda to read from Cognito User Pools
+    this.bookingsCompleteFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        "cognito-idp:AdminGetUser"
+      ],
+      resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
+    }));
 
     // POST /bookings/{bookingId}/cancel Lambda function
     this.bookingsCancelPostFunction = this.generateBasicLambdaFn(
@@ -194,6 +203,7 @@ class PublicBookingsConstruct extends LambdaConstruct {
       'index.handler',
       {
         transDataBasicReadWrite: true,
+        basicRead: true,
       }
     );
 

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -12,6 +12,7 @@ const {
 } = require("/opt/dynamodb");
 const { snsPublishCommand, snsPublishSend } = require("/opt/sns");
 const { Exception, logger } = require("/opt/base");
+const { sendConfirmationEmail, getRegionBranding } = require("../../../lib/handlers/emailDispatch/utils");
 const {
   getActivityByActivityId,
   getActivitiesByCollectionId,
@@ -21,16 +22,15 @@ const {
   DEFAULT_PRICE,
   DEFAULT_TRANSACTION_FEE_PERCENT,
   DEFAULT_TAX_PERCENT,
-  DEFAULT_MAX_BOOKING_DAYS_AHEAD,
-  DEFAULT_MAX_OCCUPANTS,
-  DEFAULT_MAX_VEHICLES,
-  BOOKING_STATUS_ENUMS
+  BOOKING_STATUS_ENUMS,
+  PARK_NAMES_BY_COLLECTION_ID
 } = require("../../common/data-constants");
 const { PUBLIC_PRODUCTDATE_PROJECTIONS } = require("../productDates/configs");
 const { fetchProductDates } = require("../productDates/methods");
 const { DateTime } = require("luxon");
 const { BOOKING_PUT_CONFIG, BOOKINGDATES_PUT_CONFIG, BOOKING_UPDATE_CONFIG } = require("./configs");
 const { unmarshall } = require("@aws-sdk/util-dynamodb");
+const { getUserInfoByUserName } = require("../users/methods");
 
 const DEFAULT_SESSION_LENGTH = 30; // in minutes
 
@@ -981,6 +981,7 @@ async function completeBooking(bookingId, sessionId, props) {
       // === Server-controlled fields ===
       bookingCompletionTime: queryTime,
       status: BOOKING_STATUS_ENUMS[1],
+      // Remove pending state from GSI1
       isPending: { action: 'remove' },
       // // Sanitized named occupant information
       namedOccupant: props?.namedOccupant
@@ -1055,14 +1056,65 @@ async function completeBooking(bookingId, sessionId, props) {
       BOOKING_UPDATE_CONFIG
     );
 
-    console.log('bookingUpdateRequest', bookingUpdateRequest);
+    const emailParams = await generateEmailParams(booking, updatedBookingItem);
 
-    return bookingUpdateRequest;
+    return {
+      updateRequests: bookingUpdateRequest,
+      emailParams: emailParams
+    };
 
 
   } catch (error) {
     logger.error(`Booking finalization failed.`);
     throw error;
+  }
+}
+
+async function generateEmailParams(booking, updatedBookingItem) {
+  try {
+
+    // get bookingDates
+    const bookingDates = await getBookingDatesByBookingId(booking.bookingId);
+
+    // get parkName
+    const parkName = PARK_NAMES_BY_COLLECTION_ID[booking.collectionId];
+
+    let emailParams = {
+      booking: {
+        bookingId: booking.bookingId,
+        invQuantity: bookingDates?.items?.reduce((total, item) => {
+          const dailyInventory = item.quantity || 0;
+          return total + dailyInventory;
+        }, 0),
+        arrivalDate: booking.reservationContext?.arrivalDate?.ts,
+        departureDate: booking.reservationContext?.departureDate?.ts,
+        accountBookingUrl: null,
+        activityType: booking.activityType.charAt(0).toUpperCase() + booking.activityType.slice(1),
+        productName: booking.displayName,
+        qrCodeDataUrl: null,
+        cancellationUrl: null,
+      },
+      customer: {
+        firstName: updatedBookingItem.namedOccupant?.firstName || '',
+        lastName: updatedBookingItem.namedOccupant?.lastName || '',
+        licensePlate: updatedBookingItem.vehicleInformation?.[0]?.licensePlate || '',
+        licensePlateRegion: updatedBookingItem.vehicleInformation?.[0]?.licensePlateRegistrationRegion || '',
+      },
+      location: {
+        parkName: parkName
+      },
+      branding: {
+        logoUrl: 'https://bcparks.ca/assets/logos/default-logo.png',
+      }
+    };
+
+    console.log('emailParams', emailParams);
+
+    return emailParams;
+
+  } catch (error) {
+    logger.error('Error generating email parameters for booking confirmation:', error);
+    return null;
   }
 }
 
@@ -2027,7 +2079,7 @@ async function getBookingDatesByBookingId(bookingId) {
 async function flagCancelledBooking(booking, queryTime) {
   try {
 
-      const updateItem = {
+    const updateItem = {
       TableName: TRANSACTIONAL_DATA_TABLE_NAME,
       Key: {
         pk: { S: booking.pk },
@@ -2044,7 +2096,7 @@ async function flagCancelledBooking(booking, queryTime) {
         ":cancelledAt": { N: queryTime.toString() },
         ":isPending": { S: 'PENDING' },
       }
-    }
+    };
 
     // return update formatted for batchTransactData
     return [
@@ -2057,6 +2109,103 @@ async function flagCancelledBooking(booking, queryTime) {
   } catch (error) {
     logger.error(`Error flagging cancelled booking ${booking.bookingId}.`);
     throw error;
+  }
+}
+
+/**
+ * Send booking confirmation email to SQS queue
+ * @param {object} booking - Booking data from DynamoDB
+ * @returns {Promise<Object>} SQS response
+ */
+async function sendBookingConfirmationEmail(booking, userName) {
+  try {
+
+    // get account email:
+    const userInfo = await getUserInfoByUserName(userName, 'public');
+
+    const accountEmail = userInfo?.UserAttributes?.find(attr => attr.Name === 'email')?.Value;
+
+    if (!accountEmail) {
+      logger.warn('Cannot send confirmation email - no email address found for user', {
+        bookingId: booking.bookingId,
+        userName: userName
+      });
+      return null;
+    }
+
+    // Calculate number of guests from partyContext
+    const partyInfo = booking.partyContext || {};
+    const numberOfGuests = (partyInfo.adult || 0) + (partyInfo.youth || 0) + (partyInfo.child || 0) + (partyInfo.senior || 0) || 1;
+
+    // Extract booking data
+    const bookingData = {
+      bookingId: booking.bookingId || booking.globalId,
+      bookingReference: booking.bookingReference || booking.bookingId || booking.globalId,
+      startDate: booking.startDate,
+      endDate: booking.endDate,
+      numberOfNights: booking.reservationContext?.totalDays || 1,
+      numberOfGuests: numberOfGuests,
+      status: booking.status || 'in-progress'
+    };
+
+    // Extract location data
+    const locationData = {
+      parkName: booking.displayName || 'BC Parks',
+      facilityName: booking.displayName || booking.facilityName,
+      siteNumber: booking.siteNumber,
+      region: booking.collectionId || 'default',
+      address: booking.address
+    };
+
+    // Extract customer data from namedOccupant
+    const namedOccupant = booking.namedOccupant || {};
+    const contactInfo = namedOccupant.contactInfo || {};
+
+
+    const customerData = {
+      firstName: namedOccupant.firstName || 'Guest',
+      lastName: namedOccupant.lastName || '',
+      email: contactInfo.email,
+      phone: contactInfo.mobilePhone,
+      address: {
+        street: contactInfo.streetAddress || '',
+        city: contactInfo.city || '',
+        province: contactInfo.province || '',
+        postalCode: contactInfo.postalCode || '',
+        country: contactInfo.country || 'CA'
+      }
+    };
+
+    // Get region-specific branding
+    const brandingData = {};
+    // const brandingData = getRegionBranding(locationData);
+
+    // Send confirmation email to SQS queue
+    const result = await sendConfirmationEmail({
+      email: accountEmail,
+      bookingData,
+      customerData,
+      locationData,
+      brandingData,
+      locale: booking.locale || 'en'
+    });
+
+    logger.info('Booking confirmation email queued successfully', {
+      bookingId: booking.bookingId,
+      recipient: customerData.email,
+      messageId: result.messageId
+    });
+
+    return result;
+
+  } catch (error) {
+    logger.error('Failed to queue booking confirmation email', {
+      bookingId: booking?.bookingId,
+      error: error.message,
+      stack: error.stack
+    });
+    // Don't throw - email failure shouldn't break the booking flow
+    return null;
   }
 }
 
@@ -2081,6 +2230,7 @@ module.exports = {
   initInventoryPoolCheckRequest,
   refundPublishCommand,
   sanitizeString,
+  sendBookingConfirmationEmail,
   validateAdminRequirements,
   validateDateRange,
   validateCollectionAccess,

--- a/src/handlers/users/methods.js
+++ b/src/handlers/users/methods.js
@@ -1,0 +1,43 @@
+const { adminGetUser } = require("/opt/cognito");
+const { logger } = require("/opt/base");
+const { getOne } = require("/opt/dynamodb");
+
+async function getUserInfoByUserName(userName, userPoolId = 'public') {
+  // This function retrieves user information from the Cognito user pool based on the user's userName
+  try {
+
+      if (userPoolId === 'admin' || userPoolId === 'public') {
+        // Shortform to get the appropriate user pool ID from config variables
+        // Instead of passing the full user pool ID, clients can pass 'admin' or 'public'
+        const config = await getOne('config', userPoolId);
+        if (userPoolId === 'admin' && config && config?.ADMIN_USER_POOL_ID) {
+          userPoolId = config.ADMIN_USER_POOL_ID;
+        } else if (userPoolId === 'public' && config && config?.PUBLIC_USER_POOL_ID) {
+          userPoolId = config.PUBLIC_USER_POOL_ID;
+        }
+      }
+
+    const user = await adminGetUser(userPoolId, userName);
+
+    return user;
+  } catch (error) {
+    logger.error('Error fetching user info from Cognito:', error);
+    throw new Error('Error fetching user info');
+  }
+}
+
+async function getUsersByUserPoolId(userPoolId, props = {}) {
+  // This function retrieves a list of users from the specified Cognito user pool
+  try {
+    const users = await listUsers(userPoolId, 60);
+    return users;
+  } catch (error) {
+    logger.error('Error fetching users from Cognito', error);
+    throw new Error('Error fetching users');
+  }
+}
+
+module.exports = {
+  getUserInfoByUserName,
+  getUsersByUserPoolId
+}


### PR DESCRIPTION
Relates to https://github.com/bcgov/reserve-rec-public/issues/56.

Intermediate to updating confirmation emails is ensuring the email goes to the right place. The current logic takes the email from the namedOccupant fields and adds an email to that address to the queue. This change ensures the email goes to the address associated with the account holder (the one making the booking).

The account email is determined by using the `claims` from the POST `/bookings/complete` event. The username is used to get user information from the appropriate Cognito Pool. Note: It may actually be easier to change the Authorization token type from `access` to `id`, such that the user's information is tokenized rather than their permissions. Public permissions will be limited and virtually the same for every user anyways. I leave that decision up to another ticket.

Some authorizer logic was changed by Claude to actually get the correct token to come through. Beforehand, the public authorizer was always failing and defaulting to `guest` users on API calls. We probably didnt figure this out already because the public front ends use Amplify to handle user information, and there is no difference between guest users and authorized users. 

Email logic follows a successful booking. The success/failure of the email being send has no influence on the success/failure of the booking itself. If the email fails, the user will simply fail to get a confirmation email.

Updating confirmation email designs will now follow this update.
