### PR TITLE
feat(bookings): block duplicate booking for same user/product/day

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -190,6 +190,34 @@ async function getBookingsByUserId(userId, props) {
   }
 }
 
+/**
+ * Finds an active (in-progress or confirmed) booking owned by a user for a given
+ * product on a given startDate. Used to enforce the one-pass-per-user-per-product-per-day
+ * rule from issue #458. Returns the first match, or null if none.
+ */
+async function findUserActiveBookingForProductOnDate(userId, productBookingPk, startDate) {
+  if (!userId || !productBookingPk || !startDate) return null;
+  const params = {
+    TableName: TRANSACTIONAL_DATA_TABLE_NAME,
+    IndexName: USERID_INDEX_NAME,
+    KeyConditionExpression: '#userId = :userId AND begins_with(sk, :startDatePrefix)',
+    FilterExpression: 'pk = :pk AND #status IN (:inProgress, :confirmed)',
+    ExpressionAttributeNames: {
+      '#userId': USERID_PROPERTY_NAME,
+      '#status': 'status',
+    },
+    ExpressionAttributeValues: {
+      ':userId': marshall(userId),
+      ':startDatePrefix': marshall(`${startDate}::`),
+      ':pk': marshall(productBookingPk),
+      ':inProgress': marshall(BOOKING_STATUS_ENUMS[0]),
+      ':confirmed': marshall(BOOKING_STATUS_ENUMS[1]),
+    },
+  };
+  const result = await runQuery(params);
+  return result?.items?.[0] || null;
+}
+
 async function getBookingByBookingId(
   bookingId,
   userId = null,
@@ -512,6 +540,17 @@ async function createBooking(props) {
     // === Validate props ===
 
     await validateBookingCreateProps(props);
+
+    // === Block duplicate booking for the same user/product/startDate (issue #458) ===
+    // One pass per user per product per day. Cancelled and expired bookings don't count.
+    const productBookingPk = `booking::${collectionId}::${activityType}::${activityId}::${productId}`;
+    const duplicate = await findUserActiveBookingForProductOnDate(props.userId, productBookingPk, props.startDate);
+    if (duplicate) {
+      throw new Exception(
+        `You already have a ${duplicate.status} booking for this pass on ${props.startDate}. Cancel it before booking again.`,
+        { code: 409, data: { existingBookingId: duplicate.bookingId, status: duplicate.status } }
+      );
+    }
 
     // === Get the Product ===
 
@@ -2327,6 +2366,7 @@ module.exports = {
   createBooking,
   fetchAllActivities,
   fetchBookingsWithPagination,
+  findUserActiveBookingForProductOnDate,
   flagCancelledBooking,
   formatBookingResponsePublic,
   getBookingsByActivityDetails,

--- a/test/booking/duplicate-check.test.js
+++ b/test/booking/duplicate-check.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+jest.mock('/opt/base', () => ({
+  Exception: jest.fn(function (message, data) {
+    this.message = message;
+    this.code = data?.code;
+    this.data = data;
+  }),
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@aws-sdk/util-dynamodb', () => ({
+  unmarshall: jest.fn((x) => x),
+}));
+
+jest.mock('/opt/dynamodb', () => ({
+  marshall: jest.fn((x) => x),
+  runQuery: jest.fn(),
+  getOne: jest.fn(),
+  getOneByGlobalId: jest.fn(),
+  REFERENCE_DATA_TABLE_NAME: 'RefTable',
+  TRANSACTIONAL_DATA_TABLE_NAME: 'TxTable',
+  SPARSE_GSI1_NAME: 'sparse-gsi-1',
+  USERID_INDEX_NAME: 'userId-index',
+  USERID_PROPERTY_NAME: 'userId',
+}));
+
+jest.mock('/opt/sns', () => ({ snsPublishCommand: jest.fn(), snsPublishSend: jest.fn() }), { virtual: true });
+
+jest.mock('../../lib/handlers/emailDispatch/utils', () => ({ sendConfirmationEmail: jest.fn() }));
+jest.mock('../../src/handlers/activities/methods', () => ({
+  getActivityByActivityId: jest.fn(),
+  getActivitiesByCollectionId: jest.fn(),
+}));
+jest.mock('../../src/common/data-utils', () => ({
+  getAndAttachNestedProperties: jest.fn(),
+  quickApiPutHandler: jest.fn(),
+  quickApiUpdateHandler: jest.fn(),
+}));
+jest.mock('../../src/handlers/productDates/methods', () => ({ fetchProductDates: jest.fn() }));
+jest.mock('../../src/handlers/productDates/configs', () => ({ PUBLIC_PRODUCTDATE_PROJECTIONS: {} }));
+jest.mock('../../src/handlers/users/methods', () => ({ getUserInfoByUserName: jest.fn() }));
+jest.mock('../../src/handlers/bookings/configs', () => ({
+  BOOKING_PUT_CONFIG: {},
+  BOOKINGDATES_PUT_CONFIG: {},
+  BOOKING_UPDATE_CONFIG: {},
+}));
+
+const { runQuery } = require('/opt/dynamodb');
+const { findUserActiveBookingForProductOnDate } = require('../../src/handlers/bookings/methods');
+
+describe('findUserActiveBookingForProductOnDate', () => {
+  const userId = 'cog-sub-123';
+  const productPk = 'booking::col-1::dayuse::1::3';
+  const startDate = '2026-06-15';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when no booking matches', async () => {
+    runQuery.mockResolvedValue({ items: [] });
+    const result = await findUserActiveBookingForProductOnDate(userId, productPk, startDate);
+    expect(result).toBeNull();
+  });
+
+  it('returns the existing booking when one is found', async () => {
+    const existing = { bookingId: 'b-1', status: 'confirmed', pk: productPk };
+    runQuery.mockResolvedValue({ items: [existing] });
+    const result = await findUserActiveBookingForProductOnDate(userId, productPk, startDate);
+    expect(result).toBe(existing);
+  });
+
+  it('queries the userId-index with begins_with on sk and filters by pk + active statuses', async () => {
+    runQuery.mockResolvedValue({ items: [] });
+    await findUserActiveBookingForProductOnDate(userId, productPk, startDate);
+    const params = runQuery.mock.calls[0][0];
+    expect(params.IndexName).toBe('userId-index');
+    expect(params.KeyConditionExpression).toContain('begins_with(sk, :startDatePrefix)');
+    expect(params.FilterExpression).toContain('pk = :pk');
+    expect(params.FilterExpression).toContain('#status IN (:inProgress, :confirmed)');
+    expect(params.ExpressionAttributeValues[':startDatePrefix']).toBe(`${startDate}::`);
+    expect(params.ExpressionAttributeValues[':pk']).toBe(productPk);
+    expect(params.ExpressionAttributeValues[':inProgress']).toBe('in progress');
+    expect(params.ExpressionAttributeValues[':confirmed']).toBe('confirmed');
+  });
+
+  it('returns null without querying when any required arg is missing', async () => {
+    expect(await findUserActiveBookingForProductOnDate(null, productPk, startDate)).toBeNull();
+    expect(await findUserActiveBookingForProductOnDate(userId, null, startDate)).toBeNull();
+    expect(await findUserActiveBookingForProductOnDate(userId, productPk, null)).toBeNull();
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- One pass per user per product per startDate (parity with legacy DUP)
- New `findUserActiveBookingForProductOnDate` queries the `userId` GSI with `begins_with(sk, '<startDate>::')` and filters by booking pk + status
- `createBooking` now rejects with `409` when an active (`in progress` or `confirmed`) booking already exists for the same product on the same date
- Cancelled and expired bookings don't block — user can rebook after cancelling
- Tests cover the lookup function

Scope notes:
- Granularity is per-product (option 1a from the design discussion). Activities/activityTypes have multiple products; this rule only blocks the same product on the same day
- Multi-day bookings with overlapping ranges aren't yet checked (only exact `startDate` match). Not a problem for day passes (start == end); could be a follow-up if needed for camping

Ref #458