### PR TITLE
fix(bookings): confirmation email — write-before-email, QR inline, account URLs

### DIFF
--- a/lib/email-dispatch-stack/email-dispatch-stack.js
+++ b/lib/email-dispatch-stack/email-dispatch-stack.js
@@ -131,7 +131,9 @@ class EmailDispatchStack extends BaseStack {
         // QR Code environment variables
         QR_SECRET_KEY: this.getSecretValue('qrSecretKey'),
         PUBLIC_FRONTEND_DOMAIN: publicFrontendDomain,
-        INCLUDE_QR_INLINE: 'false', // Default disabled - enable per facility/park
+        // Inline QR rendering needed so confirmation emails carry the
+        // park-staff check-in code (Ref bcgov/reserve-rec-public#56).
+        INCLUDE_QR_INLINE: 'true',
       },
       layers: [baseLayer, awsUtilsLayer],
       timeout: Duration.seconds(this.getConfigValue('emailDispatchFunctionTimeout')),

--- a/src/handlers/bookings/PUT/public.js
+++ b/src/handlers/bookings/PUT/public.js
@@ -1,15 +1,15 @@
-// Create new transaction
+// Complete a booking via PUT: write the booking row first, then dispatch the
+// confirmation email. Email send must follow a successful DynamoDB write —
+// otherwise a transient DB failure would leave the user with a confirmation
+// email for a booking that was never saved.
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { completeBooking } = require("../methods")
-const { BOOKING_UPDATE_CONFIG } = require("../configs");
-const { quickApiUpdateHandler } = require("../../../common/data-utils");
-const { TABLE_NAME, batchTransactData } = require("/opt/dynamodb");
+const { completeBooking, sendBookingConfirmationEmail } = require("../methods");
+const { batchTransactData } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {
   logger.info("Bookings PUT:", event);
 
   try {
-    // Get relevant data from the event
     const body = JSON.parse(event?.body);
     const bookingId = event.pathParameters?.bookingId || body.bookingId;
     const sessionId = body.sessionId;
@@ -22,23 +22,27 @@ exports.handler = async (event, context) => {
       throw new Exception("Session ID is required", { code: 400 });
     }
 
-    // Extract sub (userId) from authorizer for secure email lookup
-    const sub = event.requestContext.authorizer?.userId;
+    // Custom authorizer exposes the Cognito sub flat under `userId`.
+    const sub = event.requestContext?.authorizer?.userId;
     if (!sub) {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    // Complete booking and send confirmation email (all in one operation)
-    const updateRequests = await completeBooking(bookingId, sessionId, body, sub);
+    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body);
 
     const res = await batchTransactData(updateRequests);
 
-    const response = {
-      res: res,
-      booking: updateRequests,
+    try {
+      await sendBookingConfirmationEmail(emailParams, sub);
+    } catch (emailError) {
+      logger.error("Booking completed but confirmation email send failed", {
+        bookingId,
+        error: emailError?.message,
+        stack: emailError?.stack,
+      });
     }
 
-    return sendResponse(200, response, "Success", null, context);
+    return sendResponse(200, { res, booking: updateRequests }, "Success", null, context);
 
   } catch (error) {
     return sendResponse(

--- a/src/handlers/bookings/_bookingId/complete/POST/public.js
+++ b/src/handlers/bookings/_bookingId/complete/POST/public.js
@@ -1,6 +1,9 @@
-// Create new transaction
+// Complete a booking: write the booking row, then dispatch the confirmation
+// email. The email must go out only after the DynamoDB write succeeds —
+// otherwise a transient DB failure would leave the user with a confirmation
+// email for a booking that was never saved.
 const { Exception, logger, sendResponse } = require("/opt/base");
-const { completeBooking } = require("../../../methods");
+const { completeBooking, sendBookingConfirmationEmail } = require("../../../methods");
 const { batchTransactData } = require("/opt/dynamodb");
 
 
@@ -8,7 +11,6 @@ exports.handler = async (event, context) => {
   logger.info("POST Complete Booking:", event);
 
   try {
-    // Get relevant data from the event
     const body = JSON.parse(event?.body);
     const bookingId = event.pathParameters?.bookingId;
     const sessionId = body.sessionId;
@@ -21,22 +23,29 @@ exports.handler = async (event, context) => {
       throw new Exception("Session ID is required", { code: 400 });
     }
 
-    // Extract sub (userId) from authorizer for secure email lookup
-    const sub = event.requestContext.authorizer?.userId;
+    // Custom authorizer exposes the Cognito sub flat under `userId`.
+    const sub = event.requestContext?.authorizer?.userId;
     if (!sub) {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    // Complete booking and send confirmation email (all in one operation)
-    const updateRequests = await completeBooking(bookingId, sessionId, body, sub);
+    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body);
 
     const res = await batchTransactData(updateRequests);
 
-    const response = {
-      res: res,
+    // Booking is durable — now queue the email. Failures here are logged but
+    // do not roll back the cancellation; the user has a confirmed booking.
+    try {
+      await sendBookingConfirmationEmail(emailParams, sub);
+    } catch (emailError) {
+      logger.error("Booking completed but confirmation email send failed", {
+        bookingId,
+        error: emailError?.message,
+        stack: emailError?.stack,
+      });
     }
 
-    return sendResponse(200, response, "Success", null, context);
+    return sendResponse(200, { res }, "Success", null, context);
 
   } catch (error) {
     return sendResponse(

--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -210,10 +210,13 @@ class PublicBookingsConstruct extends LambdaConstruct {
       }
     );
 
-    // Add permissions for Lambda to read from Cognito User Pools
+    // Add permissions for Lambda to read from Cognito User Pools. ListUsers
+    // is used by getUserInfoBySub to look up the recipient's verified email
+    // by the immutable Cognito sub claim.
     this.bookingsCompleteFunction.addToRolePolicy(new iam.PolicyStatement({
       actions: [
-        "cognito-idp:AdminGetUser"
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:ListUsers",
       ],
       resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
     }));
@@ -229,6 +232,15 @@ class PublicBookingsConstruct extends LambdaConstruct {
         basicRead: true,
       }
     );
+
+    // Cancel handler also needs Cognito ListUsers — same getUserInfoBySub path.
+    this.bookingsCancelPostFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:ListUsers",
+      ],
+      resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
+    }));
 
     // POST /bookings/{bookingId}/complete
     this.bookingsByBookingIdResource.addResource('complete').addMethod('POST', new apigw.LambdaIntegration(this.bookingsCompleteFunction), {

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -1063,7 +1063,7 @@ function formatBookingResponsePublic(bookingResponse) {
   }
 }
 
-async function completeBooking(bookingId, sessionId, props, sub) {
+async function completeBooking(bookingId, sessionId, props) {
   try {
 
     // === get queryTime ===
@@ -1170,19 +1170,15 @@ async function completeBooking(bookingId, sessionId, props, sub) {
 
     const emailParams = await generateEmailParams(completeBookingForEmail);
 
-    // Send confirmation email as part of booking completion workflow
-    // Email failures should not block booking completion
-    try {
-      await sendBookingConfirmationEmail(emailParams, sub);
-    } catch (emailError) {
-      logger.warn('Booking completed but email send failed', {
-        bookingId,
-        error: emailError.message,
-      });
-      // Continue - booking should complete even if email fails
-    }
-
-    return bookingUpdateRequest;
+    // Return the update + email params for the handler to commit and dispatch
+    // in that order. We intentionally do NOT send the email here: the SQS
+    // enqueue must happen *after* batchTransactData succeeds, otherwise a
+    // failed DynamoDB write would leave the user with a confirmation email
+    // for a booking that was never saved.
+    return {
+      updateRequests: bookingUpdateRequest,
+      emailParams,
+    };
 
 
   } catch (error) {
@@ -1228,6 +1224,20 @@ async function generateEmailParams(booking) {
     // so the email still has something usable if lookup fails.
     const parkName = (await getParkNameForCollection(booking.collectionId)) || booking.collectionId;
 
+    // Build user-facing URLs to the public app's account pages. The template
+    // gates the "View booking" and "Cancel booking" buttons on these being
+    // truthy; we leave them null if PUBLIC_FRONTEND_DOMAIN isn't configured
+    // so the buttons simply don't render rather than pointing to garbage.
+    const publicDomain = process.env.PUBLIC_FRONTEND_DOMAIN
+      ? `https://${process.env.PUBLIC_FRONTEND_DOMAIN}`.replace(/^https:\/\/https:\/\//, "https://")
+      : null;
+    const accountBookingUrl = publicDomain
+      ? `${publicDomain}/account/bookings/${booking.bookingId}`
+      : null;
+    const cancellationUrl = publicDomain
+      ? `${publicDomain}/account/bookings/cancel/${booking.bookingId}`
+      : null;
+
     const emailParams = {
       booking: {
         bookingId: booking.bookingId,
@@ -1238,11 +1248,11 @@ async function generateEmailParams(booking) {
         }, 0),
         arrivalDate: booking.reservationContext?.arrivalDate?.ts,
         departureDate: booking.reservationContext?.departureDate?.ts,
-        accountBookingUrl: null,
+        accountBookingUrl,
         activityType: booking.activityType ? booking.activityType.charAt(0).toUpperCase() + booking.activityType.slice(1) : 'Activity',
         productName: booking.displayName,
         qrCodeDataUrl: null,
-        cancellationUrl: null,
+        cancellationUrl,
         namedOccupant: booking.namedOccupant || {},
       },
       customer: {


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#56

### Description:

Bug fixes:
- Restore write-before-email order in the complete-booking flow. PR #399 had moved \`sendBookingConfirmationEmail\` *inside* \`completeBooking\` so the SQS enqueue happened before the handler ran \`batchTransactData\`. A transient DB failure would have left the user with a confirmation email for a booking that was never saved. \`completeBooking\` now returns \`{ updateRequests, emailParams }\` again; POST + PUT handlers commit the write, then queue the email (and log-and-continue on email failure).
- Grant \`cognito-idp:ListUsers\` to the cancel + complete Lambdas. The \`getUserInfoBySub\` helper (introduced with the cancellation email work) uses \`ListUsers\` with a sub filter; the cancel role had no Cognito perms at all and complete only had \`AdminGetUser\`. Cancellation emails on TEST were failing with AccessDeniedException — confirmed in CloudWatch.

Feature work for #56:
- Set \`INCLUDE_QR_INLINE = 'true'\` on the email-dispatch Lambda so the QR-code section actually renders.
- Populate \`accountBookingUrl\` + \`cancellationUrl\` in \`generateEmailParams\` using \`PUBLIC_FRONTEND_DOMAIN\`. The template's "View booking" and "Cancel booking" buttons were hardcoded to null and never showed.

Ref bcgov/reserve-rec-public#56
Ref bcgov/reserve-rec-public#503