### PR TITLE
fix(bookings): resolve park name from geozone reference data

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -23,7 +23,6 @@ const {
   DEFAULT_TRANSACTION_FEE_PERCENT,
   DEFAULT_TAX_PERCENT,
   BOOKING_STATUS_ENUMS,
-  PARK_NAMES_BY_COLLECTION_ID
 } = require("../../common/data-constants");
 const { PUBLIC_PRODUCTDATE_PROJECTIONS } = require("../productDates/configs");
 const { fetchProductDates } = require("../productDates/methods");
@@ -1177,14 +1176,36 @@ async function completeBooking(bookingId, sessionId, props) {
   }
 }
 
+async function getParkNameForCollection(collectionId) {
+  if (!collectionId) return null;
+  try {
+    const queryParams = {
+      TableName: REFERENCE_DATA_TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: {
+        ':pk': marshall(`geozone::${collectionId}`)
+      }
+    };
+    const result = await runQuery(queryParams);
+    const geozones = (result?.items || []).filter(item => item.sk !== 'counter');
+    if (geozones.length === 0) return null;
+    const primary = geozones.sort((a, b) => (a.geozoneId || 0) - (b.geozoneId || 0))[0];
+    return primary?.displayName || null;
+  } catch (error) {
+    logger.warn(`Failed to fetch park name for collectionId ${collectionId}:`, error.message || error);
+    return null;
+  }
+}
+
 async function generateEmailParams(booking, updatedBookingItem) {
   try {
 
     // get bookingDates
     const bookingDates = await getBookingDatesByBookingId(booking.bookingId);
 
-    // get parkName
-    const parkName = PARK_NAMES_BY_COLLECTION_ID[booking.collectionId];
+    // get parkName from the geozone reference data; fall back to the collectionId
+    // so the confirmation email still has something usable if lookup fails.
+    const parkName = (await getParkNameForCollection(booking.collectionId)) || booking.collectionId;
 
     const emailParams = {
       booking: {
@@ -2226,6 +2247,10 @@ async function flagCancelledBooking(booking, queryTime) {
  */
 async function sendBookingConfirmationEmail(emailParams, userName) {
   try {
+    if (!emailParams?.booking) {
+      logger.warn('Cannot send confirmation email - missing email params', { userName });
+      return null;
+    }
 
     // get account email from Cognito
     const userInfo = await getUserInfoByUserName(userName, 'public');


### PR DESCRIPTION
`generateEmailParams` was importing `PARK_NAMES_BY_COLLECTION_ID` from `data-constants`, but that symbol is never exported there — so at runtime `PARK_NAMES_BY_COLLECTION_ID[booking.collectionId]` threw `Cannot read properties of undefined`. The error was caught and `null` returned, then `sendBookingConfirmationEmail` derefed `emailParams.booking` and threw again — caught and swallowed. Net effect: every booking-complete call silently dropped its confirmation email.

PR #390 wired `EMAIL_QUEUE_URL` so the path is now exercised; this PR fixes the broken park-name resolution that's been latent since #356.

- Replace hardcoded map with a runtime geozone query (mirrors `getGeoZoneForBooking`)
- Fall back to `collectionId` if no geozone is found
- Null-guard `sendBookingConfirmationEmail` so a future `generateEmailParams` failure can't crash the caller

Ref #56