### PR TITLE
fix(bookings): grant KMS GenerateDataKey to booking-complete Lambda

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -494,6 +494,14 @@ class PublicApiStack extends BaseStack {
           actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
           resources: [emailQueueArn],
         }));
+        // The email queue is encrypted with the shared KMS key, so SendMessage
+        // requires GenerateDataKey on that key as well.
+        if (kmsKey) {
+          this.publicBookingsConstruct.bookingsCompleteFunction.addToRolePolicy(new iam.PolicyStatement({
+            actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
+            resources: [kmsKey.keyArn],
+          }));
+        }
       } else {
         // For AWS deployments, use the nested stack to reduce resource count
         // in the root stack

--- a/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
+++ b/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
@@ -81,6 +81,14 @@ class PublicBookingsNestedStack extends NestedStack {
         actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
         resources: [props.emailQueueArn],
       }));
+      // The email queue is encrypted with the shared KMS key, so SendMessage
+      // requires GenerateDataKey on that key as well.
+      if (props.kmsKey) {
+        completeFn.addToRolePolicy(new iam.PolicyStatement({
+          actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
+          resources: [props.kmsKey.keyArn],
+        }));
+      }
     }
   }
 }


### PR DESCRIPTION
The email queue is encrypted with the shared customer-managed KMS key. SendMessage on the queue requires `kms:GenerateDataKey` on that key as well — without it the call returns AccessDenied and the confirmation email is silently dropped (same outward symptom as #390/#392).

Mirrors the worldlineNotification wiring in both the nested-stack and local-SAM code paths.

Ref #56