### PR TITLE
PRDT-340-3: add missing deps for naming

### DIFF
--- a/lib/admin-api-stack/admin-activities-nested-stack/admin-activities-nested-stack.js
+++ b/lib/admin-api-stack/admin-activities-nested-stack/admin-activities-nested-stack.js
@@ -12,6 +12,8 @@ class ActivitiesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmACT`;

--- a/lib/admin-api-stack/admin-bcsc-nested-stack/admin-bcsc-nested-stack.js
+++ b/lib/admin-api-stack/admin-bcsc-nested-stack/admin-bcsc-nested-stack.js
@@ -18,6 +18,8 @@ class BCSCNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmBCSC`;

--- a/lib/admin-api-stack/admin-bookings-nested-stack/admin-bookings-nested-stack.js
+++ b/lib/admin-api-stack/admin-bookings-nested-stack/admin-bookings-nested-stack.js
@@ -20,6 +20,8 @@ class BookingsNestedStack extends NestedStack {
     super(scope, id, props);
     // Propagate scope helpers from parent stack so LambdaConstructs work inside NestedStack
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
 

--- a/lib/admin-api-stack/admin-config-nested-stack/admin-config-nested-stack.js
+++ b/lib/admin-api-stack/admin-config-nested-stack/admin-config-nested-stack.js
@@ -18,6 +18,8 @@ class AdminConfigNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmCFG`;

--- a/lib/admin-api-stack/admin-facilities-nested-stack/admin-facilities-nested-stack.js
+++ b/lib/admin-api-stack/admin-facilities-nested-stack/admin-facilities-nested-stack.js
@@ -12,6 +12,8 @@ class FacilitiesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmFA`;

--- a/lib/admin-api-stack/admin-feature-flags-nested-stack/admin-feature-flags-nested-stack.js
+++ b/lib/admin-api-stack/admin-feature-flags-nested-stack/admin-feature-flags-nested-stack.js
@@ -18,6 +18,8 @@ class FeatureFlagsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmFF`;

--- a/lib/admin-api-stack/admin-geozones-nested-stack/admin-geozones-nested-stack.js
+++ b/lib/admin-api-stack/admin-geozones-nested-stack/admin-geozones-nested-stack.js
@@ -12,6 +12,8 @@ class GeozonesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmGZ`;

--- a/lib/admin-api-stack/admin-ping-nested-stack/admin-ping-nested-stack.js
+++ b/lib/admin-api-stack/admin-ping-nested-stack/admin-ping-nested-stack.js
@@ -18,6 +18,8 @@ class PingNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmPING`;

--- a/lib/admin-api-stack/admin-policies-nested-stack/admin-policies-nested-stack.js
+++ b/lib/admin-api-stack/admin-policies-nested-stack/admin-policies-nested-stack.js
@@ -18,6 +18,8 @@ class PoliciesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmPOL`;

--- a/lib/admin-api-stack/admin-product-management-nested-stack/admin-product-management-nested-stack.js
+++ b/lib/admin-api-stack/admin-product-management-nested-stack/admin-product-management-nested-stack.js
@@ -12,6 +12,8 @@ class ProductManagementNestedStack extends NestedStack {
     // This is used by LambdaConstruct for building resource IDs
     this.concreteStackId = `${scope.stackId}-AdmPM`;
     this.createScopedId = scope.createScopedId?.bind(scope);
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
 
     // Reconstruct the API reference from the imported IDs (scoped to this nested stack)

--- a/lib/admin-api-stack/admin-products-nested-stack/admin-products-nested-stack.js
+++ b/lib/admin-api-stack/admin-products-nested-stack/admin-products-nested-stack.js
@@ -12,6 +12,8 @@ class ProductsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmPRD`;

--- a/lib/admin-api-stack/admin-relationships-nested-stack/admin-relationships-nested-stack.js
+++ b/lib/admin-api-stack/admin-relationships-nested-stack/admin-relationships-nested-stack.js
@@ -18,6 +18,8 @@ class RelationshipsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmREL`;

--- a/lib/admin-api-stack/admin-reports-nested-stack/admin-reports-nested-stack.js
+++ b/lib/admin-api-stack/admin-reports-nested-stack/admin-reports-nested-stack.js
@@ -18,6 +18,8 @@ class ReportsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmREP`;

--- a/lib/admin-api-stack/admin-search-nested-stack/admin-search-nested-stack.js
+++ b/lib/admin-api-stack/admin-search-nested-stack/admin-search-nested-stack.js
@@ -18,6 +18,8 @@ class AdminSearchNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmSRCH`;

--- a/lib/admin-api-stack/admin-users-nested-stack/admin-users-nested-stack.js
+++ b/lib/admin-api-stack/admin-users-nested-stack/admin-users-nested-stack.js
@@ -20,6 +20,8 @@ class UsersNestedStack extends NestedStack {
     super(scope, id, props);
     // Propagate scope helpers from parent stack so LambdaConstructs work inside NestedStack
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
 

--- a/lib/admin-api-stack/admin-verify-nested-stack/admin-verify-nested-stack.js
+++ b/lib/admin-api-stack/admin-verify-nested-stack/admin-verify-nested-stack.js
@@ -19,6 +19,8 @@ class VerifyNestedStack extends NestedStack {
     super(scope, id, props);
     // Propagate scope helpers from parent stack so LambdaConstructs work inside NestedStack
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     // Distinct prefix for Lambda function names inside this nested stack.

--- a/lib/admin-api-stack/admin-waiting-room-nested-stack/admin-waiting-room-nested-stack.js
+++ b/lib/admin-api-stack/admin-waiting-room-nested-stack/admin-waiting-room-nested-stack.js
@@ -19,6 +19,8 @@ class AdminWaitingRoomNestedStack extends NestedStack {
     super(scope, id, props);
     // Propagate scope helpers from parent stack so LambdaConstructs work inside NestedStack
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-AdmWR`;

--- a/lib/public-api-stack/public-activities-nested-stack/public-activities-nested-stack.js
+++ b/lib/public-api-stack/public-activities-nested-stack/public-activities-nested-stack.js
@@ -18,6 +18,8 @@ class PublicActivitiesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubACT`;

--- a/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
+++ b/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
@@ -22,6 +22,8 @@ class PublicBookingsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubBKG`;

--- a/lib/public-api-stack/public-config-nested-stack/public-config-nested-stack.js
+++ b/lib/public-api-stack/public-config-nested-stack/public-config-nested-stack.js
@@ -18,6 +18,8 @@ class PublicConfigNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubCFG`;

--- a/lib/public-api-stack/public-facilities-nested-stack/public-facilities-nested-stack.js
+++ b/lib/public-api-stack/public-facilities-nested-stack/public-facilities-nested-stack.js
@@ -21,6 +21,8 @@ class PublicFacilitiesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubFAC`;

--- a/lib/public-api-stack/public-feature-flags-nested-stack/public-feature-flags-nested-stack.js
+++ b/lib/public-api-stack/public-feature-flags-nested-stack/public-feature-flags-nested-stack.js
@@ -18,6 +18,8 @@ class PublicFeatureFlagsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubFF`;

--- a/lib/public-api-stack/public-geozones-nested-stack/public-geozones-nested-stack.js
+++ b/lib/public-api-stack/public-geozones-nested-stack/public-geozones-nested-stack.js
@@ -21,6 +21,8 @@ class PublicGeozonesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubGEO`;

--- a/lib/public-api-stack/public-ping-nested-stack/public-ping-nested-stack.js
+++ b/lib/public-api-stack/public-ping-nested-stack/public-ping-nested-stack.js
@@ -18,6 +18,8 @@ class PublicPingNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubPING`;

--- a/lib/public-api-stack/public-product-dates-nested-stack/public-product-dates-nested-stack.js
+++ b/lib/public-api-stack/public-product-dates-nested-stack/public-product-dates-nested-stack.js
@@ -21,6 +21,8 @@ class PublicProductDatesNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubPD`;

--- a/lib/public-api-stack/public-products-nested-stack/public-products-nested-stack.js
+++ b/lib/public-api-stack/public-products-nested-stack/public-products-nested-stack.js
@@ -19,6 +19,8 @@ class PublicProductsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubPRD`;

--- a/lib/public-api-stack/public-search-nested-stack/public-search-nested-stack.js
+++ b/lib/public-api-stack/public-search-nested-stack/public-search-nested-stack.js
@@ -18,6 +18,8 @@ class PublicSearchNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubSRCH`;

--- a/lib/public-api-stack/public-transactions-nested-stack/public-transactions-nested-stack.js
+++ b/lib/public-api-stack/public-transactions-nested-stack/public-transactions-nested-stack.js
@@ -21,6 +21,8 @@ class PublicTransactionsNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubTXN`;

--- a/lib/public-api-stack/public-waiting-room-nested-stack/public-waiting-room-nested-stack.js
+++ b/lib/public-api-stack/public-waiting-room-nested-stack/public-waiting-room-nested-stack.js
@@ -18,6 +18,8 @@ class PublicWaitingRoomNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubWR`;

--- a/lib/public-api-stack/public-worldline-notification-nested-stack/public-worldline-notification-nested-stack.js
+++ b/lib/public-api-stack/public-worldline-notification-nested-stack/public-worldline-notification-nested-stack.js
@@ -18,6 +18,8 @@ class PublicWorldlineNotificationNestedStack extends NestedStack {
   constructor(scope, id, props) {
     super(scope, id, props);
     this.createScopedId = scope.createScopedId;
+    this.getAppName = scope.getAppName;
+    this.getDeploymentName = scope.getDeploymentName;
     this.appScope = scope.appScope;
     this._parentStackId = scope._stackId;
     this.concreteStackId = `${scope.stackId}-PubWLN`;


### PR DESCRIPTION
### Ticket:

PRDT-340-3

### Ticket URL:

#340

### Description:
- Fix missing getAppName and getDeploymentName from nested stack. These items were missing and therefore defaulting to the nested stack names, causing the collisions.
