### PR TITLE
feat(email): fix booking confirmation email dispatch

### DIFF
--- a/lib/handlers/emailDispatch/templateEngine.js
+++ b/lib/handlers/emailDispatch/templateEngine.js
@@ -8,8 +8,10 @@ const { logger, Exception } = require("/opt/base");
 const path = require('path');
 const fs = require('fs').promises;
 const { generateQRURL } = require('./qrCodeHelper');
+const { DateTime } = require('luxon');
 
-// We'll add Handlebars to package.json dependencies
+const DISPLAY_TIMEZONE = 'America/Vancouver';
+
 let Handlebars;
 try {
   Handlebars = require('handlebars');
@@ -54,28 +56,35 @@ class TemplateEngine {
       return `$${dollars.toFixed(2)}`;
     });
 
-    // Date formatting helper
-    Handlebars.registerHelper('formatDate', function(dateString, format = 'long') {
-      if (!dateString) return '';
-      
-      const date = new Date(dateString);
-      const options = {
-        short: { year: 'numeric', month: 'short', day: 'numeric' },
-        long: { 
-          weekday: 'long', 
-          year: 'numeric', 
-          month: 'long', 
-          day: 'numeric' 
-        },
-        time: { 
-          hour: '2-digit', 
-          minute: '2-digit',
-          timeZoneName: 'short'
-        }
+    // Date formatting helper — accepts named presets or Luxon format strings
+    Handlebars.registerHelper('formatDate', function(dateValue, format = 'long') {
+      if (!dateValue) return '';
+
+      const dt = (typeof dateValue === 'number')
+        ? DateTime.fromMillis(dateValue, { zone: DISPLAY_TIMEZONE })
+        : DateTime.fromISO(String(dateValue), { zone: DISPLAY_TIMEZONE });
+
+      if (!dt.isValid) return '';
+
+      const presets = {
+        short: 'MMM d, yyyy',
+        long:  'EEEE, MMMM d, yyyy',
+        time:  'h:mm a ZZZZ',
       };
-      
-      return new Intl.DateTimeFormat('en-CA', options[format] || options.long)
-        .format(date);
+
+      return dt.toFormat(presets[format] || format);
+    });
+
+    // Time-only formatting helper
+    Handlebars.registerHelper('formatTime', function(dateValue) {
+      if (!dateValue) return '';
+
+      const dt = (typeof dateValue === 'number')
+        ? DateTime.fromMillis(dateValue, { zone: DISPLAY_TIMEZONE })
+        : DateTime.fromISO(String(dateValue), { zone: DISPLAY_TIMEZONE });
+
+      if (!dt.isValid) return '';
+      return dt.toFormat('h:mm a');
     });
 
     // Conditional helper

--- a/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.html
+++ b/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.html
@@ -1,0 +1,545 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BC Parks - Booking Confirmation</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        svg {
+            vertical-align: middle;
+            margin-top: -2px;
+        }
+
+        /* Email-specific resets */
+        img {
+            border: 0;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        table {
+            border-collapse: collapse;
+            border-spacing: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            background-color: #f5f5f5;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .email-wrapper {
+            background-color: #f5f5f5;
+            padding: 20px 0;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+        }
+
+        .header {
+            background-color: #ffffff;
+            padding: 24px 32px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .logo {
+            width: 48px;
+            height: 48px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-top: 25px;
+        }
+
+        .logo-text {
+            font-weight: 600;
+            font-size: 16px;
+        }
+
+        .content {
+            padding: 32px 32px;
+        }
+
+        h1 {
+            font-size: 23px;
+            font-weight: 700;
+            color: #003366;
+            margin-bottom: 20px;
+            line-height: 33.2px;
+        }
+
+        h2 {
+            font-size: 19px;
+            font-weight: 700;
+            color: #003366;
+            margin-bottom: 10px;
+            line-height: 27px;
+        }
+
+        .success-message {
+            font-size: 16px;
+            font-weight: 700;
+            margin-bottom: 12px;
+        }
+
+        .instructions {
+            font-size: 16px;
+            line-height: 1.6;
+            margin-bottom: 24px;
+        }
+
+        .btn-primary {
+            font-size: 16px;
+            font-weight: 700;
+            color: #003366;
+            margin-bottom: 20px;
+            line-height: 25px;
+            border: 1px solid #003366;
+            padding: 10px 16px;
+            border-radius: 4px;
+            margin-bottom: 15px;
+            text-decoration: none;
+        }
+
+        .btn-secondary {
+            font-size: 16px;
+            font-weight: 700;
+            color: #fff;
+            margin-bottom: 10px;
+            line-height: 25px;
+            background: #003366;
+            padding: 10px 16px;
+            border-radius: 4px;
+            margin-top: 16px;
+            text-decoration: none;
+        }
+
+        .booking-card {
+            border: 1px solid #d9d9d9;
+            border-radius: 8px;
+            overflow: hidden;
+            margin-top: 36px;
+            margin-bottom: 24px;
+        }
+
+        .card-header {
+            padding: 20px 24px;
+            border: 1px solid #C7C7C7;
+            border-radius: 8px 8px 0 0;
+            background: #f2f2f2;
+        }
+
+        .park-name {
+            font-size: 16px;
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .park-subtitle {
+            font-size: 16px;
+            color: #5c5c5c;
+        }
+
+        .card-body {
+            border: 1px solid #C7C7C7;
+            border-radius: 0 0 8px 8px;
+            padding: 24px;
+        }
+
+        .card-full {
+            border: 1px solid #C7C7C7;
+            border-radius: 8px;
+            padding: 24px;
+        }
+
+        .details-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+
+        .detail-item {
+            margin-bottom: 0;
+        }
+
+        .detail-label {
+            font-size: 16px;
+            font-weight: 800;
+            margin-bottom: 4px;
+            display: block;
+        }
+
+        .detail-value {
+            font-size: 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .detail-value-time {
+            font-size: 13px;
+            display: flex;
+            align-items: center;
+        }
+
+        .detail-icon {
+            width: 16px;
+            height: 16px;
+        }
+
+        .full-width {
+            grid-column: 1 / -1;
+        }
+
+        .booking-number {
+            font-size: 16px;
+        }
+
+        .cardless-body {
+            padding: 24px;
+        }
+
+        .qr-code {
+            max-width: 200px;
+            width: 100%;
+            height: auto;
+            margin: 0 auto 16px;
+            display: block;
+        }
+
+        .qr-card {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .horizontal-rule {
+            border: 1px solid #d9d9d9;
+            grid-column: 1 / -1;
+        }
+
+        .horizontal-rule-yellow {
+            border-top: 3px solid #FCBA19;
+            margin-bottom: 24px;
+            margin-right: 85%;
+        }
+
+        .cancellation-instructions {
+            font-size: 16px;
+            line-height: 25px;
+            margin-bottom: 30px;
+        }
+
+        .before-you-go-instructions {
+            font-size: 16px;
+            line-height: 25px;
+            margin-bottom: 30px;
+        }
+
+        .customer-service {
+            background-color: #C7E3FD;
+            padding: 25px 25px;
+            margin-bottom: 30px;
+        }
+
+        .customer-service h3 {
+            font-size: 19px;
+            font-weight: 700;
+            color: #003366;
+            margin-bottom: 12px;
+            line-height: 27px;
+        }
+
+        .customer-service p {
+            font-size: 16px;
+            line-height: 25px;
+            margin-bottom: 20px;
+        }
+
+        .customer-service-text {
+            font: 16px;
+            font-weight: 700;
+            color: #003366;
+            line-height: 25px;
+            padding-right: 10px;
+        }
+
+        .customer-service-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: #003366;
+            font-size: 16px;
+        }
+
+        .disclaimer {
+            font-size: 14.5px;
+            font-style: italic;
+            line-height: 24px;
+            margin-bottom: 24px;
+        }
+
+        .footer {
+            background-color: #1E3A5F;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .acknowledgment {
+            background-color: #2464A4;
+            color: white;
+            padding: 25px 36px;
+            margin: 0 60px 20px 60px;
+            font-size: 13px;
+            line-height: 1.6;
+        }
+
+        .footer-content {
+            padding: 32px 170px 32px 22px;
+            font-size: 24px;
+            font-weight: 400;
+            color: white;
+            margin-bottom: 5px;
+            font-family: auto;
+        }
+
+        .footer-address {
+            font-size: 12px;
+            color: white;
+            line-height: 1.6;
+            margin-bottom: 4px;
+        }
+
+        .social-icons {
+            margin-top: 20px;
+            display: flex;
+            justify-content: center;
+            gap: 16px;
+        }
+
+        .social-icon {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            background-color: rgba(255, 255, 255, 0.2);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            text-decoration: none;
+            font-size: 18px;
+        }
+
+        @media only screen and (max-width: 600px) {
+            .content {
+                padding: 24px 16px;
+            }
+
+            .details-grid,
+            .payment-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .card-body,
+            .payment-body {
+                padding: 16px;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="email-wrapper">
+        <div class="container">
+            <!-- Header -->
+            <div class="header">
+                <div class="logo">
+                    <img src="https://bcparks.ca/static/BCParks_Primary_Reversed_Vertical-9873b7442479cf33ebc73121675114fa.svg" alt="BC Parks" style="width: 128px; height: 128px;">
+                </div>
+            </div>
+
+            <!-- Content -->
+            <div class="content">
+                <h1>Your day-use passes for {{#if location.parkName}}{{location.parkName}}{{else}}your visit{{/if}}</h1>
+
+                <p class="success-message">Success! You're all set.</p>
+
+                <p class="instructions">Save this email for entering with your pass online. Please bring your printed
+                    pass or saved screenshot with you during your visit.</p>
+                {{#if booking.accountBookingUrl}}
+                <a href="{{booking.accountBookingUrl}}" target="_blank" class="btn-primary">View your booking</a>
+                {{/if}}
+                <!-- Booking Card -->
+                <div class="booking-card">
+                    <div class="card-header">
+                        <div class="park-name">{{#if location.parkName}}{{location.parkName}}{{else}}Your visit{{/if}}</div>
+                        <div class="park-subtitle">{{#if booking.displayName}}{{booking.displayName}}{{/if}}</div>
+                    </div>
+
+                    <div class="card-body">
+                        <div class="details-grid">
+                            {{#if booking.arrivalDate}}
+                            <div class="detail-item">
+                                <span class="detail-label">Arrival</span>
+                                <div class="detail-value">{{formatDate booking.arrivalDate 'EEEE MMMM d, yyyy'}}<br></div>
+                                <span class="detail-value-time">{{ formatTime booking.arrivalDate}}</span>
+                            </div>
+                            {{/if}}
+
+                            {{#if booking.departureDate}}
+                            <div class="detail-item">
+                                <span class="detail-label">Departure</span>
+                                <div class="detail-value">{{formatDate booking.departureDate 'EEEE MMMM d, yyyy'}}<br></div>
+                                <span class="detail-value-time">{{ formatTime booking.departureDate}}</span>
+                            </div>
+                            {{/if}}
+
+                            {{#if booking.productName}}
+                            <div class="detail-item">
+                                <span class="detail-label">Pass type</span>
+                                <div class="detail-value">
+                                    {{booking.productName}}
+                                </div>
+                            </div>
+                            {{/if}}
+
+                            {{#if booking.invQuantity}}
+                            <div class="detail-item">
+                                <span class="detail-label">Passes</span>
+                                <div class="detail-value">
+                                    {{booking.invQuantity}}
+                                </div>
+                            </div>
+                            {{/if}}
+
+                            <div class="horizontal-rule"></div>
+
+                            <div class="detail-item">
+                                <span class="detail-label">Named occupant</span>
+                                <div class="detail-value">{{customer.firstName}} {{customer.lastName}}</div>
+                            </div>
+
+                            {{#if customer.licensePlate}}
+                            <div class="detail-item">
+                                <span class="detail-label">License plate</span>
+                                <div class="detail-value">{{customer.licensePlate}}</div>
+                            </div>
+                            {{/if}}
+
+                            <div class="horizontal-rule"></div>
+
+                            <div class="detail-item full-width">
+                                <span class="detail-label">Booking number</span>
+                                <div class="detail-value booking-number">{{booking.bookingId}}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- QR Code -->
+                <div class="booking-card">
+                    <div class="card-full">
+                        <div class="qr-card">
+                            {{#if booking.qrCodeDataUrl}}
+                            <img src="{{booking.qrCodeDataUrl}}" alt="QR Code" class="qr-code" />
+                            <a href="{{booking.qrCodeDataUrl}}" target="_blank" class="btn-secondary">Download QR code</a>
+                            {{/if}}
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Cancellations -->
+                {{#if booking.cancellationUrl}}
+                <div class="cardless-body">
+                    <h2>Cancellations and refunds</h2>
+                    <div class="horizontal-rule-yellow"></div>
+                    <p class="cancellation-instructions">
+                        If you can no longer make the trip, please cancel your reservations to receive a refund and
+                        allow the passes to be re-allocated to other park visitors.
+                    </p>
+                    <a href="{{booking.cancellationUrl}}" target="_blank" class="btn-primary">Cancel your reservation</a>
+                </div>
+                {{/if}}
+
+                <!-- Before you go -->
+                <div class="cardless-body">
+                    <h2>Before you go</h2>
+                    <div class="horizontal-rule-yellow"></div>
+                    <p class="before-you-go-instructions">
+                        Please ensure you have your pass available to show BC Parks staff when required: print or
+                        save/screenshot a copy of this email and the QR code to your phone as proof of your booking, as
+                        Wi-Fi connectivity is not always reliable within the parks.
+                        <br>
+                        <br>
+                        If you have booked more than 1 trail pass on your reservation, please ensure all members of your
+                        party are in attendance when checking in.
+                    </p>
+                </div>
+
+                <!-- Customer Service -->
+                <div class="customer-service">
+                    <h3>Customer Service</h3>
+                    <p>For any inquiries about your receipt or payment, please contact a customer service
+                        representative.</p>
+                    {{#if branding.contactEmail}}
+                    <span class="customer-service-text">Email</span>
+                    <a href="mailto:{{branding.contactEmail}}" class="customer-service-link">
+                        {{branding.contactEmail}}
+                    </a>
+                    {{/if}}
+                </div>
+
+                <p class="disclaimer">
+                    Please do not reply to this message. It was sent from an unmonitored email address. This message is
+                    a service email related to your BC Parks account use.
+                </p>
+            </div>
+
+            <!-- Footer -->
+            <div class="footer">
+                <div class="acknowledgment">
+                    We acknowledge all First Nations on whose territories BC Parks were established. We honour the
+                    connection to the land and respect the importance of their diverse teachings, traditions, and practices
+                    within these territories.
+                </div>
+                <div>
+                <div class="footer-content">
+                    <div class="footer-logo">BC Parks</div>
+
+                    <div class="footer-address">PO Box 9398</div>
+                    <div class="footer-address">Victoria, BC V8W9M9</div>
+                    <div class="footer-address">Canada</div>
+
+                </div>
+                <div class="footer-content">
+                    <div class="social-icons">
+                        <a href="https://www.facebook.com/BCParks/" target="_blank" class="social-icon">FB</a>
+                        <a href="https://www.instagram.com/bcparks/" target="_blank" class="social-icon">IG</a>
+                    </div>
+                </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.txt
+++ b/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.txt
@@ -1,0 +1,79 @@
+BC PARKS
+========================================
+YOUR BOOKING CONFIRMATION
+========================================
+
+Your day-use passes for {{#if location.parkName}}{{location.parkName}}{{else}}your visit{{/if}}
+
+Success! You're all set.
+
+Save this email for entering with your pass online. Please bring your printed pass or saved screenshot with you during your visit.
+
+{{#if booking.accountBookingUrl}}
+View your booking: {{booking.accountBookingUrl}}
+{{/if}}
+
+----------------------------------------
+BOOKING DETAILS
+----------------------------------------
+
+Park: {{#if location.parkName}}{{location.parkName}}{{else}}Your visit{{/if}}
+{{#if booking.displayName}}Pass: {{booking.displayName}}{{/if}}
+
+{{#if booking.arrivalDate}}
+Arrival:   {{formatDate booking.arrivalDate 'EEEE MMMM d, yyyy'}}{{#if (formatTime booking.arrivalDate)}} at {{formatTime booking.arrivalDate}}{{/if}}
+{{/if}}
+{{#if booking.departureDate}}
+Departure: {{formatDate booking.departureDate 'EEEE MMMM d, yyyy'}}{{#if (formatTime booking.departureDate)}} at {{formatTime booking.departureDate}}{{/if}}
+{{/if}}
+{{#if booking.productName}}
+Pass type: {{booking.productName}}
+{{/if}}
+{{#if booking.invQuantity}}
+Passes:    {{booking.invQuantity}}
+{{/if}}
+
+Named occupant: {{customer.firstName}} {{customer.lastName}}
+{{#if customer.licensePlate}}
+License plate:  {{customer.licensePlate}}
+{{/if}}
+
+Booking number: {{booking.bookingId}}
+
+{{#if booking.cancellationUrl}}
+----------------------------------------
+CANCELLATIONS AND REFUNDS
+----------------------------------------
+
+If you can no longer make the trip, please cancel your reservation to receive a refund and allow the passes to be re-allocated to other park visitors.
+
+Cancel your reservation: {{booking.cancellationUrl}}
+
+{{/if}}
+----------------------------------------
+BEFORE YOU GO
+----------------------------------------
+
+Please ensure you have your pass available to show BC Parks staff when required: print or save/screenshot a copy of this email and the QR code to your phone as proof of your booking, as Wi-Fi connectivity is not always reliable within the parks.
+
+If you have booked more than 1 trail pass on your reservation, please ensure all members of your party are in attendance when checking in.
+
+----------------------------------------
+CUSTOMER SERVICE
+----------------------------------------
+
+For any inquiries about your receipt or payment, please contact a customer service representative.
+{{#if branding.contactEmail}}
+Email: {{branding.contactEmail}}
+{{/if}}
+
+Please do not reply to this message. It was sent from an unmonitored email address. This message is a service email related to your BC Parks account use.
+
+========================================
+BC Parks
+PO Box 9398, Victoria, BC V8W9M9, Canada
+Facebook: https://www.facebook.com/BCParks/
+Instagram: https://www.instagram.com/bcparks/
+
+We acknowledge all First Nations on whose territories BC Parks were established. We honour the connection to the land and respect the importance of their diverse teachings, traditions, and practices within these territories.
+========================================

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -12,7 +12,7 @@ const {
 } = require("/opt/dynamodb");
 const { snsPublishCommand, snsPublishSend } = require("/opt/sns");
 const { Exception, logger } = require("/opt/base");
-const { sendConfirmationEmail, getRegionBranding } = require("../../../lib/handlers/emailDispatch/utils");
+const { sendConfirmationEmail } = require("../../../lib/handlers/emailDispatch/utils");
 const {
   getActivityByActivityId,
   getActivitiesByCollectionId,
@@ -1147,9 +1147,10 @@ async function generateEmailParams(booking, updatedBookingItem) {
     // get parkName
     const parkName = PARK_NAMES_BY_COLLECTION_ID[booking.collectionId];
 
-    let emailParams = {
+    const emailParams = {
       booking: {
         bookingId: booking.bookingId,
+        displayName: booking.displayName,
         invQuantity: bookingDates?.items?.reduce((total, item) => {
           const dailyInventory = item.quantity || 0;
           return total + dailyInventory;
@@ -1175,8 +1176,6 @@ async function generateEmailParams(booking, updatedBookingItem) {
         logoUrl: 'https://bcparks.ca/assets/logos/default-logo.png',
       }
     };
-
-    console.log('emailParams', emailParams);
 
     return emailParams;
 
@@ -2182,85 +2181,39 @@ async function flagCancelledBooking(booking, queryTime) {
 
 /**
  * Send booking confirmation email to SQS queue
- * @param {object} booking - Booking data from DynamoDB
+ * @param {object} emailParams - Structured email params from generateEmailParams
+ * @param {string} userName - Cognito username, used to look up the account email
  * @returns {Promise<Object>} SQS response
  */
-async function sendBookingConfirmationEmail(booking, userName) {
+async function sendBookingConfirmationEmail(emailParams, userName) {
   try {
 
-    // get account email:
+    // get account email from Cognito
     const userInfo = await getUserInfoByUserName(userName, 'public');
-
     const accountEmail = userInfo?.UserAttributes?.find(attr => attr.Name === 'email')?.Value;
 
     if (!accountEmail) {
       logger.warn('Cannot send confirmation email - no email address found for user', {
-        bookingId: booking.bookingId,
-        userName: userName
+        bookingId: emailParams?.booking?.bookingId,
+        userName
       });
       return null;
     }
 
-    // Calculate number of guests from partyContext
-    const partyInfo = booking.partyContext || {};
-    const numberOfGuests = (partyInfo.adult || 0) + (partyInfo.youth || 0) + (partyInfo.child || 0) + (partyInfo.senior || 0) || 1;
-
-    // Extract booking data
-    const bookingData = {
-      bookingId: booking.bookingId || booking.globalId,
-      bookingReference: booking.bookingReference || booking.bookingId || booking.globalId,
-      startDate: booking.startDate,
-      endDate: booking.endDate,
-      numberOfNights: booking.reservationContext?.totalDays || 1,
-      numberOfGuests: numberOfGuests,
-      status: booking.status || 'in-progress'
-    };
-
-    // Extract location data
-    const locationData = {
-      parkName: booking.displayName || 'BC Parks',
-      facilityName: booking.displayName || booking.facilityName,
-      siteNumber: booking.siteNumber,
-      region: booking.collectionId || 'default',
-      address: booking.address
-    };
-
-    // Extract customer data from namedOccupant
-    const namedOccupant = booking.namedOccupant || {};
-    const contactInfo = namedOccupant.contactInfo || {};
-
-
-    const customerData = {
-      firstName: namedOccupant.firstName || 'Guest',
-      lastName: namedOccupant.lastName || '',
-      email: contactInfo.email,
-      phone: contactInfo.mobilePhone,
-      address: {
-        street: contactInfo.streetAddress || '',
-        city: contactInfo.city || '',
-        province: contactInfo.province || '',
-        postalCode: contactInfo.postalCode || '',
-        country: contactInfo.country || 'CA'
-      }
-    };
-
-    // Get region-specific branding
-    const brandingData = {};
-    // const brandingData = getRegionBranding(locationData);
-
-    // Send confirmation email to SQS queue
     const result = await sendConfirmationEmail({
       email: accountEmail,
-      bookingData,
-      customerData,
-      locationData,
-      brandingData,
-      locale: booking.locale || 'en'
+      bookingData: emailParams.booking,
+      customerData: {
+        ...emailParams.customer,
+        email: accountEmail,
+      },
+      locationData: emailParams.location,
+      brandingData: emailParams.branding,
+      locale: 'en'
     });
 
     logger.info('Booking confirmation email queued successfully', {
-      bookingId: booking.bookingId,
-      recipient: customerData.email,
+      bookingId: emailParams?.booking?.bookingId,
       messageId: result.messageId
     });
 
@@ -2268,7 +2221,7 @@ async function sendBookingConfirmationEmail(booking, userName) {
 
   } catch (error) {
     logger.error('Failed to queue booking confirmation email', {
-      bookingId: booking?.bookingId,
+      bookingId: emailParams?.booking?.bookingId,
       error: error.message,
       stack: error.stack
     });


### PR DESCRIPTION
- Fix sendBookingConfirmationEmail to use structured emailParams from generateEmailParams instead of re-reading raw DynamoDB booking fields (all reads were undefined, resulting in empty template data)
- Add booking.displayName to generateEmailParams so template card header subtitle renders correctly; remove stray console.log
- Remove unused getRegionBranding import from methods.js
- Extend templateEngine formatDate to use Luxon with support for custom format strings (e.g. 'EEEE MMMM d, yyyy') alongside named presets; add formatTime helper; both use America/Vancouver timezone
- Add confirmation_bcparks_default.html (Cameron's corrected Handlebars syntax — dev/test S3 had broken JS-style optional chaining) and matching .txt plain-text template

Ref #56