### PR TITLE
fix(waitingRoom): resolve Mode 2 viewer fn name from public SSM

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -82,7 +82,6 @@ const defaults = {
     opensearchReferenceDataIndexName: "",
     opensearchTransactionalDataIndexName: "",
     opensearchUserIndexName: "",
-    viewerFunctionName: "",
 
     // Feature flags for selective deployment. These will allow you 
     // to deploy the admin API with only certain endpoints enabled, which can
@@ -668,7 +667,7 @@ class AdminApiStack extends BaseStack {
         waitingRoomTableName: scope.resolveWaitingRoomTableName(),
         waitingRoomTableArn: scope.resolveWaitingRoomTableArn(),
         releaseLambdaArn: scope.resolveReleaseLambdaArn(),
-        viewerFunctionName: this.getConfigValue('viewerFunctionName') || '',
+        viewerFunctionName: scope.resolvePublicWaitingRoomViewerFnName(this),
         wsManagementEndpoint: scope.resolveWsManagementEndpoint ? scope.resolveWsManagementEndpoint() : '',
       });
     }

--- a/lib/core-stack/core-stack.js
+++ b/lib/core-stack/core-stack.js
@@ -65,6 +65,7 @@ class CoreStack extends BaseStack {
     const deploymentName = scope.getDeploymentName();
     this.setConfigValue('publicDomainNameSSMPath', `/reserveRecPublic/${deploymentName}/distributionStack/distributionDomainName`);
     this.setConfigValue('adminDomainNameSSMPath', `/reserveRecAdmin/${deploymentName}/distributionStack/distributionDomainName`);
+    this.setConfigValue('waitingRoomViewerFnNameSSMPath', `/reserveRecPublic/${deploymentName}/distributionStack/waitingRoomViewerFnName`);
 
     // Create the Base Lambda Layer
 
@@ -151,6 +152,7 @@ class CoreStack extends BaseStack {
     scope.resolveOpenSearchUserIndexName = this.resolveOpenSearchUserIndexName.bind(this);
     scope.resolveAdminDomainName = this.resolveAdminDomainName.bind(this);
     scope.resolvePublicDomainName = this.resolvePublicDomainName.bind(this);
+    scope.resolvePublicWaitingRoomViewerFnName = this.resolvePublicWaitingRoomViewerFnName.bind(this);
   }
 
   resolveBaseLayer(consumerScope) {
@@ -205,6 +207,12 @@ class CoreStack extends BaseStack {
   // Gets the Domain for the public site from SSM
   resolvePublicDomainName(consumerScope) {
     return this.resolveReference(consumerScope, this.getConfigValue('publicDomainNameSSMPath'));
+  }
+
+  // Gets the Mode 2 CloudFront Function name exported by the public distribution stack.
+  // Used by the admin API toggle-mode2 Lambda to call cloudfront:GetFunction/UpdateFunction/PublishFunction.
+  resolvePublicWaitingRoomViewerFnName(consumerScope) {
+    return this.resolveReference(consumerScope, this.getConfigValue('waitingRoomViewerFnNameSSMPath'));
   }
 
   // Getters for resources


### PR DESCRIPTION
- Admin-api-stack now reads `/reserveRecPublic/{env}/distributionStack/waitingRoomViewerFnName` via `resolveReference` (same pattern as `publicDomainName`)
- Removes the manually-maintained `viewerFunctionName` from the admin config blob; SSM admin config no longer needs the key (existing entries become harmless dead fields)
- Mode 2 activation was 500'ing because the manual value was a mangled string that didn't match the actual deployed CF Function name

Ref #366