### PR TITLE
fix(auth): match superadmin group for all environments

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -55,13 +55,9 @@ const logger = createLogger({
 async function getSyncSecretFromSM(scope, secret) {
   try {
     logger.debug(`Fetching Secrets Manager secret: ${secret.path}`);
-    if (scope.getDeploymentName() !== 'prod') {
-      const command = new GetSecretValueCommand({ SecretId: secret.path });
-      const retrievedSecret = await secretsClient.send(command);
-      return retrievedSecret.SecretString;
-    } else {
-      throw 'Synchronous secret retrieval is not implemented for prod';
-    }
+    const command = new GetSecretValueCommand({ SecretId: secret.path });
+    const retrievedSecret = await secretsClient.send(command);
+    return retrievedSecret.SecretString;
   } catch (error) {
     // If running offline, just return the secret name for local testing
     if (scope.isOffline()) {

--- a/src/handlers/authorizers/admin.js
+++ b/src/handlers/authorizers/admin.js
@@ -154,8 +154,7 @@ exports.handler = async function (event, context, callback) {
         return generatePolicy(sub, 'Deny', normalizedEvent.methodArn);
       } else if (payload?.["cognito:groups"].some(group => {
         // Any users that have been manually added to the SuperAdmin group in Cognito are granted everything
-        return (group === 'ReserveRecApi-Dev-AdminIdentityStack-SuperAdminGroup' ||
-                group === 'ReserveRecApi-Test-AdminIdentityStack-SuperAdminGroup');
+        return group.endsWith('-AdminIdentityStack-SuperAdminGroup');
       })) {
         return {
           principalId: sub,


### PR DESCRIPTION
Superadmin group check was hardcoded to Dev and Test group names, so prod superadmins fell through to the DynamoDB lookup and got denied. Replace with `endsWith('-AdminIdentityStack-SuperAdminGroup')` to cover all environments.

Ref #372