### PR TITLE
feat: wire refDataStream Lambda to reference data DynamoDB stream

### DIFF
--- a/lib/reference-data-stack/reference-data-stack.js
+++ b/lib/reference-data-stack/reference-data-stack.js
@@ -205,25 +205,27 @@ class ReferenceDataStack extends BaseStack {
     });
 
     // Setup DynamoDB Stream processing Lambda
-    // this.dynamoStreamConstruct = new DynamoStreamConstruct(this, this.getConstructId('dynamoStream'), {
-    //   table: this.refDataTable,
-    //   handlerPrefix: 'refDataStream',
-    //   tablesCreatedByCDK: true,
-    //   environment: {
-    //     LOG_LEVEL: this.getConfigValue('logLevel'),
-    //     OPENSEARCH_DOMAIN_ENDPOINT: osDomainUrl,
-    //     REFERENCE_DATA_TABLE_NAME: this.getRefDataTableName(),
-    //     OPENSEARCH_REFERENCE_DATA_INDEX_NAME: scope.resolveOpenSearchReferenceDataIndexName(this),
-    //     OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME: scope.resolveOpenSearchTransactionalDataIndexName(this),
-    //     AUDIT_TABLE_NAME: this.auditTable.tableName,
-    //     PUBSUB_TABLE_NAME: this.pubsubTable.tableName,
-    //   },
-    //   layers: [
-    //     baseLayer,
-    //     awsUtilsLayer
-    //   ],
-    //   role: this.dynamoStreamRole,
-    // });
+    this.dynamoStreamConstruct = new DynamoStreamConstruct(this, this.getConstructId('dynamoStream'), {
+      table: this.refDataTable,
+      handlerPrefix: 'refDataStream',
+      tablesCreatedByCDK: true,
+      environment: {
+        LOG_LEVEL: this.getConfigValue('logLevel'),
+        OPENSEARCH_DOMAIN_ENDPOINT: osDomainUrl,
+        REFERENCE_DATA_TABLE_NAME: this.getRefDataTableName(),
+        OPENSEARCH_REFERENCE_DATA_INDEX_NAME: scope.resolveOpenSearchReferenceDataIndexName(this),
+        OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME: scope.resolveOpenSearchTransactionalDataIndexName(this),
+        AUDIT_TABLE_NAME: this.auditTable.tableName,
+        PUBSUB_TABLE_NAME: this.pubsubTable.tableName,
+        WEBSOCKET_URL: scope.resolveWsApiUrl ? scope.resolveWsApiUrl(this) : '',
+        API_STAGE: 'ws',
+      },
+      layers: [
+        baseLayer,
+        awsUtilsLayer
+      ],
+      role: this.dynamoStreamRole,
+    });
 
     // Export References
 


### PR DESCRIPTION
The `DynamoStreamConstruct` in `reference-data-stack` was commented out, so no Lambda existed to sync reference data table changes to OpenSearch. As a result, the prod `referenceData` index is empty and public search returns nothing.

This uncomments the construct (creating the Lambda + event source mapping) and adds the two env vars that were missing from the original commented block: `WEBSOCKET_URL` and `API_STAGE` for WebSocket push on data change, with a safe fallback if `waitingRoomStack` is unavailable at synth time.

After this deploys, existing DynamoDB items will need a one-off reindex to populate OpenSearch.