### PR TITLE
fix: resolve WAF origin-verify secret at deploy time, not synth time

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -2,5 +2,6 @@
   "key-provider:account=623829546818:aliasName=alias/ReserveRecApi-Dev-CoreStack-KmsKey:region=ca-central-1": {
     "keyId": "b6b19e5b-4d1b-44ef-9b6b-a11dc5ad3df0"
   },
-  "ssm:account=623829546818:parameterName=/reserveRecApi/dev/originVerifySecret:region=ca-central-1": "aca696bfbf371e3ce8adebd7924fd444a125a726767fcf5defda22a74ec1a39b"
+  "ssm:account=623829546818:parameterName=/reserveRecApi/dev/originVerifySecret:region=ca-central-1": "aca696bfbf371e3ce8adebd7924fd444a125a726767fcf5defda22a74ec1a39b",
+  "ssm:account=628373393242:parameterName=/reserveRecApi/prod/originVerifySecret:region=ca-central-1": "e29192055009d71c8ba62b1cc4acb8fd5ff6d05e325eed84c12056f9d70d55fd"
 }

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,7 +1,5 @@
 {
   "key-provider:account=623829546818:aliasName=alias/ReserveRecApi-Dev-CoreStack-KmsKey:region=ca-central-1": {
     "keyId": "b6b19e5b-4d1b-44ef-9b6b-a11dc5ad3df0"
-  },
-  "ssm:account=623829546818:parameterName=/reserveRecApi/dev/originVerifySecret:region=ca-central-1": "aca696bfbf371e3ce8adebd7924fd444a125a726767fcf5defda22a74ec1a39b",
-  "ssm:account=628373393242:parameterName=/reserveRecApi/prod/originVerifySecret:region=ca-central-1": "e29192055009d71c8ba62b1cc4acb8fd5ff6d05e325eed84c12056f9d70d55fd"
+  }
 }

--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -822,7 +822,7 @@ class PublicApiStack extends BaseStack {
     // WAF: enforce X-Origin-Verify header so only CloudFront can reach the API Gateway stage
     // Path uses reserveRecApi (camelCase) matching sandbox-setup.sh APP_NAME convention
     const originVerifySecretPath = `/reserveRecApi/${this.getDeploymentName()}/originVerifySecret`;
-    const originVerifySecret = ssm.StringParameter.valueFromLookup(this, originVerifySecretPath);
+    const originVerifySecret = ssm.StringParameter.valueForStringParameter(this, originVerifySecretPath);
 
     const originVerifyWebAcl = new wafv2.CfnWebACL(this, this.getConstructId('originVerifyWebAcl'), {
       scope: 'REGIONAL',


### PR DESCRIPTION
`valueFromLookup` cached the `originVerifySecret` in `cdk.context.json`. When that cached value was absent (e.g. a fresh checkout or an excluded commit), CDK synthesized a template without the WAF resource — causing it to be silently deleted on the next prod deploy and leaving the API Gateway unprotected.

- Switch to `valueForStringParameter` so CloudFormation resolves the SSM value at deploy time; the secret never touches source control
- Remove the previously committed dev-account `originVerifySecret` value from `cdk.context.json`

Ref #366