### PR TITLE
fix(bookings): require auth on the booking GET endpoint

### DIFF
--- a/src/handlers/bookings/GET/public.js
+++ b/src/handlers/bookings/GET/public.js
@@ -55,42 +55,32 @@ exports.handler = async (event, context) => {
     // Search by ID
     const bookingId = event?.pathParameters?.bookingId || event?.queryStringParameters?.bookingId;
     const fetchAccessPoints = event?.queryStringParameters?.fetchAccessPoints || false;
-    const email = event?.queryStringParameters?.email || null;
 
-    // Get userId from claims (may be null for anonymous users)
+    // Bookings can only be made by authenticated users (see bookings/POST/public.js),
+    // so every legitimate lookup happens on behalf of a known Cognito sub. The
+    // older `?email=` guest lookup path has been removed: it bypassed ownership
+    // verification and allowed any caller with a booking ID + a matching
+    // namedOccupant email to view someone else's booking.
     const userId = getRequestClaimsFromEvent(event)?.sub || null;
+    if (!userId) {
+      throw new Exception(
+        "Unauthorized: authentication required to view bookings",
+        { code: 401 }
+      );
+    }
 
     // If bookingId is provided, fetch that specific booking
     if (bookingId) {
       const booking = await getBookingByBookingId(bookingId, fetchAccessPoints);
 
-      // Email provided - verify email matches booking email (for guest/unauthenticated lookup)
-      if (email) {
-        if (booking?.namedOccupant?.contactInfo?.email !== email) {
-          throw new Exception(
-            `Forbidden: Email ${email} does not match booking ${bookingId}`,
-            { code: 403 }
-          );
-        }
-        // Email matches, allow access - generate QR code after authorization
-        const qrCodeData = await generateQRCodeForBooking(bookingId, booking);
-        return sendResponse(200, { ...booking, qrCode: qrCodeData }, "Success", null, context);
-      } else if (userId) {
-        if (booking?.userId !== userId) {
-          throw new Exception(
-            `Forbidden: User ${userId} does not have access to booking ${bookingId}`,
-            { code: 403 }
-          );
-        }
-        // User authorized - generate QR code after authorization
-        const qrCodeData = await generateQRCodeForBooking(bookingId, booking);
-        return sendResponse(200, { ...booking, qrCode: qrCodeData }, "Success", null, context);
-      } else {
+      if (booking?.userId !== userId) {
         throw new Exception(
-          "Unauthorized: Must provide either email or be authenticated",
-          { code: 401 }
+          `Forbidden: User ${userId} does not have access to booking ${bookingId}`,
+          { code: 403 }
         );
       }
+      const qrCodeData = await generateQRCodeForBooking(bookingId, booking);
+      return sendResponse(200, { ...booking, qrCode: qrCodeData }, "Success", null, context);
     }
 
     const collectionId = event?.pathParameters?.collectionId || event?.queryStringParameters?.collectionId;

--- a/test/booking/GET-qrcode.test.js
+++ b/test/booking/GET-qrcode.test.js
@@ -38,6 +38,8 @@ const { getRequestClaimsFromEvent, logger } = require('/opt/base');
 ({ getBookingByBookingId, getBookingsByUserId } = require('../../src/handlers/bookings/methods'));
 ({ generateQRURL, generateQRCodeDataURL } = require('../../lib/handlers/emailDispatch/qrCodeHelper'));
 
+const OWNER = 'user-owner';
+
 describe('Bookings GET handler - QR Code Generation', () => {
   const context = {};
 
@@ -46,134 +48,81 @@ describe('Bookings GET handler - QR Code Generation', () => {
   });
 
   describe('QR Code Security', () => {
-    it('should NOT generate QR code before authorization check', async () => {
+    it('should NOT fetch a booking or generate a QR code when unauthenticated', async () => {
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-123' },
-        queryStringParameters: { email: 'wrong@example.com' }
       };
-      
-      getBookingByBookingId.mockResolvedValue({
-        bookingId: 'booking-123',
-        bookingStatus: 'confirmed',
-        namedOccupant: {
-          contactInfo: {
-            email: 'correct@example.com'
-          }
-        }
-      });
       getRequestClaimsFromEvent.mockReturnValue(null);
-      
+
       const res = await handler(event, context);
-      
-      // Should fail authorization
-      expect(res.status).toBe(403);
-      // QR code functions should NOT have been called
+
+      expect(res.status).toBe(401);
+      expect(getBookingByBookingId).not.toHaveBeenCalled();
       expect(generateQRURL).not.toHaveBeenCalled();
       expect(generateQRCodeDataURL).not.toHaveBeenCalled();
     });
 
-    it('should NOT generate QR code for unauthorized userId', async () => {
+    it('should NOT generate QR code when authenticated sub does not own the booking', async () => {
       const event = {
         httpMethod: 'GET',
-        pathParameters: { bookingId: 'booking-123' }
+        pathParameters: { bookingId: 'booking-123' },
       };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-123',
         bookingStatus: 'confirmed',
-        userId: 'user-correct'
+        userId: OWNER,
       });
       getRequestClaimsFromEvent.mockReturnValue({ sub: 'user-wrong' });
-      
+
       const res = await handler(event, context);
-      
-      // Should fail authorization
+
       expect(res.status).toBe(403);
-      // QR code functions should NOT have been called
       expect(generateQRURL).not.toHaveBeenCalled();
       expect(generateQRCodeDataURL).not.toHaveBeenCalled();
     });
   });
 
   describe('QR Code Generation for Authorized Users', () => {
-    it('should generate QR code for confirmed booking with matching email', async () => {
+    it('should generate QR code for confirmed booking when sub matches owner', async () => {
       const event = {
         httpMethod: 'GET',
-        pathParameters: { bookingId: 'booking-123' },
-        queryStringParameters: { email: 'test@example.com' }
+        pathParameters: { bookingId: 'booking-456' },
       };
-      
-      getBookingByBookingId.mockResolvedValue({
-        bookingId: 'booking-123',
-        bookingStatus: 'confirmed',
-        namedOccupant: {
-          contactInfo: {
-            email: 'test@example.com'
-          }
-        }
-      });
-      getRequestClaimsFromEvent.mockReturnValue(null);
-      generateQRURL.mockReturnValue('https://example.com/verify/booking-123/abc123');
-      generateQRCodeDataURL.mockResolvedValue('data:image/png;base64,QRCODE');
-      
-      const res = await handler(event, context);
-      
-      expect(res.status).toBe(200);
-      expect(generateQRURL).toHaveBeenCalledWith('booking-123');
-      expect(generateQRCodeDataURL).toHaveBeenCalledWith('https://example.com/verify/booking-123/abc123');
-      expect(res.data.qrCode).toEqual({
-        dataUrl: 'data:image/png;base64,QRCODE',
-        verificationUrl: 'https://example.com/verify/booking-123/abc123'
-      });
-    });
-
-    it('should generate QR code for confirmed booking with matching userId', async () => {
-      const event = {
-        httpMethod: 'GET',
-        pathParameters: { bookingId: 'booking-456' }
-      };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-456',
         bookingStatus: 'confirmed',
-        userId: 'user-123'
+        userId: OWNER,
       });
-      getRequestClaimsFromEvent.mockReturnValue({ sub: 'user-123' });
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
       generateQRURL.mockReturnValue('https://example.com/verify/booking-456/def456');
       generateQRCodeDataURL.mockResolvedValue('data:image/png;base64,QRCODE2');
-      
+
       const res = await handler(event, context);
-      
+
       expect(res.status).toBe(200);
       expect(generateQRURL).toHaveBeenCalledWith('booking-456');
       expect(generateQRCodeDataURL).toHaveBeenCalledWith('https://example.com/verify/booking-456/def456');
       expect(res.data.qrCode).toEqual({
         dataUrl: 'data:image/png;base64,QRCODE2',
-        verificationUrl: 'https://example.com/verify/booking-456/def456'
+        verificationUrl: 'https://example.com/verify/booking-456/def456',
       });
     });
 
-    it('should NOT generate QR code for non-confirmed bookings', async () => {
+    it('should NOT generate QR code for in-progress bookings even when owner is authorized', async () => {
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-789' },
-        queryStringParameters: { email: 'test@example.com' }
       };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-789',
         bookingStatus: 'in progress',
-        namedOccupant: {
-          contactInfo: {
-            email: 'test@example.com'
-          }
-        }
+        userId: OWNER,
       });
-      getRequestClaimsFromEvent.mockReturnValue(null);
-      
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
+
       const res = await handler(event, context);
-      
+
       expect(res.status).toBe(200);
       expect(generateQRURL).not.toHaveBeenCalled();
       expect(generateQRCodeDataURL).not.toHaveBeenCalled();
@@ -184,22 +133,16 @@ describe('Bookings GET handler - QR Code Generation', () => {
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-cancel' },
-        queryStringParameters: { email: 'test@example.com' }
       };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-cancel',
         bookingStatus: 'cancelled',
-        namedOccupant: {
-          contactInfo: {
-            email: 'test@example.com'
-          }
-        }
+        userId: OWNER,
       });
-      getRequestClaimsFromEvent.mockReturnValue(null);
-      
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
+
       const res = await handler(event, context);
-      
+
       expect(res.status).toBe(200);
       expect(generateQRURL).not.toHaveBeenCalled();
       expect(generateQRCodeDataURL).not.toHaveBeenCalled();
@@ -208,116 +151,91 @@ describe('Bookings GET handler - QR Code Generation', () => {
   });
 
   describe('QR Code Generation Error Handling', () => {
-    it('should return booking without QR code if QR generation fails', async () => {
+    it('should return booking without QR code if QR generation throws', async () => {
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-error' },
-        queryStringParameters: { email: 'test@example.com' }
       };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-error',
         bookingStatus: 'confirmed',
-        namedOccupant: {
-          contactInfo: {
-            email: 'test@example.com'
-          }
-        }
+        userId: OWNER,
       });
-      getRequestClaimsFromEvent.mockReturnValue(null);
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
       generateQRURL.mockImplementation(() => {
         throw new Error('QR generation failed');
       });
-      
+
       const res = await handler(event, context);
-      
-      // Should still succeed with booking data
+
       expect(res.status).toBe(200);
       expect(res.data.bookingId).toBe('booking-error');
-      // QR code should be null due to error
       expect(res.data.qrCode).toBeNull();
-      // Should log warning
       expect(logger.warn).toHaveBeenCalledWith(
         'Failed to generate QR code for booking',
         expect.objectContaining({
           bookingId: 'booking-error',
-          error: 'QR generation failed'
+          error: 'QR generation failed',
         })
       );
     });
 
-    it('should handle QR code data URL generation failure gracefully', async () => {
+    it('should handle QR data-URL generation failure gracefully', async () => {
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-url-error' },
-        queryStringParameters: { email: 'test@example.com' }
       };
-      
       getBookingByBookingId.mockResolvedValue({
         bookingId: 'booking-url-error',
         bookingStatus: 'confirmed',
-        namedOccupant: {
-          contactInfo: {
-            email: 'test@example.com'
-          }
-        }
+        userId: OWNER,
       });
-      getRequestClaimsFromEvent.mockReturnValue(null);
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
       generateQRURL.mockReturnValue('https://example.com/verify/booking-url-error/hash');
       generateQRCodeDataURL.mockRejectedValue(new Error('PNG generation failed'));
-      
+
       const res = await handler(event, context);
-      
-      // Should still succeed with booking data
+
       expect(res.status).toBe(200);
       expect(res.data.bookingId).toBe('booking-url-error');
-      // QR code should be null due to error
       expect(res.data.qrCode).toBeNull();
-      // Should log warning
       expect(logger.warn).toHaveBeenCalled();
     });
   });
 
   describe('QR Code Timing - Authorization First', () => {
-    it('should verify authorization before any QR code processing', async () => {
+    it('should verify ownership before any QR code processing', async () => {
       const callOrder = [];
-      
+
       const event = {
         httpMethod: 'GET',
         pathParameters: { bookingId: 'booking-timing' },
-        queryStringParameters: { email: 'test@example.com' }
       };
-      
+
       getBookingByBookingId.mockImplementation(async () => {
         callOrder.push('fetchBooking');
         return {
           bookingId: 'booking-timing',
           bookingStatus: 'confirmed',
-          namedOccupant: {
-            contactInfo: {
-              email: 'test@example.com'
-            }
-          }
+          userId: OWNER,
         };
       });
-      
+
       generateQRURL.mockImplementation(() => {
         callOrder.push('generateQRURL');
         return 'https://example.com/verify/booking-timing/hash';
       });
-      
+
       generateQRCodeDataURL.mockImplementation(async () => {
         callOrder.push('generateQRCodeDataURL');
         return 'data:image/png;base64,QR';
       });
-      
-      getRequestClaimsFromEvent.mockReturnValue(null);
-      
+
+      getRequestClaimsFromEvent.mockReturnValue({ sub: OWNER });
+
       await handler(event, context);
-      
-      // Verify call order: fetch booking, then generate QR (authorization happens in between)
+
       expect(callOrder).toEqual(['fetchBooking', 'generateQRURL', 'generateQRCodeDataURL']);
-      // This ensures authorization check happens after booking fetch but before QR generation
     });
   });
 });

--- a/test/booking/GET.test.js
+++ b/test/booking/GET.test.js
@@ -46,81 +46,96 @@ describe('Bookings GET handler', () => {
     expect(res.status).toBe(200);
   });
 
-  it('should get booking by bookingId with email verification', async () => {
+  it('returns 401 when no auth token is present (single booking)', async () => {
     const event = {
       httpMethod: 'GET',
       pathParameters: { bookingId: 'b1' },
-      queryStringParameters: { email: 'test@example.com' }
     };
-    getBookingByBookingId.mockResolvedValue({
-      id: 'b1',
-      namedOccupant: {
-        contactInfo: {
-          email: 'test@example.com'
-        }
-      }
-    });
     getRequestClaimsFromEvent.mockReturnValue(null);
-    
+
     const res = await handler(event, context);
-    expect(getBookingByBookingId).toHaveBeenCalledWith('b1', false);
-    expect(res.status).toBe(200);
-    expect(res.data.id).toBe('b1');
+    expect(res.status).toBe(401);
+    expect(getBookingByBookingId).not.toHaveBeenCalled();
   });
 
-  it('should reject booking lookup with mismatched email', async () => {
+  it('returns 401 even if ?email= is provided (no anonymous lookup)', async () => {
     const event = {
       httpMethod: 'GET',
       pathParameters: { bookingId: 'b1' },
-      queryStringParameters: { email: 'wrong@example.com' }
+      queryStringParameters: { email: 'test@example.com' },
+    };
+    getRequestClaimsFromEvent.mockReturnValue(null);
+
+    const res = await handler(event, context);
+    expect(res.status).toBe(401);
+    expect(getBookingByBookingId).not.toHaveBeenCalled();
+  });
+
+  it('ignores ?email= when authenticated — uses sub for ownership only', async () => {
+    // Caller (Bob) is authenticated but tries to fetch Alice's booking by
+    // passing Alice's email in the query string. The handler must use the
+    // JWT sub, not the email, to decide ownership.
+    const event = {
+      httpMethod: 'GET',
+      pathParameters: { bookingId: 'b-alice' },
+      queryStringParameters: { email: 'alice@example.com' },
     };
     getBookingByBookingId.mockResolvedValue({
-      id: 'b1',
-      namedOccupant: {
-        contactInfo: {
-          email: 'test@example.com'
-        }
-      }
+      id: 'b-alice',
+      userId: 'alice-sub',
+      namedOccupant: { contactInfo: { email: 'alice@example.com' } },
     });
-    getRequestClaimsFromEvent.mockReturnValue(null);
-    
+    getRequestClaimsFromEvent.mockReturnValue({ sub: 'bob-sub' });
+
     const res = await handler(event, context);
     expect(res.status).toBe(403);
   });
 
-  it('should get booking by bookingId with userId verification', async () => {
+  it('returns the booking when authenticated and sub matches userId', async () => {
     const event = {
       httpMethod: 'GET',
-      pathParameters: { bookingId: 'b2' }
+      pathParameters: { bookingId: 'b2' },
     };
     getBookingByBookingId.mockResolvedValue({
       id: 'b2',
-      userId: 'user123'
+      userId: 'user123',
     });
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'user123' });
-    
+
     const res = await handler(event, context);
     expect(getBookingByBookingId).toHaveBeenCalledWith('b2', false);
     expect(res.status).toBe(200);
     expect(res.data.id).toBe('b2');
   });
 
-  it('should reject booking lookup with mismatched userId', async () => {
+  it('returns 403 when authenticated but sub does not match booking owner', async () => {
     const event = {
       httpMethod: 'GET',
-      pathParameters: { bookingId: 'b2' }
+      pathParameters: { bookingId: 'b2' },
     };
     getBookingByBookingId.mockResolvedValue({
       id: 'b2',
-      userId: 'user123'
+      userId: 'user123',
     });
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'wronguser' });
-    
+
     const res = await handler(event, context);
     expect(res.status).toBe(403);
   });
 
-  it('should get bookings by userId with filters', async () => {
+  it('returns 401 when listing bookings without auth', async () => {
+    const event = {
+      httpMethod: 'GET',
+      queryStringParameters: { collectionId: 'col1' },
+    };
+    getRequestClaimsFromEvent.mockReturnValue(null);
+
+    const res = await handler(event, context);
+    expect(res.status).toBe(401);
+    expect(getBookingsByUserId).not.toHaveBeenCalled();
+  });
+
+  it('lists bookings by sub with filters when authenticated', async () => {
     const event = {
       httpMethod: 'GET',
       queryStringParameters: {
@@ -128,12 +143,12 @@ describe('Bookings GET handler', () => {
         activityType: 'frontcountryCamp',
         activityId: 'act1',
         startDate: '2024-01-01',
-        endDate: '2024-01-02'
-      }
+        endDate: '2024-01-02',
+      },
     };
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'user123' });
     getBookingsByUserId.mockResolvedValue([{ id: 'b3' }, { id: 'b4' }]);
-    
+
     const res = await handler(event, context);
     expect(getBookingsByUserId).toHaveBeenCalledWith('user123', {
       collectionId: 'col1',
@@ -142,53 +157,51 @@ describe('Bookings GET handler', () => {
       startDate: '2024-01-01',
       endDate: '2024-01-02',
       bookingId: undefined,
-      fetchAccessPoints: false
+      fetchAccessPoints: false,
     });
     expect(res.status).toBe(200);
     expect(res.data).toHaveLength(2);
   });
 
-  it('should get bookings with fetchAccessPoints flag', async () => {
+  it('honors the fetchAccessPoints flag on list', async () => {
     const event = {
       httpMethod: 'GET',
-      queryStringParameters: {
-        fetchAccessPoints: 'true'
-      }
+      queryStringParameters: { fetchAccessPoints: 'true' },
     };
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'user123' });
     getBookingsByUserId.mockResolvedValue([]);
-    
+
     const res = await handler(event, context);
     expect(getBookingsByUserId).toHaveBeenCalledWith('user123', expect.objectContaining({
-      fetchAccessPoints: 'true'
+      fetchAccessPoints: 'true',
     }));
     expect(res.status).toBe(200);
   });
 
-  it('should handle errors and return error response', async () => {
+  it('surfaces downstream errors with explicit code', async () => {
     const event = {
       httpMethod: 'GET',
-      queryStringParameters: {}
+      queryStringParameters: {},
     };
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'user123' });
     getBookingsByUserId.mockRejectedValue({
       code: 500,
       msg: 'DB error',
-      error: 'Database connection failed'
+      error: 'Database connection failed',
     });
-    
+
     const res = await handler(event, context);
     expect(res.status).toBe(500);
   });
 
-  it('should handle errors without code property', async () => {
+  it('falls back to 400 when the error has no code', async () => {
     const event = {
       httpMethod: 'GET',
-      queryStringParameters: {}
+      queryStringParameters: {},
     };
     getRequestClaimsFromEvent.mockReturnValue({ sub: 'user123' });
     getBookingsByUserId.mockRejectedValue(new Error('Unknown error'));
-    
+
     const res = await handler(event, context);
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#503

### Ticket URL:

https://github.com/bcgov/reserve-rec-public/issues/503

### Description:

- Removed the `?email=` guest path from `bookings/GET/public.js`. The handler now always requires a Cognito sub and enforces `booking.userId === claims.sub`. Anonymous and email-only callers get 401.
- The old branch authorized by matching `namedOccupant.contactInfo.email` with no JWT check — two users sharing an email could fetch each other's bookings. Bookings can only be created by authenticated users (POST requires `claims.sub`), so the path served no legitimate flow.
- Tests rewritten to cover the new contract.
- Companion PR in reserve-rec-public will remove the now-dead client paths (`find-booking`, `getBookingByGlobalIdAndEmail`) and sub-scope the cart in localStorage.

Ref bcgov/reserve-rec-public#503