### PR TITLE
bug:PRDT-165-9, removing ::base suffix from getProductById

### DIFF
--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -522,7 +522,7 @@ async function getProductsByActivity(orcs, activityType, activityId) {
 async function getProductById(orcs, activityType, activityId, productId, fetchObj = null, startDate = null, endDate = null) {
   logger.info('Get Product By Id');
   try {
-    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}::base`);
+    let res = await getOne(`product::${orcs}::${activityType}::${activityId}`, `${productId}`);
     let promiseObj = {};
     if (fetchObj?.fetchPolicies) {
       POLICY_TYPES.map(policyType => {
@@ -748,7 +748,7 @@ async function fetchProducts(collectionId, activityType, activityId, productId, 
     let res = null;
     let filters = {};
     let allowedFilters = ALLOWED_FILTERS;
-    
+
     // Loop through each allowed filter to check if it's in queryParams
     allowedFilters.forEach((filter) => {
       if (queryParams[filter.name]) {
@@ -765,8 +765,8 @@ async function fetchProducts(collectionId, activityType, activityId, productId, 
     // Get product by productId
     if (productId) {
       res = await getProductByProductId(
-        collectionId, 
-        activityType, 
+        collectionId,
+        activityType,
         activityId,
         productId
       );


### PR DESCRIPTION
Small change: the `sk` of a product is now just `<productId>`. It used to be `<productId>::base` a long time ago but we have since moved beyond the need of the `::base` suffix. 

Team message justification https://teams.cloud.microsoft/l/message/19:163facd69a2e4fe1a14eac3ae95fb3c4@thread.tacv2/1775864147649?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&groupId=aadf267c-d6ab-4c8c-9cff-e574713575e6&parentMessageId=1775864147649&teamName=External%3A%20Team%20Osprey&channelName=Dev%20Chat&createdTime=1775864147649