### PR TITLE
feat(opensearch): make EBS size and multi-AZ standby configurable

### DIFF
--- a/lib/opensearch-stack/opensearch-stack.js
+++ b/lib/opensearch-stack/opensearch-stack.js
@@ -44,8 +44,13 @@ const defaults = {
     opensearchDomainPrefix: 'reserve-rec-opensearch',
     opensearchDataNodeCount: 2,
     opensearchInstanceType: 't3.small.search',
+    opensearchEbsVolumeSize: 10,
     opensearchEbsVolumeIops: '3000',
     opensearchEbsVolumeThroughput: '125',
+    // When true, the domain enables zone awareness across 3 AZs and provisions
+    // an active-active-standby cluster (test/prod prod-grade resilience).
+    // Defaults to false for dev/sandbox.
+    opensearchMultiAzWithStandby: false,
     logLevel: process.env.LOG_LEVEL || 'info',
     importedDomainArn: '',
     importedDomainEndpoint: '',
@@ -224,14 +229,21 @@ class OpenSearchStack extends BaseStack {
     } else {
       // Else if no imported domain properties, create new domain
       logger.info('Creating new OpenSearch Domain');
+      const multiAzWithStandby = this.getConfigValue('opensearchMultiAzWithStandby') === true
+        || this.getConfigValue('opensearchMultiAzWithStandby') === 'true';
       this.openSearchDomain = new opensearch.Domain(this, this.getConstructId('openSearchDomain'), {
         domainName: `${this.getConfigValue('opensearchDomainPrefix')}-${this.getDeploymentName()}`,
         version: opensearch.EngineVersion.OPENSEARCH_2_17,
         capacity: {
           dataNodes: this.getConfigValue('opensearchDataNodeCount'),
           dataNodeInstanceType: this.getConfigValue('opensearchInstanceType'),
-          multiAzWithStandbyEnabled: false,
+          multiAzWithStandbyEnabled: multiAzWithStandby,
         },
+        // Multi-AZ with standby requires zone awareness across 3 AZs.
+        zoneAwareness: multiAzWithStandby ? {
+          enabled: true,
+          availabilityZoneCount: 3,
+        } : undefined,
         enforceHttps: true,
         nodeToNodeEncryption: true,
         encryptionAtRest: {
@@ -241,7 +253,7 @@ class OpenSearchStack extends BaseStack {
         enableVersionUpgrade: true,
         ebs: {
           enabled: true,
-          volumeSize: 10,
+          volumeSize: parseInt(this.getConfigValue('opensearchEbsVolumeSize'), 10) || 10,
           volumeType: 'gp3',
           iops: parseInt(this.getConfigValue('opensearchEbsVolumeIops'), 10) || 3000,
           throughput: parseInt(this.getConfigValue('opensearchEbsVolumeThroughput'), 10) || 125,


### PR DESCRIPTION
Exposes `opensearchEbsVolumeSize` and `opensearchMultiAzWithStandby` so they can be set per-env via the SSM config blob. No change for dev (defaults preserved). Test/prod SSM will be bumped to `m6g.large.search` to fix the burstable cold-start 400s. Ref bcgov/reserve-rec-public#507