### PR TITLE
fix: remove auth from public browse endpoints

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -612,6 +612,213 @@ class PublicApiStack extends BaseStack {
       dataTraceEnabled: true,
     });
 
+    // Public Config Getters
+    this.publicConfigLambdas = new PublicConfigLambdas(this, this.getConstructId('publicConfigLambdas'), {
+      layers: [
+        baseLayer,
+        awsUtilsLayer
+      ],
+      api: this.publicApi
+    });
+
+    // Public OpenSearch Search Function
+    const searchEndpoint = `https://${scope.resolveOpenSearchDomainEndpoint(this)}`;
+    this.publicSearchConstruct = new PublicSearchLambda(this, this.getConstructId('publicSearchLambda'), {
+      opensearchDomainArn: opensearchDomainArn,
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        OPENSEARCH_DOMAIN_ENDPOINT: searchEndpoint,
+        OPENSEARCH_REFERENCE_DATA_INDEX_NAME: this.getConfigValue('opensearchReferenceDataIndexName'),
+        OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME: this.getConfigValue('opensearchTransactionalIndexName'),
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer
+    });
+
+    // Geozone Lambdas
+    this.geozonesConstruct = new GeozonesConstruct(this, this.getConstructId('geozonesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'admin',
+      publicRead: true,
+    });
+
+    // Facilities Lambdas
+    this.publicFacilitiesConstruct = new PublicFacilitiesConstruct(this, this.getConstructId('publicFacilitiesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+    });
+
+    // Activities Lambdas
+    this.activitiesConstruct = new ActivitiesConstruct(this, this.getConstructId('activitiesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+        WAITING_ROOM_TABLE_NAME: scope.resolveWaitingRoomTableName(),
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'public',
+      publicRead: true,
+    });
+    // Grant read access so the public GET handler can check waiting room status
+    scope.getWaitingRoomTable().grantReadData(this.activitiesConstruct.activitiesCollectionIdGetFunction);
+
+    // Products Lambdas
+    this.publicProductsConstruct = new PublicProductsConstruct(this, this.getConstructId('publicProductsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+    });
+
+    // Bookings Lambdas
+    this.publicBookingsConstruct = new PublicBookingsConstruct(this, this.getConstructId('publicBookingsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+        TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
+        BOOKING_NOTIFICATION_TOPIC_ARN: bookingNotificationTopicArn,
+        QR_SECRET_KEY: this.getSecretValue('qrSecretKey'),
+        PUBLIC_FRONTEND_DOMAIN: publicFrontendDomain,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'public',
+      kmsKey: kmsKey,
+    });
+
+    // Transactions Lambdas
+    this.transactionsConstruct = new TransactionsConstruct(this, this.getConstructId('transactionsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
+        MERCHANT_ID: this.getSecretValue('merchantId'),
+        HASH_KEY: this.getSecretValue('hashKey'),
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      refundRequestTopicArn: refundRequestTopicArn,
+      kmsKey: kmsKey,
+    });
+
+    // Worldline Notification Lambdas
+    this.worldlineNotificationConstruct = new WorldlineNotificationConstruct(this, this.getConstructId('worldlineNotificationConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        TRANSACTIONAL_DATA_TABLE_NAME: transactionalDataTableName,
+        WORLDLINE_WEBHOOK_SECRET: this.getSecretValue('worldlineWebhookSecret'),
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      emailQueueUrl: emailQueueUrl,
+      emailQueueArn: emailQueueArn,
+      kmsKey: kmsKey,
+    });
+
+    // Feature Flags Lambdas
+    this.publicFeatureFlagsConstruct = new PublicFeatureFlagsConstruct(this, this.getConstructId('publicFeatureFlagsConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+    });
+
+    // ProductDates Lambdas
+    this.publicProductDatesConstruct = new PublicProductDatesConstruct(this, this.getConstructId('publicProductDatesConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        REFERENCE_DATA_TABLE_NAME: referenceDataTableName,
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      handlerPrefix: 'public',
+    });
+
+    // Waiting Room API Lambdas — join + claim + heartbeat endpoints
+    this.waitingRoomPublicConstruct = new WaitingRoomPublicConstruct(this, this.getConstructId('waitingRoomPublicConstruct'), {
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        WAITING_ROOM_TABLE_NAME: scope.resolveWaitingRoomTableName(),
+        HMAC_SIGNING_KEY_ARN: scope.resolveHmacSigningKeyArn(),
+        ADMISSION_TTL_MINUTES: '15',
+        MAX_ADMISSION_MINUTES: '30',
+        MAX_ENTRIES_PER_IP: '4',
+        MIN_ACCOUNT_AGE_HOURS: '0',
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer,
+      ],
+      api: this.publicApi,
+      authorizer: requestAuthorizer,
+      waitingRoomTable: scope.getWaitingRoomTable(),
+      hmacSigningKey: scope.getHmacSigningKey(),
+    });
+
+    // Add WAITING_ROOM_TABLE_NAME + HMAC_SIGNING_KEY_ARN to the booking POST Lambda
+    // so it can enforce admission token requirements when a waiting room is active.
+    this.publicBookingsConstruct.bookingsPostFunction.addEnvironment(
+      'WAITING_ROOM_TABLE_NAME', scope.resolveWaitingRoomTableName()
+    );
+    this.publicBookingsConstruct.bookingsPostFunction.addEnvironment(
+      'HMAC_SIGNING_KEY_ARN', scope.resolveHmacSigningKeyArn()
+    );
+    // Grant DynamoDB read access on WR table and Secrets Manager read access for HMAC key
+    scope.getWaitingRoomTable().grantReadData(this.publicBookingsConstruct.bookingsPostFunction);
+    scope.getHmacSigningKey().grantRead(this.publicBookingsConstruct.bookingsPostFunction);
+
     // WAF: enforce X-Origin-Verify header so only CloudFront can reach the API Gateway stage
     // Path uses reserveRecApi (camelCase) matching sandbox-setup.sh APP_NAME convention
     const originVerifySecretPath = `/reserveRecApi/${this.getDeploymentName()}/originVerifySecret`;

--- a/src/handlers/activities/constructs.js
+++ b/src/handlers/activities/constructs.js
@@ -27,6 +27,12 @@ class ActivitiesConstruct extends LambdaConstruct {
 
     const handlerPrefix = props?.handlerPrefix || 'admin';
     const handlerName = `${handlerPrefix}.handler`;
+    const getAuthType = props?.publicRead
+      ? apigw.AuthorizationType.NONE
+      : apigw.AuthorizationType.CUSTOM;
+    const getAuthOptions = props?.publicRead
+      ? {}
+      : { authorizer: this.resolveAuthorizer() };
 
     // Add /activities resource
     this.activitiesResource = this.resolveApi().root.addResource('activities');
@@ -56,14 +62,14 @@ class ActivitiesConstruct extends LambdaConstruct {
 
     // GET /activities/{collectionId}
     this.activitiesCollectionIdResource.addMethod('GET', new apigw.LambdaIntegration(this.activitiesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: getAuthType,
+      ...getAuthOptions,
     });
 
     // GET /activities/{collectionId}/{activityType}/{activityId}
     this.activitiesActivityIdResource.addMethod('GET', new apigw.LambdaIntegration(this.activitiesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: getAuthType,
+      ...getAuthOptions,
     });
 
     // Activities POST by Collection ID Lambda Function (admin-only, no public handler)

--- a/src/handlers/facilities/constructs.js
+++ b/src/handlers/facilities/constructs.js
@@ -57,20 +57,17 @@ class PublicFacilitiesConstruct extends LambdaConstruct {
 
     // GET /facilities/{collectionId}
     this.facilitiesCollectionIdResource.addMethod('GET', new apigw.LambdaIntegration(this.facilitiesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
 
     // GET /facilities/{collectionId}/{facilityType}
     this.facilitiesFacilityTypeResource.addMethod('GET', new apigw.LambdaIntegration(this.facilitiesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
 
     // GET /facilities/{collectionId}/{facilityType}/{facilityId}
     this.facilitiesFacilityIdResource.addMethod('GET', new apigw.LambdaIntegration(this.facilitiesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
 
     // Add permissions to all functions

--- a/src/handlers/geozones/constructs.js
+++ b/src/handlers/geozones/constructs.js
@@ -27,6 +27,12 @@ class GeozonesConstruct extends LambdaConstruct {
 
     const handlerPrefix = props?.handlerPrefix || 'public';
     const handlerName = `${handlerPrefix}.handler`;
+    const getAuthType = props?.publicRead
+      ? apigw.AuthorizationType.NONE
+      : apigw.AuthorizationType.CUSTOM;
+    const getAuthOptions = props?.publicRead
+      ? {}
+      : { authorizer: this.resolveAuthorizer() };
 
     // Add /geozones resource
     this.geozonesResource = this.resolveApi().root.addResource('geozones');
@@ -56,14 +62,14 @@ class GeozonesConstruct extends LambdaConstruct {
 
     // GET /geozones/{collectionId}
     this.geozonesCollectionIdResource.addMethod('GET', new apigw.LambdaIntegration(this.geozonesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: getAuthType,
+      ...getAuthOptions,
     });
 
     // GET /geozones/{collectionId}/{geozoneId}
     this.geozonesGeozoneIdResource.addMethod('GET', new apigw.LambdaIntegration(this.geozonesCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: getAuthType,
+      ...getAuthOptions,
     });
 
     // Geozones POST by Collection ID Lambda Function

--- a/src/handlers/productDates/constructs.js
+++ b/src/handlers/productDates/constructs.js
@@ -129,8 +129,7 @@ class PublicProductDatesConstruct extends LambdaConstruct {
 
     // GET /product-dates/{collectionId}/{activityType}/{activityId}/{productId}
     this.productDatesByProductResource.addMethod('GET', new apigw.LambdaIntegration(this.productDatesGetByDatesFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
   }
 }

--- a/src/handlers/products/constructs.js
+++ b/src/handlers/products/constructs.js
@@ -57,14 +57,12 @@ class PublicProductsConstruct extends LambdaConstruct {
 
     // GET /products/{collectionId}
     this.productsCollectionIdResource.addMethod('GET', new apigw.LambdaIntegration(this.productsCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
 
     // GET /products/{collectionId}/{activityType}/{activityId}
     this.productsActivityIdResource.addMethod('GET', new apigw.LambdaIntegration(this.productsCollectionIdGetFunction), {
-      authorizationType: apigw.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigw.AuthorizationType.NONE,
     });
 
     // Add permissions to all functions

--- a/src/handlers/search/constructs.js
+++ b/src/handlers/search/constructs.js
@@ -84,8 +84,7 @@ class PublicSearchLambda extends LambdaConstruct {
 
     // Add POST method to /search resource
     this.searchResource.addMethod('POST', new apigateway.LambdaIntegration(this.searchFunction), {
-      authorizationType: apigateway.AuthorizationType.CUSTOM,
-      authorizer: this.resolveAuthorizer(),
+      authorizationType: apigateway.AuthorizationType.NONE,
     });
 
     // Add OpenSearch policy to the function


### PR DESCRIPTION
Public GET endpoints for facilities, activities, products, product-dates, geozones, and POST /search were incorrectly requiring a JWT token (CUSTOM authorizer). Browse access should be unauthenticated — only booking and transactional endpoints require auth.

- `PublicFacilitiesConstruct`: CUSTOM → NONE on all 3 GET methods
- `PublicProductsConstruct`: CUSTOM → NONE on both GET methods
- `PublicProductDatesConstruct`: CUSTOM → NONE on GET method
- `PublicSearchLambda`: CUSTOM → NONE on POST /search
- `ActivitiesConstruct`: added `publicRead` prop; GET methods use NONE when true, CUSTOM otherwise (POST/PUT/DELETE always CUSTOM)
- `GeozonesConstruct`: same `publicRead` conditional pattern
- `public-api-stack`: pass `publicRead: true` to Geozones and Activities constructs

Ref #366