### PR TITLE
fix(auth): properly check superadmin in activities/geozones GET

### DIFF
--- a/src/handlers/activities/_collectionId/GET/admin.js
+++ b/src/handlers/activities/_collectionId/GET/admin.js
@@ -65,8 +65,12 @@ exports.handler = async (event, context) => {
       );
     }
 
-    // If the user isn't a superadmin, remove adminNotes from the response
-    if (res && authContext.permissions !== 'superadmin') {
+    // If the user isn't a superadmin, remove adminNotes from the response.
+    // permissions is an object like { superadmin: 'superadmin' } or
+    // { '<collectionId>': 'staff' }; comparing the whole object to a string
+    // is always !== 'superadmin', so this used to strip adminNotes for everyone.
+    const isSuperAdmin = authContext?.permissions?.superadmin === 'superadmin';
+    if (res && !isSuperAdmin) {
       const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
       res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }

--- a/src/handlers/geozones/_collectionId/GET/admin.js
+++ b/src/handlers/geozones/_collectionId/GET/admin.js
@@ -62,8 +62,12 @@ exports.handler = async (event, context) => {
       );
     }
 
-    // If the user isn't a superadmin, remove adminNotes from the response
-    if (res && authContext.permissions !== 'superadmin') {
+    // If the user isn't a superadmin, remove adminNotes from the response.
+    // permissions is an object like { superadmin: 'superadmin' } or
+    // { '<collectionId>': 'staff' }; comparing the whole object to a string
+    // is always !== 'superadmin', so this used to strip adminNotes for everyone.
+    const isSuperAdmin = authContext?.permissions?.superadmin === 'superadmin';
+    if (res && !isSuperAdmin) {
       const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
       res = Array.isArray(res) ? res.map(removedFields) : removedFields(res);
     }


### PR DESCRIPTION
Inline check was `authContext.permissions !== 'superadmin'` — permissions is an object, !== string is always true, so adminNotes was stripped for everyone including superadmins. Fixed in both activities and geozones admin GETs. Ref bcgov/reserve-rec-admin#222