### PR TITLE
fix(bookings): pass top-level email to sendConfirmationEmail

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -2313,6 +2313,11 @@ async function sendBookingConfirmationEmail(emailParams, sub) {
     }
 
     const result = await sendConfirmationEmail({
+      // `sendConfirmationEmail` reads recipientEmail from the top-level
+      // `email` key (different shape than the cancellation helper, which
+      // reads from customerData.email). Without this the payload validator
+      // rejects with "Missing required field: recipientEmail".
+      email: accountEmail,
       bookingData: emailParams.booking,
       customerData: {
         ...emailParams.customer,
@@ -2334,6 +2339,10 @@ async function sendBookingConfirmationEmail(emailParams, sub) {
     logger.error('Failed to queue booking confirmation email', {
       bookingId,
       error: error.message,
+      // The schema-validation Exception attaches a `data.errors` array;
+      // log it so the per-field reason isn't swallowed by the generic
+      // "Invalid email payload" message.
+      validationErrors: error?.data?.errors || error?.errors,
       stack: error.stack,
     });
     // Don't throw - email failure shouldn't break the booking flow
@@ -2410,6 +2419,7 @@ async function sendBookingCancellationEmail(emailParams, sub) {
     logger.error('Failed to queue booking cancellation email', {
       bookingId,
       error: error.message,
+      validationErrors: error?.data?.errors || error?.errors,
       stack: error.stack,
     });
     // Don't throw - email failure shouldn't break the cancel flow


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#56

### Ticket URL:

https://github.com/bcgov/reserve-rec-public/issues/56

### Description:

- \`sendConfirmationEmail\` destructures \`email\` from top-level params; the call was only putting it inside \`customerData\`, so \`recipientEmail\` came through undefined and the schema validator threw "Invalid email payload" — confirmation emails were silently dropped on every booking completion. Adds the top-level \`email\` field.
- Also surfaces \`error.data.errors\` in the catch so future schema-validation failures show the per-field reason instead of just the wrapper message.

Ref bcgov/reserve-rec-public#56