### PR TITLE
PRDT: Fix issue with finding user sub using getUserInfoBySub

### DIFF
--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -192,6 +192,15 @@ class PublicBookingsConstruct extends LambdaConstruct {
       }
     );
 
+    // Allow BookingsPOST to make call and find user by sub
+    this.bookingsPostFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:ListUsers",
+      ],
+      resources: ["*"],
+    }));
+
     // POST /bookings
     this.bookingsResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsPostFunction), {
       authorizationType: apigw.AuthorizationType.CUSTOM,


### PR DESCRIPTION
### Ticket:

PRDT-fix

### Ticket URL:

--

### Description:
- Add IAM policy to bookingsPOST function to allow the getUserInfoBySub helper function acces cognito and get a user's `sub`
