### PR TITLE
fix(waitingRoom): push queueClosed WS message on admin force-close

### DIFF
--- a/src/handlers/waiting-room/admin/close-queue.js
+++ b/src/handlers/waiting-room/admin/close-queue.js
@@ -36,19 +36,34 @@ exports.handler = async (event) => {
       abandonedCount++;
     }
 
-    // Disconnect active WebSocket connections so users see immediate feedback
-    // instead of a stale waiting room UI.
+    // Notify each active client that the queue was force-closed, then disconnect.
+    // Without the message, the client's onclose just reconnects and the user keeps
+    // waiting. The 'queueClosed' message tells the client to bypass the queue and
+    // proceed to the booking flow.
     const endpoint = process.env.WEBSOCKET_MANAGEMENT_ENDPOINT;
     if (endpoint && activeEntries.length > 0) {
-      const { ApiGatewayManagementApiClient, DeleteConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
+      const {
+        ApiGatewayManagementApiClient,
+        PostToConnectionCommand,
+        DeleteConnectionCommand,
+      } = require('@aws-sdk/client-apigatewaymanagementapi');
       const wsClient = new ApiGatewayManagementApiClient({ endpoint });
+      const closedMsg = Buffer.from(JSON.stringify({ type: 'queueClosed' }));
+
       for (const entry of activeEntries) {
-        if (entry.connectionId) {
-          try {
-            await wsClient.send(new DeleteConnectionCommand({ ConnectionId: entry.connectionId }));
-          } catch (err) {
-            logger.debug(`Could not delete connection ${entry.connectionId}: ${err.message}`);
-          }
+        if (!entry.connectionId) continue;
+        try {
+          await wsClient.send(new PostToConnectionCommand({
+            ConnectionId: entry.connectionId,
+            Data: closedMsg,
+          }));
+        } catch (err) {
+          logger.debug(`Could not push queueClosed to ${entry.connectionId}: ${err.message}`);
+        }
+        try {
+          await wsClient.send(new DeleteConnectionCommand({ ConnectionId: entry.connectionId }));
+        } catch (err) {
+          logger.debug(`Could not delete connection ${entry.connectionId}: ${err.message}`);
         }
       }
     }

--- a/test/waiting-room/admin.test.js
+++ b/test/waiting-room/admin.test.js
@@ -40,6 +40,13 @@ jest.mock('@aws-sdk/client-cloudfront', () => ({
   PublishFunctionCommand: jest.fn(),
 }));
 
+const mockWsSend = jest.fn();
+jest.mock('@aws-sdk/client-apigatewaymanagementapi', () => ({
+  ApiGatewayManagementApiClient: jest.fn(() => ({ send: mockWsSend })),
+  PostToConnectionCommand: jest.fn((args) => ({ __cmd: 'Post', ...args })),
+  DeleteConnectionCommand: jest.fn((args) => ({ __cmd: 'Delete', ...args })),
+}));
+
 const { sendResponse } = require('/opt/base');
 const db = require('../../src/handlers/waiting-room/utils/dynamodb');
 // CloudFrontClient import not needed directly — we use mockCFSend
@@ -226,6 +233,35 @@ describe('close-queue handler', () => {
     expect(body.data.abandonedCount).toBe(2);
     expect(db.updateQueueMetaStatus).toHaveBeenCalledWith(queueId, 'closed');
     expect(db.updateQueueEntryStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('pushes queueClosed and disconnects each connected client', async () => {
+    process.env.WEBSOCKET_MANAGEMENT_ENDPOINT = 'https://ws.example.com/ws';
+    db.getQueueMeta.mockResolvedValue({ queueStatus: 'releasing' });
+    db.updateQueueMetaStatus.mockResolvedValue({});
+    db.queryQueueEntries.mockResolvedValue([
+      { pk: queueId, cognitoSub: 'user1', connectionId: 'conn-1' },
+      { pk: queueId, cognitoSub: 'user2', connectionId: 'conn-2' },
+    ]);
+    db.updateQueueEntryStatus.mockResolvedValue({});
+    mockWsSend.mockResolvedValue({});
+
+    const res = await handler({ pathParameters: { queueId: encodeURIComponent(queueId) } });
+    expect(res.statusCode).toBe(200);
+
+    const posts = mockWsSend.mock.calls
+      .map(([cmd]) => cmd)
+      .filter((cmd) => cmd.__cmd === 'Post');
+    const deletes = mockWsSend.mock.calls
+      .map(([cmd]) => cmd)
+      .filter((cmd) => cmd.__cmd === 'Delete');
+
+    expect(posts).toHaveLength(2);
+    expect(deletes).toHaveLength(2);
+    expect(JSON.parse(posts[0].Data.toString())).toEqual({ type: 'queueClosed' });
+    expect(posts.map((c) => c.ConnectionId).sort()).toEqual(['conn-1', 'conn-2']);
+
+    delete process.env.WEBSOCKET_MANAGEMENT_ENDPOINT;
   });
 
   it('returns 200 immediately if queue is already closed', async () => {


### PR DESCRIPTION
- Force-close now `PostToConnectionCommand`s `{type: 'queueClosed'}` to each active client before `DeleteConnectionCommand`
- Without the message the client just reconnected in a loop; the user saw no UI change
- Companion PR on reserve-rec-public adds the client-side handler

Ref #366