### PR TITLE
fix(bookings): resolve occupant identity from Cognito sub

### DIFF
--- a/src/handlers/bookings/PUT/public.js
+++ b/src/handlers/bookings/PUT/public.js
@@ -28,7 +28,7 @@ exports.handler = async (event, context) => {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body);
+    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body, { sub });
 
     const res = await batchTransactData(updateRequests);
 

--- a/src/handlers/bookings/_bookingId/complete/POST/public.js
+++ b/src/handlers/bookings/_bookingId/complete/POST/public.js
@@ -29,7 +29,7 @@ exports.handler = async (event, context) => {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body);
+    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body, { sub });
 
     const res = await batchTransactData(updateRequests);
 

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -34,6 +34,37 @@ const { getUserInfoByUserName, getUserInfoBySub } = require("../users/methods");
 const DEFAULT_SESSION_LENGTH = 30; // in minutes
 
 /**
+ * Resolve the booking owner's identity (firstName, lastName, email, phone) from
+ * the verified Cognito user pool, given their immutable `sub`. The booking row
+ * must store these from Cognito — never from the request body — so that a
+ * client cannot put another user's name/email on their booking (Ref #480).
+ *
+ * Address fields are intentionally not sourced here: Cognito does not reliably
+ * carry address attributes for BCSC users, so the booking flow accepts those
+ * from the request body. Identity (name + contact) lives in Cognito.
+ *
+ * @param {string} sub - Cognito sub of the authenticated user
+ * @returns {Promise<{firstName:string,lastName:string,email:string,mobilePhone:string}|null>}
+ */
+async function resolveAuthenticatedOccupantIdentity(sub) {
+  if (!sub) return null;
+  try {
+    const userInfo = await getUserInfoBySub(sub, 'public');
+    const attrs = userInfo?.Attributes || [];
+    const get = (n) => attrs.find(a => a.Name === n)?.Value || '';
+    return {
+      firstName: get('given_name'),
+      lastName: get('family_name'),
+      email: get('email'),
+      mobilePhone: get('custom:mobilePhone') || get('phone_number'),
+    };
+  } catch (error) {
+    logger.error('Failed to resolve occupant identity from Cognito', { sub, error: error?.message });
+    throw error;
+  }
+}
+
+/**
  * Helper: Get start of day in UTC for a date string
  * @param {string} dateString - ISO date string (e.g., "2025-12-12")
  * @returns {Date} Date object set to midnight UTC
@@ -696,6 +727,13 @@ async function initBookingRequestItems(product, productDates, assetRef, props) {
     const timeout = product?.holdDuration?.minutes || DEFAULT_SESSION_LENGTH;
     const sessionExpiry = addMinutes(new Date(), timeout).getTime();
 
+    // === Resolve owner identity from Cognito ===
+    // Name, email, and phone for the booking owner come from the verified
+    // Cognito profile keyed by `userId` (the authenticated sub), not from the
+    // request body — clients must not be able to put another user's identity
+    // on a booking (Ref #480). Address fields stay from props.
+    const ownerIdentity = await resolveAuthenticatedOccupantIdentity(userId);
+
     // === Build the child BookingDates first
     const bookingDateItems = productDates.items.map((productDate) => initBookingDateItem(globalId, product, productDate, assetRef, props));
 
@@ -733,39 +771,36 @@ async function initBookingRequestItems(product, productDates, assetRef, props) {
       partyPolicySnapshot: deleteEmptyAttributes(product.partyPolicy),
       partyContext: deleteEmptyAttributes(props.partyInformation),
       smsOptIn: Boolean(props?.smsOptIn),
-      namedOccupant: props?.namedOccupant
+      namedOccupant: ownerIdentity
         ? {
-          firstName: sanitizeString(props.namedOccupant.firstName, 100),
-          lastName: sanitizeString(props.namedOccupant.lastName, 100),
+          firstName: ownerIdentity.firstName,
+          lastName: ownerIdentity.lastName,
           contactInfo: {
-            email: sanitizeString(props.namedOccupant.contactInfo?.email, 200),
-            mobilePhone: sanitizeString(
-              props.namedOccupant.contactInfo?.mobilePhone,
-              20
-            ),
+            email: ownerIdentity.email,
+            mobilePhone: ownerIdentity.mobilePhone,
             homePhone: sanitizeString(
-              props.namedOccupant.contactInfo?.homePhone,
+              props?.namedOccupant?.contactInfo?.homePhone,
               20
             ),
             streetAddress: sanitizeString(
-              props.namedOccupant.contactInfo?.streetAddress,
+              props?.namedOccupant?.contactInfo?.streetAddress,
               200
             ),
             unitNumber: sanitizeString(
-              props.namedOccupant.contactInfo?.unitNumber,
+              props?.namedOccupant?.contactInfo?.unitNumber,
               20
             ),
             postalCode: sanitizeString(
-              props.namedOccupant.contactInfo?.postalCode,
+              props?.namedOccupant?.contactInfo?.postalCode,
               20
             ),
-            city: sanitizeString(props.namedOccupant.contactInfo?.city, 100),
+            city: sanitizeString(props?.namedOccupant?.contactInfo?.city, 100),
             province: sanitizeString(
-              props.namedOccupant.contactInfo?.province,
+              props?.namedOccupant?.contactInfo?.province,
               50
             ),
             country: sanitizeString(
-              props.namedOccupant.contactInfo?.country,
+              props?.namedOccupant?.contactInfo?.country,
               50
             ),
           },
@@ -1063,12 +1098,14 @@ function formatBookingResponsePublic(bookingResponse) {
   }
 }
 
-async function completeBooking(bookingId, sessionId, props) {
+async function completeBooking(bookingId, sessionId, props, { sub } = {}) {
   try {
 
     // === get queryTime ===
     const queryTime = new Date().getTime();
-    props['queryTime'] = queryTime;
+    if (props && typeof props === 'object') {
+      props['queryTime'] = queryTime;
+    }
 
     // === Get original Booking ===
 
@@ -1093,45 +1130,52 @@ async function completeBooking(bookingId, sessionId, props) {
       status: BOOKING_STATUS_ENUMS[1],
       // Remove pending state from GSI1
       isPending: { action: 'remove' },
-      namedOccupant: props?.namedOccupant
+    };
+
+    // When the FE-driven complete handler invokes us with the authenticated
+    // sub, rewrite the named-occupant identity fields from Cognito and accept
+    // booking-context fields (address/vehicle/equipment) from the request.
+    // Server-side webhook completions (e.g. Worldline) pass no sub — in that
+    // case leave namedOccupant + booking-context alone (createBooking already
+    // wrote them when the booking was first created). Ref #480.
+    if (sub) {
+      const ownerIdentity = await resolveAuthenticatedOccupantIdentity(sub);
+      updatedBookingItem.namedOccupant = ownerIdentity
         ? {
-          firstName: sanitizeString(props.namedOccupant.firstName, 100),
-          lastName: sanitizeString(props.namedOccupant.lastName, 100),
+          firstName: ownerIdentity.firstName,
+          lastName: ownerIdentity.lastName,
           contactInfo: {
-            email: sanitizeString(props.namedOccupant.contactInfo?.email, 200),
-            mobilePhone: sanitizeString(
-              props.namedOccupant.contactInfo?.mobilePhone,
-              20
-            ),
+            email: ownerIdentity.email,
+            mobilePhone: ownerIdentity.mobilePhone,
             homePhone: sanitizeString(
-              props.namedOccupant.contactInfo?.homePhone,
+              props?.namedOccupant?.contactInfo?.homePhone,
               20
             ),
             streetAddress: sanitizeString(
-              props.namedOccupant.contactInfo?.streetAddress,
+              props?.namedOccupant?.contactInfo?.streetAddress,
               200
             ),
             unitNumber: sanitizeString(
-              props.namedOccupant.contactInfo?.unitNumber,
+              props?.namedOccupant?.contactInfo?.unitNumber,
               20
             ),
             postalCode: sanitizeString(
-              props.namedOccupant.contactInfo?.postalCode,
+              props?.namedOccupant?.contactInfo?.postalCode,
               20
             ),
-            city: sanitizeString(props.namedOccupant.contactInfo?.city, 100),
+            city: sanitizeString(props?.namedOccupant?.contactInfo?.city, 100),
             province: sanitizeString(
-              props.namedOccupant.contactInfo?.province,
+              props?.namedOccupant?.contactInfo?.province,
               50
             ),
             country: sanitizeString(
-              props.namedOccupant.contactInfo?.country,
+              props?.namedOccupant?.contactInfo?.country,
               50
             ),
           },
         }
-        : null,
-      vehicleInformation: Array.isArray(props.vehicleInformation)
+        : null;
+      updatedBookingItem.vehicleInformation = Array.isArray(props?.vehicleInformation)
         ? props.vehicleInformation.slice(0, 5).map((v) => ({
           licensePlate: sanitizeString(v.licensePlate, 20),
           licensePlateRegistrationRegion: sanitizeString(
@@ -1142,9 +1186,9 @@ async function completeBooking(bookingId, sessionId, props) {
           vehicleModel: sanitizeString(v.vehicleModel, 50),
           vehicleColour: sanitizeString(v.vehicleColour, 30),
         }))
-        : [],
-      equipmentInformation: sanitizeString(props.equipmentInformation, 1000),
-    };
+        : [];
+      updatedBookingItem.equipmentInformation = sanitizeString(props?.equipmentInformation, 1000);
+    }
 
     // Format the update request for the Booking item
 
@@ -2535,6 +2579,7 @@ module.exports = {
   initInventoryPoolCheckRequest,
   refundPublishCommand,
   sanitizeString,
+  resolveAuthenticatedOccupantIdentity,
   sendBookingConfirmationEmail,
   sendBookingCancellationEmail,
   validateAdminRequirements,

--- a/test/booking/resolve-occupant-identity.test.js
+++ b/test/booking/resolve-occupant-identity.test.js
@@ -1,0 +1,130 @@
+"use strict";
+
+// Mock /opt/* layers and the modules that methods.js pulls in at require-time.
+jest.mock("/opt/base", () => ({
+  Exception: jest.fn(function (message, data) {
+    this.message = message;
+    this.code = data?.code;
+    this.data = data;
+  }),
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("/opt/dynamodb", () => ({
+  TRANSACTIONAL_DATA_TABLE_NAME: "trans",
+  REFERENCE_DATA_TABLE_NAME: "ref",
+  SPARSE_GSI1_NAME: "gsi1",
+  USERID_INDEX_NAME: "userIdx",
+  USERID_PROPERTY_NAME: "userId",
+  getOneByGlobalId: jest.fn(),
+  marshall: jest.fn((x) => x),
+  runQuery: jest.fn(),
+  getOne: jest.fn(),
+}));
+
+jest.mock("/opt/sns", () => ({
+  snsPublishCommand: jest.fn(),
+  snsPublishSend: jest.fn(),
+}), { virtual: true });
+
+jest.mock("../../lib/handlers/emailDispatch/utils", () => ({
+  sendConfirmationEmail: jest.fn(),
+  sendCancellationEmail: jest.fn(),
+}));
+
+jest.mock("../../src/handlers/users/methods", () => ({
+  getUserInfoByUserName: jest.fn(),
+  getUserInfoBySub: jest.fn(),
+}));
+
+jest.mock("../../src/handlers/activities/methods", () => ({
+  getActivityByActivityId: jest.fn(),
+  getActivitiesByCollectionId: jest.fn(),
+}));
+jest.mock("../../src/common/data-utils", () => ({
+  getAndAttachNestedProperties: jest.fn(),
+  quickApiPutHandler: jest.fn(),
+  quickApiUpdateHandler: jest.fn(),
+}));
+jest.mock("../../src/handlers/productDates/methods", () => ({
+  fetchProductDates: jest.fn(),
+}));
+jest.mock("@aws-sdk/util-dynamodb", () => ({
+  unmarshall: jest.fn((x) => x),
+}));
+
+const { resolveAuthenticatedOccupantIdentity } = require("../../src/handlers/bookings/methods");
+const { getUserInfoBySub } = require("../../src/handlers/users/methods");
+
+const SUB = "11111111-2222-3333-4444-555555555555";
+
+function cognitoAttrs(map) {
+  return {
+    Attributes: Object.entries(map).map(([Name, Value]) => ({ Name, Value })),
+  };
+}
+
+describe("resolveAuthenticatedOccupantIdentity", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns identity fields from Cognito attributes", async () => {
+    getUserInfoBySub.mockResolvedValue(cognitoAttrs({
+      given_name: "Jane",
+      family_name: "Doe",
+      email: "jane@example.com",
+      phone_number: "+12345550000",
+    }));
+
+    const id = await resolveAuthenticatedOccupantIdentity(SUB);
+
+    expect(getUserInfoBySub).toHaveBeenCalledWith(SUB, "public");
+    expect(id).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane@example.com",
+      mobilePhone: "+12345550000",
+    });
+  });
+
+  it("prefers custom:mobilePhone over phone_number when both present", async () => {
+    getUserInfoBySub.mockResolvedValue(cognitoAttrs({
+      "custom:mobilePhone": "+19999999999",
+      phone_number: "+10000000000",
+    }));
+
+    const id = await resolveAuthenticatedOccupantIdentity(SUB);
+
+    expect(id.mobilePhone).toBe("+19999999999");
+  });
+
+  it("returns empty strings for attributes Cognito does not have", async () => {
+    getUserInfoBySub.mockResolvedValue(cognitoAttrs({
+      email: "jane@example.com",
+    }));
+
+    const id = await resolveAuthenticatedOccupantIdentity(SUB);
+
+    expect(id).toEqual({
+      firstName: "",
+      lastName: "",
+      email: "jane@example.com",
+      mobilePhone: "",
+    });
+  });
+
+  it("returns null when sub is missing", async () => {
+    const id = await resolveAuthenticatedOccupantIdentity(null);
+    expect(getUserInfoBySub).not.toHaveBeenCalled();
+    expect(id).toBeNull();
+  });
+
+  it("propagates Cognito errors so callers can fail closed", async () => {
+    getUserInfoBySub.mockRejectedValue(new Error("Cognito down"));
+    await expect(resolveAuthenticatedOccupantIdentity(SUB)).rejects.toThrow("Cognito down");
+  });
+});


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#480

### Description:

- Add `resolveAuthenticatedOccupantIdentity(sub)` helper using `getUserInfoBySub`
- `createBooking`/`completeBooking` override namedOccupant identity (firstName, lastName, email, mobilePhone) with Cognito values; FE-provided values for those fields are ignored
- `completeBooking` now takes `{ sub }` via options; webhook (Worldline) callers without a sub leave namedOccupant untouched
- Address fields remain client-provided (not reliably on Cognito for BCSC users)

Ref bcgov/reserve-rec-public#480