### PR TITLE
PRDT-377: Fix Sandbox to Prevent Cognito Lambda Extension Overwrite

### DIFF
--- a/lib/public-identity-integration-stack/public-identity-integration-stack.js
+++ b/lib/public-identity-integration-stack/public-identity-integration-stack.js
@@ -35,6 +35,13 @@ class PublicIdentityIntegrationStack extends BaseStack {
 
     logger.info(`Creating Public Identity Integration Stack: ${this.stackId}`);
 
+    // Skip mode: sandbox environments share Dev's user pool and must not overwrite its
+    // Lambda triggers with a sandbox-specific function.
+    if (this.overrides?.skipCreation === true) {
+      logger.info('Skip mode enabled: Skipping Lambda trigger creation to protect the shared Dev user pool.');
+      return;
+    }
+
     // Resolve dependencies from other stacks
     const baseLayer = scope.resolveBaseLayer(this);
     const awsUtilsLayer = scope.resolveAwsUtilsLayer(this);

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -29,6 +29,7 @@ STACKS=(
   "adminApiStack"
   "publicApiStack"
   "waitingRoomStack"
+  "publicIdentityIntegrationStack"
 )
 
 echo "Step 1: Copying SSM config parameters..."
@@ -152,6 +153,18 @@ EOF
 # Inject overrides for both identity stacks
 inject_identity_overrides "adminIdentityStack"
 inject_identity_overrides "publicIdentityStack"
+
+# Mark the integration stack as skipCreation so it does not overwrite
+# Dev's Pre Token Generation Lambda trigger with a sandbox-specific Lambda.
+INTEGRATION_CONFIG_PATH="/${APP_NAME}/${DEPLOYMENT_NAME}/publicIdentityIntegrationStack/config"
+INTEGRATION_CONFIG=$(aws ssm get-parameter --region ${REGION} --name "${INTEGRATION_CONFIG_PATH}" --query 'Parameter.Value' --output text 2>/dev/null || echo "{}")
+UPDATED_INTEGRATION_CONFIG=$(echo "${INTEGRATION_CONFIG}" | jq '.overrides.skipCreation = true')
+aws ssm put-parameter --region ${REGION} \
+  --name "${INTEGRATION_CONFIG_PATH}" \
+  --type String \
+  --value "${UPDATED_INTEGRATION_CONFIG}" \
+  --overwrite >/dev/null
+echo "  publicIdentityIntegrationStack: ✓ skipCreation override injected"
 
 echo ""
 echo "Step 1.6: Copying frontend domain parameter..."


### PR DESCRIPTION
### Ticket:

PRDT-377

### Ticket URL:

#377 

### Description:
- The `PublicIdentityIntegrationStack` was unconditionally creating a sandbox-specific `PostConfirm` Lambda and calling `updateUserPool` on Dev's shared user pool (resolved via the `publicIdentityStack` skipCreation override), replacing Dev's `PreTokenGeneration` trigger with the sandbox Lambda on every deploy.
- On teardown the `AwsCustomResource` had no `onDelete` handler, so cdk destroy left Dev's pool pointing at the now-deleted sandbox Lambda indefinitely.
- Add `publicIdentityIntegrationStack` to the `STACKS` array in sandbox-setup.sh so its SSM config is copied from dev
- Inject `overrides.skipCreation = true` into its config alongside the other identity stack overrides
