### PR TITLE
PRDT-527: Fix to missing quantity on Bookings

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -820,6 +820,7 @@ async function initBookingRequestItems(product, productDates, assetRef, props) {
         }))
         : [],
       equipmentInformation: sanitizeString(props.equipmentInformation, 1000),
+      quantity: props?.invQuantity,
       feePolicySnapshot: deleteEmptyAttributes(product.feePolicy),
       bookingDates: bookingDateItems.map((bd) => {
         return {


### PR DESCRIPTION
### Ticket:

PRDT-527

### Ticket URL:

#527

### Description:
- Add `quantity: props?.invQuantity` onto bookingItem