### PR TITLE
fix: complete public browse endpoint auth removal missed in #366

### DIFF
--- a/lib/public-api-stack/public-activities-nested-stack/public-activities-nested-stack.js
+++ b/lib/public-api-stack/public-activities-nested-stack/public-activities-nested-stack.js
@@ -36,6 +36,7 @@ class PublicActivitiesNestedStack extends NestedStack {
       api: importedApi,
       authorizer: props.authorizer,
       handlerPrefix: props.handlerPrefix,
+      publicRead: true,
     });
 
     // Grant read access so the public GET handler can check waiting room status

--- a/src/handlers/productDates/_productId/GET/public.js
+++ b/src/handlers/productDates/_productId/GET/public.js
@@ -1,7 +1,7 @@
 
 const { fetchProductDates } = require("../../methods");
 const { PUBLIC_PRODUCTDATE_PROJECTIONS } = require("../../configs");
-const { getRequestClaimsFromEvent, logger, sendResponse, Exception } = require("/opt/base");
+const { logger, sendResponse, Exception } = require("/opt/base");
 /**
  * Fetches available ProductDates from a public user perspective. This means that discovery rules will ALWAYS be applied to the query, and only ProductDates that are discoverable to the user will be returned.
  */
@@ -15,12 +15,6 @@ exports.handler = async (event, context) => {
 
   
   try {
-
-    const user = getRequestClaimsFromEvent(event);
-
-    if (!user) {
-      throw new Exception("Unauthorized.", { code: 401 });
-    }
 
     const collectionId = event?.pathParameters?.collectionId;
     const activityType = event?.pathParameters?.activityType;

--- a/src/handlers/productDates/configs.js
+++ b/src/handlers/productDates/configs.js
@@ -18,7 +18,6 @@ const PUBLIC_PRODUCTDATE_PROJECTIONS = [
   "activityId",
   "productId",
   "date",
-  "availabilitySignal",
   "displayName",
   "reservationContext",
   "version",


### PR DESCRIPTION
Two gaps missed in #366:

- Product-dates Lambda was still throwing 401 for unauthenticated users despite API GW having `AuthorizationType.NONE` — `user` was never used downstream so the check was dead code
- `PublicActivitiesNestedStack` missing `publicRead: true` — the nested stack (deployed path) still applied the custom authorizer even though the flat SAM path was fixed in #366

Also removes `availabilitySignal` from `PUBLIC_PRODUCTDATE_PROJECTIONS` (not used by either frontend).

Ref #366