### PR TITLE
fix(bookings): wire email queue to booking-complete Lambda

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -407,6 +407,8 @@ class PublicApiStack extends BaseStack {
         hmacSigningKeyArn: scope.resolveHmacSigningKeyArn(),
         smsReminderQueueUrl: smsReminderQueueUrl,
         smsReminderQueueArn: smsReminderQueueArn,
+        emailQueueUrl: emailQueueUrl,
+        emailQueueArn: emailQueueArn,
         waitingRoomTable: scope.getWaitingRoomTable(),
         hmacSigningKey: scope.getHmacSigningKey(),
       };
@@ -433,6 +435,15 @@ class PublicApiStack extends BaseStack {
         this.publicBookingsConstruct.bookingsPostFunction.addToRolePolicy(new iam.PolicyStatement({
           actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
           resources: [smsReminderQueueArn],
+        }));
+        // Wire the email dispatch queue to the booking-complete Lambda so it can
+        // enqueue confirmation emails.
+        this.publicBookingsConstruct.bookingsCompleteFunction.addEnvironment(
+          'EMAIL_QUEUE_URL', emailQueueUrl
+        );
+        this.publicBookingsConstruct.bookingsCompleteFunction.addToRolePolicy(new iam.PolicyStatement({
+          actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
+          resources: [emailQueueArn],
         }));
       } else {
         // For AWS deployments, use the nested stack to reduce resource count

--- a/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
+++ b/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
@@ -69,6 +69,19 @@ class PublicBookingsNestedStack extends NestedStack {
         resources: [props.smsReminderQueueArn],
       }));
     }
+
+    // Wire the email dispatch queue to the booking-complete Lambda so it can
+    // enqueue confirmation emails.
+    const completeFn = this.publicBookingsConstruct.bookingsCompleteFunction;
+    if (props.emailQueueUrl) {
+      completeFn.addEnvironment('EMAIL_QUEUE_URL', props.emailQueueUrl);
+    }
+    if (props.emailQueueArn) {
+      completeFn.addToRolePolicy(new iam.PolicyStatement({
+        actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
+        resources: [props.emailQueueArn],
+      }));
+    }
   }
 }
 


### PR DESCRIPTION
The booking-complete Lambda was missing `EMAIL_QUEUE_URL`. Its handler calls `sendConfirmationEmail`, which throws when the env var is unset; `sendBookingConfirmationEmail` swallows that error so bookings still succeed — silently dropping every confirmation email.

- Pass `emailQueueUrl` + `emailQueueArn` through `bookingsProps`
- Set `EMAIL_QUEUE_URL` and grant `sqs:SendMessage` on `bookingsCompleteFunction` in both the local and nested-stack code paths

Ref #56