### PR TITLE
fix(waitingRoom): allow re-creating an empty pre-open/closed queue

### DIFF
--- a/src/handlers/waiting-room/admin/create-queues.js
+++ b/src/handlers/waiting-room/admin/create-queues.js
@@ -1,9 +1,15 @@
 'use strict';
 
 const { Exception, logger, sendResponse } = require('/opt/base');
-const { buildQueueId, createQueueMeta } = require('../utils/dynamodb');
+const { buildQueueId, createQueueMeta, getQueueMeta, putQueueMeta } = require('../utils/dynamodb');
 
 const TTL_BUFFER_HOURS = 48; // Queue META TTL: openingTime + 48h
+
+// Statuses where overwriting an existing queue's META is safe.
+// 'pre-open' = not yet opened; 'closed' = lifecycle complete.
+// Any other status (randomizing, releasing) means an active queue with
+// admitted/in-flight users — refuse to overwrite.
+const SAFE_TO_OVERWRITE_STATUSES = ['pre-open', 'closed'];
 
 exports.handler = async (event) => {
   logger.info('WaitingRoom admin CREATE-QUEUES');
@@ -39,30 +45,46 @@ exports.handler = async (event) => {
       const openingTimeUnix = Math.floor(openingTimeMs / 1000);
       const ttl = openingTimeUnix + TTL_BUFFER_HOURS * 3600;
 
-      try {
-        await createQueueMeta({
-          pk: queueId,
-          sk: 'META',
-          queueStatus: 'pre-open',
-          collectionId,
-          activityType,
-          activityId,
-          startDate,
-          openingTime,
-          totalEntries: 0,
-          admittedCount: 0,
-          createdAt: now,
-          updatedAt: now,
-          ttl,
-        });
+      const meta = {
+        pk: queueId,
+        sk: 'META',
+        queueStatus: 'pre-open',
+        collectionId,
+        activityType,
+        activityId,
+        startDate,
+        openingTime,
+        totalEntries: 0,
+        admittedCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        ttl,
+      };
 
+      try {
+        await createQueueMeta(meta);
         created.push({ queueId, startDate, openingTime });
         logger.info(`Created queue: ${queueId}`);
       } catch (err) {
-        if (err.name === 'ConditionalCheckFailedException') {
-          errors.push({ startDate, reason: 'Queue already exists for this date' });
-        } else {
+        if (err.name !== 'ConditionalCheckFailedException') {
           errors.push({ startDate, reason: err.message });
+          continue;
+        }
+
+        // Queue already exists — overwrite if it's in a safe state with no entries.
+        const existing = await getQueueMeta(queueId);
+        const status = existing?.queueStatus;
+        const total = existing?.totalEntries ?? 0;
+
+        if (SAFE_TO_OVERWRITE_STATUSES.includes(status) && total === 0) {
+          await putQueueMeta({ ...meta, createdAt: existing.createdAt ?? now });
+          created.push({ queueId, startDate, openingTime, overwrote: true });
+          logger.info(`Overwrote empty queue: ${queueId} (was '${status}')`);
+        } else {
+          errors.push({
+            startDate,
+            reason: `Queue exists with status '${status}' and ${total} entries; close+delete it before recreating`,
+          });
         }
       }
     }

--- a/test/waiting-room/admin.test.js
+++ b/test/waiting-room/admin.test.js
@@ -144,16 +144,33 @@ describe('create-queues handler', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it('records error for duplicate queue (ConditionalCheckFailedException)', async () => {
+  it('overwrites a duplicate queue when existing is pre-open with no entries', async () => {
     const err = new Error('conditional failed');
     err.name = 'ConditionalCheckFailedException';
     db.createQueueMeta.mockRejectedValueOnce(err).mockResolvedValueOnce({});
+    db.getQueueMeta.mockResolvedValueOnce({ queueStatus: 'pre-open', totalEntries: 0, createdAt: 1234 });
+    db.putQueueMeta.mockResolvedValueOnce({});
+    const res = await handler({ body: JSON.stringify(validBody) });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.data.created).toHaveLength(2);
+    expect(body.data.created[0].overwrote).toBe(true);
+    expect(body.data.errors).toHaveLength(0);
+    expect(db.putQueueMeta).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to overwrite an active queue with entries', async () => {
+    const err = new Error('conditional failed');
+    err.name = 'ConditionalCheckFailedException';
+    db.createQueueMeta.mockRejectedValueOnce(err).mockResolvedValueOnce({});
+    db.getQueueMeta.mockResolvedValueOnce({ queueStatus: 'releasing', totalEntries: 42 });
     const res = await handler({ body: JSON.stringify(validBody) });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.data.created).toHaveLength(1);
     expect(body.data.errors).toHaveLength(1);
-    expect(body.data.errors[0].reason).toMatch(/already exists/);
+    expect(body.data.errors[0].reason).toMatch(/status 'releasing' and 42 entries/);
+    expect(db.putQueueMeta).not.toHaveBeenCalled();
   });
 
   it('records error for invalid openingTime', async () => {


### PR DESCRIPTION
- Queue id is deterministic from (collectionId, activityType, activityId, startDate); a strict `attribute_not_exists` blocked all retries
- Now overwrites the META if the existing queue is `pre-open` or `closed` AND `totalEntries === 0`
- Otherwise responds with a clearer error: `Queue exists with status 'X' and N entries; close+delete it before recreating`
- New tests cover both the overwrite and the refusal paths

Ref #366