### PR TITLE
PRDT-535: Bookings dont display pass count

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -256,12 +256,23 @@ async function getBookingByBookingId(
   logger.debug("Getting booking by bookingId:", bookingId);
   try {
     let data = await getOneByGlobalId(bookingId, TRANSACTIONAL_DATA_TABLE_NAME);
+    if (!data) {
+      logger.error("getOneByGlobalId returned null/undefined!", { bookingId });
+      throw new Exception(`Booking not found (BookingID: ${bookingId})`, { code: 404 });
+    }
+    
     if (fetchAccessPoints) {
       console.debug("Fetching access points for booking:", bookingId);
       await getAndAttachNestedProperties(data, ["entryPoint", "exitPoint"]);
     }
     return data;
   } catch (error) {
+    logger.error("Error in getBookingByBookingId:", {
+      bookingId,
+      errorMessage: error?.message,
+      errorCode: error?.code,
+      stack: error?.stack,
+    });
     throw new Exception("Error getting booking by bookingId", {
       code: 400,
       error: error.message || String(error),
@@ -678,12 +689,13 @@ function createInventoryRequests(assetRef, productDates, invQuantity) {
             pk: marshall(inventoryPK),
             sk: marshall(inventorySK)
           },
-          UpdateExpression: "SET #availability = #availability - :quantity",
+          UpdateExpression: "ADD #availability :decrement",
           ExpressionAttributeNames: {
             "#availability": "availability"
           },
           ExpressionAttributeValues: {
-            ":quantity": marshall(numericQuantity)
+            ":quantity": marshall(numericQuantity),
+            ":decrement": marshall(numericQuantity * -1)
           },
           ConditionExpression: "attribute_exists(pk) AND #availability >= :quantity"
         }
@@ -771,6 +783,7 @@ async function initBookingRequestItems(product, productDates, assetRef, props) {
       reservationContext: buildBookingReservationContext(product, productDates, queryTime),
       partyPolicySnapshot: deleteEmptyAttributes(product.partyPolicy),
       partyContext: deleteEmptyAttributes(props.partyInformation),
+      invQuantity: props?.invQuantity,
       smsOptIn: Boolean(props?.smsOptIn),
       namedOccupant: ownerIdentity
         ? {


### PR DESCRIPTION
Ticket: [535](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=191147450&issue=bcgov%7Creserve-rec-public%7C535)

Notes: For this ticket we just needed to include the inventoryQuantity in the write when creating passes.

I also updated the inventory pools to reduce availability for more than 1 if multiple passes are booked. 

There was also some planning required here for what will happen once other offerings are included in the system. We will need to write party details instead of inventoryQuantity when that time comes. The front end will be find to take a count of the party and display it here but will still need to differ what comprises the party. 