### PR TITLE
fix(auth): respect superadmin marker when filtering by role

### DIFF
--- a/src/handlers/facilities/methods.js
+++ b/src/handlers/facilities/methods.js
@@ -6,7 +6,7 @@ const {
   marshall,
   incrementCounter,
 } = require("/opt/dynamodb");
-const { Exception, logger, filterByRole } = require("/opt/base");
+const { Exception, logger, filterByRole, effectiveCollectionRole } = require("/opt/base");
 const { ALLOWED_FILTERS, ROLE_BASED_FILTERS } = require("./configs");
 const { getRelationshipsByGsipk, expandRelationships } = require("../../common/relationship-utils");
 
@@ -431,10 +431,9 @@ async function fetchFacilities(
     res = await getFacilitiesByCollectionId(collectionId, filters, queryParams);
   }
 
-  // Check user's role from authContext (if provided), otherwise provide default return
-  const role = authContext?.permissions?.[collectionId] ?? "default";
-
-  // Filter by the role of the user - for public, that's 'default' (least privilege)
+  // Filter by the user's effective role for this collection. Resolves the
+  // top-level superadmin marker so superadmins see adminNotes etc.
+  const role = effectiveCollectionRole(authContext, collectionId);
   return filterByRole(res, role, ROLE_BASED_FILTERS);
 }
 

--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -4,6 +4,7 @@ const {
   Exception,
   buildDateRange,
   buildDateTimeFromShortDate,
+  effectiveCollectionRole,
   getNow,
   filterByRole,
   logger,
@@ -782,10 +783,9 @@ async function fetchProducts(collectionId, activityType, activityId, productId, 
       );
     }
 
-    // Check user's role from authContext (if provided), otherwise provide default return
-    const role = authContext?.permissions?.[collectionId] ?? "default";
-
-    // Filter by the role of the user - for public, that's 'default' (least privilege)
+    // Filter by the user's effective role for this collection. Resolves the
+    // top-level superadmin marker so superadmins see adminNotes etc.
+    const role = effectiveCollectionRole(authContext, collectionId);
     return filterByRole(res, role, ROLE_BASED_FILTERS);
 }
 

--- a/src/layers/base/base.js
+++ b/src/layers/base/base.js
@@ -226,6 +226,24 @@ function removeFields(obj, fields) {
  *
  * @returns {Object} Filtered response data object
  */
+/**
+ * Resolves the effective response-filtering role for a user against a specific
+ * collection. Superadmin permissions live at the top level of authContext.permissions
+ * (`{ superadmin: 'superadmin' }`) — without this helper, a per-collection lookup
+ * misses that and falls through to 'default', which strips fields like adminNotes
+ * even from superadmin responses.
+ *
+ * @param {Object} authContext - object returned by checkAuthContext
+ * @param {string} collectionId - collection being read
+ * @returns {string} role to pass to filterByRole
+ */
+function effectiveCollectionRole(authContext, collectionId) {
+  if (authContext?.permissions?.['superadmin'] === 'superadmin') {
+    return 'superadmin';
+  }
+  return authContext?.permissions?.[collectionId] ?? 'default';
+}
+
 function filterByRole(res, role = 'default', ROLE_BASED_FILTERS) {
   // Return the response as-is for superadmin
   if (role === 'superadmin') {
@@ -485,6 +503,7 @@ module.exports = {
   getNow,
   getNowEpoch,
   getNowISO,
+  effectiveCollectionRole,
   filterByRole,
   checkAuthContext,
   getRequestClaimsFromEvent,

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -3,6 +3,7 @@ const {
   checkWarmup,
   Exception,
   getRequestClaimsFromEvent,
+  effectiveCollectionRole,
 } = require('../src/layers/base/base');
 
 describe('Base Layer Tests', () => {
@@ -135,6 +136,30 @@ describe('Base Layer Tests', () => {
       expect(claims.sub).toBe('user456');
       expect(claims.email).toBe('user@example.com');
       expect(claims.username).toBe('testuser');
+    });
+  });
+
+  describe('effectiveCollectionRole', () => {
+    it('returns superadmin when permissions has the superadmin marker', () => {
+      const ctx = { permissions: { superadmin: 'superadmin', 'bcparks_1': 'staff' } };
+      expect(effectiveCollectionRole(ctx, 'bcparks_1')).toBe('superadmin');
+    });
+
+    it('returns the per-collection role for non-superadmins', () => {
+      const ctx = { permissions: { 'bcparks_1': 'staff', 'bcparks_2': 'limited' } };
+      expect(effectiveCollectionRole(ctx, 'bcparks_1')).toBe('staff');
+      expect(effectiveCollectionRole(ctx, 'bcparks_2')).toBe('limited');
+    });
+
+    it('falls back to default when collection is not in permissions', () => {
+      const ctx = { permissions: { 'bcparks_1': 'staff' } };
+      expect(effectiveCollectionRole(ctx, 'bcparks_99')).toBe('default');
+    });
+
+    it('handles missing authContext or permissions gracefully', () => {
+      expect(effectiveCollectionRole(null, 'bcparks_1')).toBe('default');
+      expect(effectiveCollectionRole({}, 'bcparks_1')).toBe('default');
+      expect(effectiveCollectionRole({ permissions: {} }, 'bcparks_1')).toBe('default');
     });
   });
 });


### PR DESCRIPTION
Fetch handlers looked up role at `permissions[collectionId]` which returns undefined for superadmins (whose marker is `permissions.superadmin`). Role fell through to 'default' and `filterByRole` stripped `adminNotes` from the response. New `effectiveCollectionRole` helper resolves the superadmin marker first; products and facilities fetches use it. Ref bcgov/reserve-rec-admin#208