### PR TITLE
Update expired booking scraper to not overwrite status of cancelled b…

### DIFF
--- a/lib/handlers/incompleteBookingScraper/index.js
+++ b/lib/handlers/incompleteBookingScraper/index.js
@@ -86,22 +86,44 @@ exports.handler = async (event, context) => {
         updateItems.push(updateRequest);
       }
 
-      // Create the update request for the Booking itself
+      // Create the update request for the Booking itself.
+      // Cancelled bookings should only clear isPending after inventory is released.
+      // In-progress bookings should be timed out and clear isPending.
+      let bookingUpdateRequest;
 
-      const bookingUpdateRequest = {
-        TableName: TRANSACTIONAL_DATA_TABLE_NAME,
-        Key: {
-          pk: marshall(booking.pk),
-          sk: marshall(booking.sk),
-        },
-        UpdateExpression: 'SET #status = :timedOut REMOVE isPending',
-        ExpressionAttributeNames: {
-          "#status": "status",
-        },
-        ExpressionAttributeValues: {
-          ":timedOut": { S: "TIMED_OUT" },
-        },
-        ConditionExpression: "attribute_exists(isPending)", // Only update if the booking is still pending, to ensure idempotency
+      if (booking.status === 'cancelled') {
+        bookingUpdateRequest = {
+          TableName: TRANSACTIONAL_DATA_TABLE_NAME,
+          Key: {
+            pk: marshall(booking.pk),
+            sk: marshall(booking.sk),
+          },
+          UpdateExpression: 'REMOVE isPending',
+          ExpressionAttributeNames: {
+            "#status": "status",
+          },
+          ExpressionAttributeValues: {
+            ":cancelled": { S: "cancelled" },
+          },
+          ConditionExpression: "attribute_exists(isPending) AND #status = :cancelled",
+        };
+      } else {
+        bookingUpdateRequest = {
+          TableName: TRANSACTIONAL_DATA_TABLE_NAME,
+          Key: {
+            pk: marshall(booking.pk),
+            sk: marshall(booking.sk),
+          },
+          UpdateExpression: 'SET #status = :timedOut REMOVE isPending',
+          ExpressionAttributeNames: {
+            "#status": "status",
+          },
+          ExpressionAttributeValues: {
+            ":timedOut": { S: "TIMED_OUT" },
+            ":inProgress": { S: "in progress" },
+          },
+          ConditionExpression: "attribute_exists(isPending) AND #status = :inProgress",
+        };
       }
 
       updateItems.push(bookingUpdateRequest);


### PR DESCRIPTION
Expired scraper was resetting the status of cancelled passes. Update to just remove the isPending flag. 