### PR TITLE
PRDT-172: Add collections to nested redeployment dependency list

### DIFF
--- a/lib/admin-api-stack/admin-api-stack.js
+++ b/lib/admin-api-stack/admin-api-stack.js
@@ -726,6 +726,7 @@ class AdminApiStack extends BaseStack {
     // CDK doesn't automatically track their changes for redeployment.
     // We explicitly add dependencies so the deployment updates when spoke stacks change.
     const nestedStacks = [
+      isLocal ? null : this.collectionsNestedStack,
       isLocal ? null : this.geozonesNestedStack,
       isLocal ? null : this.facilitiesNestedStack,
       isLocal ? null : this.activitiesNestedStack,

--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -654,6 +654,7 @@ class PublicApiStack extends BaseStack {
     // CDK doesn't automatically track their changes for redeployment.
     // We explicitly add dependencies so the deployment updates when spoke stacks change.
     const nestedStacks = [
+      isLocal ? null : this.collectionsNestedStack,
       isLocal ? null : this.geozonesNestedStack,
       isLocal ? null : this.facilitiesNestedStack,
       isLocal ? null : this.publicActivitiesNestedStack,


### PR DESCRIPTION
### Ticket:

PRDT-172

### Ticket URL:

[#172](https://github.com/bcgov/reserve-rec-admin/issues/172)

### Description:
- Add `collections` to the nested stack redeployment dependencies
- This should fix the issue of the `collections` endpoint not being available (giving `403`s and `Invalid key=value pair` errors)  because it was still using the `AWS_IAM` authorization type in TEST.
