### PR TITLE
fix: resolve Secrets Manager secrets for prod deployments

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -55,13 +55,9 @@ const logger = createLogger({
 async function getSyncSecretFromSM(scope, secret) {
   try {
     logger.debug(`Fetching Secrets Manager secret: ${secret.path}`);
-    if (scope.getDeploymentName() !== 'prod') {
-      const command = new GetSecretValueCommand({ SecretId: secret.path });
-      const retrievedSecret = await secretsClient.send(command);
-      return retrievedSecret.SecretString;
-    } else {
-      throw 'Synchronous secret retrieval is not implemented for prod';
-    }
+    const command = new GetSecretValueCommand({ SecretId: secret.path });
+    const retrievedSecret = await secretsClient.send(command);
+    return retrievedSecret.SecretString;
   } catch (error) {
     // If running offline, just return the secret name for local testing
     if (scope.isOffline()) {


### PR DESCRIPTION
`getSyncSecretFromSM` was deliberately throwing for prod environments and falling back to returning the construct ID string (e.g. `ReserveRecApi-Prod-AdminIdentityStack-AzureClientSecret`). This caused live AWS resources to be configured with the secret name instead of the secret value.

Affected stacks: admin IDIR/BCSC client secrets, public BCSC client secret, QR secret key (admin API + email dispatch), OpenSearch master password, Worldline merchant ID.

Fix: remove the prod guard — `prime()` is already async and runs before CDK synthesis, so Secrets Manager can be called during `cdk deploy` in CI.