### PR TITLE
PRDT-250: Fix issue with Product counter

### DIFF
--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -323,7 +323,7 @@ async function processItem(
     delete item?.version;
 
     // Increment the productId counter for this activity
-    productId = await incrementCounter(pk, ["counter"]);
+    productId = await incrementCounter(pk);
 
     // Construct SK from the new productId
     sk = `${productId}`;


### PR DESCRIPTION
### Ticket:

PRDT-250

### Ticket URL:

[#250](https://github.com/bcgov/reserve-rec-admin/issues/250)

### Description:
- Fix an issue where creating a product wasn't possible because the `counter` data item for a product was incorrectly made
- TL;DR: not related to what this ticket was anyway, but creating a new product works now
- Following [#506](https://github.com/bcgov/reserve-rec-public/issues/506) where a seed file was created, the product counter was created in the format `pk`: `product::bcparks_7::dayuse::1` and `sk`: `counter`. This is the correct pk/sk. The old setup had the pk created as `product::bcparks_7::dayuse::1::counter` which is incorrect. Therefore, when trying to create a new product the old setup wasn't incrementing (because it wasn't seeded like that, because that's incorrect, because past David was a fool).
