### PR TITLE
fix(email): match booking confirmation email to design + QA fixes

### DIFF
--- a/lib/handlers/emailDispatch/index.js
+++ b/lib/handlers/emailDispatch/index.js
@@ -6,9 +6,15 @@
 const { logger, Exception } = require("/opt/base");
 const { validateEmailPayload } = require('./schema');
 const { TemplateEngine } = require('./templateEngine');
-const { SESClient, SendEmailCommand } = require('@aws-sdk/client-ses');
-const { generateQRURL, generateQRCodeDataURL } = require('./qrCodeHelper');
+const { SESClient, SendRawEmailCommand } = require('@aws-sdk/client-ses');
+const MailComposer = require('nodemailer/lib/mail-composer');
+const { generateQRURL, generateQRCodeBuffer } = require('./qrCodeHelper');
 const { redactEmail } = require('./utils');
+
+// Content-ID used to reference the inline QR code from the HTML template
+// (<img src="cid:booking-qr">). Email clients strip `data:` URIs, so the QR
+// must be delivered as a real MIME attachment referenced by this id.
+const QR_CONTENT_ID = 'booking-qr';
 
 const SES_REGION = process.env.SES_REGION || 'ca-central-1';
 const SES_FROM_EMAIL = process.env.SES_FROM_EMAIL || 'noreply@bcparks.ca';
@@ -123,18 +129,22 @@ async function processEmailMessage(record) {
     });
   }
 
-  // Pre-generate QR code if enabled and booking data is present
-  // QR codes must be generated before template rendering since Handlebars is synchronous
+  // Pre-generate QR code if enabled and booking data is present.
+  // The QR is delivered as a CID inline attachment (not a data: URI) so it
+  // renders in Gmail and other clients that strip data URIs. We generate the
+  // PNG bytes here and expose `qrCid` to the template; the buffer is attached
+  // to the MIME message in sendEmail().
+  let qrCodeBuffer = null;
   if (INCLUDE_QR_INLINE && payload.templateData?.booking?.bookingId) {
     try {
       const bookingId = payload.templateData.booking.bookingId;
       const verificationUrl = generateQRURL(bookingId);
-      const qrCodeDataUrl = await generateQRCodeDataURL(verificationUrl);
-      
-      // Add QR code data URL to booking object for template access
-      payload.templateData.booking.qrCodeDataUrl = qrCodeDataUrl;
+      qrCodeBuffer = await generateQRCodeBuffer(verificationUrl);
+
+      // Expose the Content-ID so the template can reference the inline image.
+      payload.templateData.booking.qrCid = QR_CONTENT_ID;
       payload.templateData.booking.qrVerificationUrl = verificationUrl;
-      
+
       logger.debug('QR code generated for email', {
         bookingId,
         hasQRCode: true
@@ -155,6 +165,17 @@ async function processEmailMessage(record) {
     payload.templateData
   );
 
+  // Attach the QR PNG inline (referenced from the HTML by Content-ID) when present.
+  const attachments = qrCodeBuffer
+    ? [{
+        filename: 'booking-qr.png',
+        content: qrCodeBuffer,
+        contentType: 'image/png',
+        cid: QR_CONTENT_ID,
+        contentDisposition: 'inline',
+      }]
+    : [];
+
   // Send the email via SES
   const emailResult = await sendEmail({
     to: payload.recipientEmail,
@@ -162,6 +183,7 @@ async function processEmailMessage(record) {
     subject: payload.subject,
     htmlContent: emailContent.html,
     textContent: emailContent.text,
+    attachments,
     metadata: payload.metadata
   });
 
@@ -174,60 +196,54 @@ async function processEmailMessage(record) {
 }
 
 /**
- * Send email via AWS SES
+ * Send email via AWS SES using a raw MIME message.
+ *
+ * We build the MIME with nodemailer's MailComposer and send via
+ * SendRawEmailCommand (rather than SendEmailCommand) so the QR code can be
+ * embedded as a CID inline attachment — clients like Gmail strip `data:` URIs,
+ * so an attachment referenced by Content-ID is the only reliable way to render
+ * it. MailComposer also handles correct quoted-printable/base64 encoding of
+ * non-ASCII content (e.g. park names like "Mʔuqʷin/Brooks Peninsula Park").
+ *
  * @param {Object} params - Email parameters
  * @returns {Object} SES response
  */
 async function sendEmail(params) {
-  const { to, toName, subject, htmlContent, textContent, metadata = {} } = params;
-
-  const emailParams = {
-    Source: SES_FROM_EMAIL,
-    Destination: {
-      ToAddresses: [toName ? `${toName} <${to}>` : to],
-    },
-    Message: {
-      Subject: {
-        Data: subject,
-        Charset: 'UTF-8',
-      },
-      Body: {
-        Html: {
-          Data: htmlContent,
-          Charset: 'UTF-8',
-        },
-        Text: {
-          Data: textContent,
-          Charset: 'UTF-8',
-        },
-      },
-    },
-    // Add metadata as email headers for tracking
-    Tags: [
-      {
-        Name: 'Source',
-        Value: 'ReserveRecAPI',
-      },
-      {
-        Name: 'MessageType',
-        Value: metadata.messageType || 'unknown',
-      },
-      {
-        Name: 'BookingId',
-        Value: metadata.bookingId || 'unknown',
-      }
-    ]
-  };
+  const { to, toName, subject, htmlContent, textContent, attachments = [], metadata = {} } = params;
 
   try {
-    const command = new SendEmailCommand(emailParams);
+    const mail = new MailComposer({
+      from: SES_FROM_EMAIL,
+      to: toName ? `${toName} <${to}>` : to,
+      subject,
+      text: textContent,
+      html: htmlContent,
+      attachments,
+      // Mirror the previous SES message tags as custom headers for tracking.
+      headers: {
+        'X-RR-Source': 'ReserveRecAPI',
+        'X-RR-MessageType': metadata.messageType || 'unknown',
+        'X-RR-BookingId': metadata.bookingId || 'unknown',
+      },
+    });
+
+    const rawMessage = await new Promise((resolve, reject) => {
+      mail.compile().build((err, message) => (err ? reject(err) : resolve(message)));
+    });
+
+    const command = new SendRawEmailCommand({
+      Source: SES_FROM_EMAIL,
+      Destinations: [toName ? `${toName} <${to}>` : to],
+      RawMessage: { Data: rawMessage },
+    });
     const result = await sesClient.send(command);
-    
+
     logger.info('Email sent via SES', {
       messageId: result.MessageId,
       bookingId: metadata.bookingId,
       recipientDomain: redactEmail(to),
-      subject: subject
+      subject: subject,
+      hasAttachments: attachments.length > 0
     });
 
     return result;

--- a/lib/handlers/emailDispatch/qrCodeHelper.js
+++ b/lib/handlers/emailDispatch/qrCodeHelper.js
@@ -155,6 +155,19 @@ function validateHash(bookingId, hash, secretKey = QR_SECRET_KEY) {
  * @returns {Promise<string>} - Base64 data URL of QR code image (data:image/png;base64,...)
  * @throws {Error} If URL is missing or QR generation fails
  */
+// Shared QR rendering options — kept identical across data-URL and Buffer output
+// so the visual result is the same regardless of how the code is embedded.
+const QR_RENDER_OPTIONS = {
+  errorCorrectionLevel: 'M', // Medium error correction (15% damage recovery)
+  type: 'image/png',
+  width: 300, // 300x300 pixels (good for email and print)
+  margin: 2, // 2-module margin (white border)
+  color: {
+    dark: '#000000',  // Black QR code
+    light: '#FFFFFF'  // White background
+  }
+};
+
 async function generateQRCodeDataURL(url) {
   if (!url) {
     throw new Error('URL is required for QR code generation');
@@ -162,31 +175,64 @@ async function generateQRCodeDataURL(url) {
 
   try {
     const startTime = Date.now();
-    
+
     // Generate QR code as data URL (base64 PNG)
-    const dataUrl = await QRCode.toDataURL(url, {
-      errorCorrectionLevel: 'M', // Medium error correction (15% damage recovery)
-      type: 'image/png',
-      width: 300, // 300x300 pixels (good for email and print)
-      margin: 2, // 2-module margin (white border)
-      color: {
-        dark: '#000000',  // Black QR code
-        light: '#FFFFFF'  // White background
-      }
-    });
-    
+    const dataUrl = await QRCode.toDataURL(url, QR_RENDER_OPTIONS);
+
     const duration = Date.now() - startTime;
     const sizeKB = Math.round(dataUrl.length / 1024);
-    
+
     logger.debug('QR code generated successfully', {
       duration,
       sizeKB,
       urlLength: url.length
     });
-    
+
     return dataUrl;
   } catch (error) {
     logger.error('QR code generation failed', {
+      error: error.message,
+      stack: error.stack,
+      url: url.substring(0, 50) + '...' // Log partial URL for debugging
+    });
+    throw new Error(`Failed to generate QR code: ${error.message}`);
+  }
+}
+
+/**
+ * Generates a QR code as a raw PNG Buffer from a verification URL.
+ *
+ * Used to embed the QR as a CID inline attachment in MIME emails. Email
+ * clients (notably Gmail) strip `data:` URIs from <img> tags, so a real
+ * attachment referenced by Content-ID is required for the code to render.
+ *
+ * @param {string} url - The verification URL to encode
+ * @returns {Promise<Buffer>} - PNG image bytes
+ * @throws {Error} If URL is missing or QR generation fails
+ */
+async function generateQRCodeBuffer(url) {
+  if (!url) {
+    throw new Error('URL is required for QR code generation');
+  }
+
+  try {
+    const startTime = Date.now();
+
+    // Generate QR code as a PNG Buffer
+    const buffer = await QRCode.toBuffer(url, QR_RENDER_OPTIONS);
+
+    const duration = Date.now() - startTime;
+    const sizeKB = Math.round(buffer.length / 1024);
+
+    logger.debug('QR code buffer generated successfully', {
+      duration,
+      sizeKB,
+      urlLength: url.length
+    });
+
+    return buffer;
+  } catch (error) {
+    logger.error('QR code buffer generation failed', {
       error: error.message,
       stack: error.stack,
       url: url.substring(0, 50) + '...' // Log partial URL for debugging
@@ -199,5 +245,6 @@ module.exports = {
   generateQRURL,
   validateHash,
   generateQRCodeDataURL,
+  generateQRCodeBuffer,
   validateEnvironment, // Export for testing
 };

--- a/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.html
+++ b/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.html
@@ -12,11 +12,6 @@
             box-sizing: border-box;
         }
 
-        svg {
-            vertical-align: middle;
-            margin-top: -2px;
-        }
-
         /* Email-specific resets */
         img {
             border: 0;
@@ -48,26 +43,20 @@
             background-color: #ffffff;
         }
 
+        /* Interim header: white BC Parks wordmark on a brand-blue band.
+           The official colour logo asset is not yet available (see #56);
+           a text wordmark renders reliably in every client, unlike the
+           reversed SVG which Gmail strips. */
         .header {
-            background-color: #ffffff;
-            padding: 24px 32px;
-            display: flex;
-            align-items: center;
-            gap: 12px;
+            background-color: #003366;
+            padding: 22px 32px;
         }
 
-        .logo {
-            width: 48px;
-            height: 48px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin-top: 25px;
-        }
-
-        .logo-text {
-            font-weight: 600;
-            font-size: 16px;
+        .header-wordmark {
+            font-size: 22px;
+            font-weight: 700;
+            color: #ffffff;
+            letter-spacing: 0.3px;
         }
 
         .content {
@@ -103,33 +92,19 @@
         }
 
         .btn-primary {
+            display: inline-block;
             font-size: 16px;
             font-weight: 700;
             color: #003366;
-            margin-bottom: 20px;
             line-height: 25px;
             border: 1px solid #003366;
             padding: 10px 16px;
             border-radius: 4px;
-            margin-bottom: 15px;
-            text-decoration: none;
-        }
-
-        .btn-secondary {
-            font-size: 16px;
-            font-weight: 700;
-            color: #fff;
-            margin-bottom: 10px;
-            line-height: 25px;
-            background: #003366;
-            padding: 10px 16px;
-            border-radius: 4px;
-            margin-top: 16px;
             text-decoration: none;
         }
 
         .booking-card {
-            border: 1px solid #d9d9d9;
+            border: 1px solid #C7C7C7;
             border-radius: 8px;
             overflow: hidden;
             margin-top: 36px;
@@ -138,8 +113,7 @@
 
         .card-header {
             padding: 20px 24px;
-            border: 1px solid #C7C7C7;
-            border-radius: 8px 8px 0 0;
+            border-bottom: 1px solid #C7C7C7;
             background: #f2f2f2;
         }
 
@@ -155,26 +129,16 @@
         }
 
         .card-body {
-            border: 1px solid #C7C7C7;
-            border-radius: 0 0 8px 8px;
             padding: 24px;
         }
 
-        .card-full {
-            border: 1px solid #C7C7C7;
-            border-radius: 8px;
-            padding: 24px;
+        .details-table {
+            width: 100%;
         }
 
-        .details-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 20px;
-            margin-bottom: 20px;
-        }
-
-        .detail-item {
-            margin-bottom: 0;
+        .details-table td {
+            vertical-align: top;
+            padding-bottom: 20px;
         }
 
         .detail-label {
@@ -186,122 +150,72 @@
 
         .detail-value {
             font-size: 16px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
         }
 
         .detail-value-time {
             font-size: 13px;
-            display: flex;
-            align-items: center;
-        }
-
-        .detail-icon {
-            width: 16px;
-            height: 16px;
-        }
-
-        .full-width {
-            grid-column: 1 / -1;
-        }
-
-        .booking-number {
-            font-size: 16px;
-        }
-
-        .cardless-body {
-            padding: 24px;
-        }
-
-        .qr-code {
-            max-width: 200px;
-            width: 100%;
-            height: auto;
-            margin: 0 auto 16px;
+            color: #5c5c5c;
             display: block;
         }
 
-        .qr-card {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
+        .row-rule td {
+            border-top: 1px solid #d9d9d9;
+            padding-top: 0;
+            padding-bottom: 12px;
         }
 
-        .horizontal-rule {
-            border: 1px solid #d9d9d9;
-            grid-column: 1 / -1;
+        .card-full {
+            border: 1px solid #C7C7C7;
+            border-radius: 8px;
+            padding: 24px;
+            text-align: center;
+        }
+
+        .qr-code {
+            width: 200px;
+            max-width: 200px;
+            height: auto;
+            margin: 0 auto 12px;
+            display: block;
+        }
+
+        .qr-caption {
+            font-size: 14px;
+            color: #5c5c5c;
         }
 
         .horizontal-rule-yellow {
             border-top: 3px solid #FCBA19;
-            margin-bottom: 24px;
-            margin-right: 85%;
+            width: 60px;
+            margin-bottom: 20px;
         }
 
-        .cancellation-instructions {
-            font-size: 16px;
-            line-height: 25px;
-            margin-bottom: 30px;
+        .cardless-body {
+            padding: 24px 0;
         }
 
         .before-you-go-instructions {
             font-size: 16px;
             line-height: 25px;
-            margin-bottom: 30px;
-        }
-
-        .customer-service {
-            background-color: #C7E3FD;
-            padding: 25px 25px;
-            margin-bottom: 30px;
-        }
-
-        .customer-service h3 {
-            font-size: 19px;
-            font-weight: 700;
-            color: #003366;
-            margin-bottom: 12px;
-            line-height: 27px;
-        }
-
-        .customer-service p {
-            font-size: 16px;
-            line-height: 25px;
-            margin-bottom: 20px;
-        }
-
-        .customer-service-text {
-            font: 16px;
-            font-weight: 700;
-            color: #003366;
-            line-height: 25px;
-            padding-right: 10px;
-        }
-
-        .customer-service-link {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            color: #003366;
-            font-size: 16px;
+            margin-bottom: 16px;
         }
 
         .disclaimer {
             font-size: 14.5px;
             font-style: italic;
             line-height: 24px;
+            margin-top: 8px;
             margin-bottom: 24px;
+        }
+
+        .disclaimer a {
+            color: #003366;
         }
 
         .footer {
             background-color: #1E3A5F;
             padding: 0;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
+            text-align: center;
         }
 
         .acknowledgment {
@@ -314,12 +228,15 @@
         }
 
         .footer-content {
-            padding: 32px 170px 32px 22px;
+            padding: 24px 22px;
+            color: white;
+        }
+
+        .footer-logo {
             font-size: 24px;
             font-weight: 400;
             color: white;
-            margin-bottom: 5px;
-            font-family: auto;
+            margin-bottom: 8px;
         }
 
         .footer-address {
@@ -330,23 +247,20 @@
         }
 
         .social-icons {
-            margin-top: 20px;
-            display: flex;
-            justify-content: center;
-            gap: 16px;
+            margin-top: 16px;
         }
 
         .social-icon {
+            display: inline-block;
             width: 32px;
             height: 32px;
+            line-height: 32px;
             border-radius: 50%;
             background-color: rgba(255, 255, 255, 0.2);
-            display: flex;
-            align-items: center;
-            justify-content: center;
             color: white;
             text-decoration: none;
-            font-size: 18px;
+            font-size: 14px;
+            margin: 0 8px;
         }
 
         @media only screen and (max-width: 600px) {
@@ -354,14 +268,13 @@
                 padding: 24px 16px;
             }
 
-            .details-grid,
-            .payment-grid {
-                grid-template-columns: 1fr;
+            .card-body {
+                padding: 16px;
             }
 
-            .card-body,
-            .payment-body {
-                padding: 16px;
+            .details-table td {
+                display: block;
+                width: 100% !important;
             }
         }
     </style>
@@ -372,111 +285,89 @@
         <div class="container">
             <!-- Header -->
             <div class="header">
-                <div class="logo">
-                    <img src="https://bcparks.ca/static/BCParks_Primary_Reversed_Vertical-9873b7442479cf33ebc73121675114fa.svg" alt="BC Parks" style="width: 128px; height: 128px;">
-                </div>
+                <span class="header-wordmark">BC Parks</span>
             </div>
 
             <!-- Content -->
             <div class="content">
-                <h1>Your day-use passes for {{#if location.parkName}}{{location.parkName}}{{else}}your visit{{/if}}</h1>
+                <h1>Your day-use {{pluralize booking.invQuantity "pass" "passes"}} for {{#if location.parkName}}{{location.parkName}}{{else}}your visit{{/if}}</h1>
 
                 <p class="success-message">Success! You're all set.</p>
 
-                <p class="instructions">Save this email for entering with your pass online. Please bring your printed
-                    pass or saved screenshot with you during your visit.</p>
+                <p class="instructions">You must arrive and depart according to the times on the pass you have
+                    booked, to ensure access to the park.</p>
                 {{#if booking.accountBookingUrl}}
                 <a href="{{booking.accountBookingUrl}}" target="_blank" class="btn-primary">View your booking</a>
                 {{/if}}
+
                 <!-- Booking Card -->
                 <div class="booking-card">
                     <div class="card-header">
                         <div class="park-name">{{#if location.parkName}}{{location.parkName}}{{else}}Your visit{{/if}}</div>
-                        <div class="park-subtitle">{{#if booking.displayName}}{{booking.displayName}}{{/if}}</div>
+                        <div class="park-subtitle">{{#if booking.activityTypeLabel}}{{booking.activityTypeLabel}}{{else}}Day-use pass{{/if}}</div>
                     </div>
 
                     <div class="card-body">
-                        <div class="details-grid">
-                            {{#if booking.arrivalDate}}
-                            <div class="detail-item">
-                                <span class="detail-label">Arrival</span>
-                                <div class="detail-value">{{formatDate booking.arrivalDate 'EEEE MMMM d, yyyy'}}<br></div>
-                                <span class="detail-value-time">{{ formatTime booking.arrivalDate}}</span>
-                            </div>
-                            {{/if}}
-
-                            {{#if booking.departureDate}}
-                            <div class="detail-item">
-                                <span class="detail-label">Departure</span>
-                                <div class="detail-value">{{formatDate booking.departureDate 'EEEE MMMM d, yyyy'}}<br></div>
-                                <span class="detail-value-time">{{ formatTime booking.departureDate}}</span>
-                            </div>
-                            {{/if}}
-
-                            {{#if booking.productName}}
-                            <div class="detail-item">
-                                <span class="detail-label">Pass type</span>
-                                <div class="detail-value">
-                                    {{booking.productName}}
-                                </div>
-                            </div>
-                            {{/if}}
-
-                            {{#if booking.invQuantity}}
-                            <div class="detail-item">
-                                <span class="detail-label">Passes</span>
-                                <div class="detail-value">
-                                    {{booking.invQuantity}}
-                                </div>
-                            </div>
-                            {{/if}}
-
-                            <div class="horizontal-rule"></div>
-
-                            <div class="detail-item">
-                                <span class="detail-label">Named occupant</span>
-                                <div class="detail-value">{{customer.firstName}} {{customer.lastName}}</div>
-                            </div>
-
-                            {{#if customer.licensePlate}}
-                            <div class="detail-item">
-                                <span class="detail-label">License plate</span>
-                                <div class="detail-value">{{customer.licensePlate}}</div>
-                            </div>
-                            {{/if}}
-
-                            <div class="horizontal-rule"></div>
-
-                            <div class="detail-item full-width">
-                                <span class="detail-label">Booking number</span>
-                                <div class="detail-value booking-number">{{booking.bookingId}}</div>
-                            </div>
-                        </div>
+                        <table class="details-table" role="presentation">
+                            <tr>
+                                {{#if booking.arrivalDate}}
+                                <td width="50%">
+                                    <span class="detail-label">Arrival</span>
+                                    <span class="detail-value">{{formatDate booking.arrivalDate 'EEEE, MMMM d, yyyy'}}</span>
+                                    <span class="detail-value-time">{{formatTime booking.arrivalDate}}</span>
+                                </td>
+                                {{/if}}
+                                {{#if booking.departureDate}}
+                                <td width="50%">
+                                    <span class="detail-label">Departure</span>
+                                    <span class="detail-value">{{formatDate booking.departureDate 'EEEE, MMMM d, yyyy'}}</span>
+                                    <span class="detail-value-time">{{formatTime booking.departureDate}}</span>
+                                </td>
+                                {{/if}}
+                            </tr>
+                            <tr>
+                                {{#if booking.productName}}
+                                <td width="50%">
+                                    <span class="detail-label">Pass type</span>
+                                    <span class="detail-value">{{booking.productName}}{{#if booking.arrivalDate}} &middot; {{formatDate booking.arrivalDate 'short'}}{{/if}}</span>
+                                </td>
+                                {{/if}}
+                                {{#if booking.invQuantity}}
+                                <td width="50%">
+                                    <span class="detail-label">{{pluralize booking.invQuantity "Pass" "Passes"}}</span>
+                                    <span class="detail-value">{{booking.invQuantity}}</span>
+                                </td>
+                                {{/if}}
+                            </tr>
+                            <tr class="row-rule">
+                                <td width="50%">
+                                    <span class="detail-label">Named occupant</span>
+                                    <span class="detail-value">{{customer.firstName}} {{customer.lastName}}</span>
+                                </td>
+                                {{#if customer.licensePlate}}
+                                <td width="50%">
+                                    <span class="detail-label">License plate</span>
+                                    <span class="detail-value">{{customer.licensePlate}}{{#if customer.licensePlateRegion}}, {{customer.licensePlateRegion}}{{/if}}</span>
+                                </td>
+                                {{else}}
+                                <td width="50%"></td>
+                                {{/if}}
+                            </tr>
+                            <tr class="row-rule">
+                                <td colspan="2">
+                                    <span class="detail-label">Confirmation number</span>
+                                    <span class="detail-value">{{booking.bookingId}}</span>
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                 </div>
 
                 <!-- QR Code -->
-                <div class="booking-card">
-                    <div class="card-full">
-                        <div class="qr-card">
-                            {{#if booking.qrCodeDataUrl}}
-                            <img src="{{booking.qrCodeDataUrl}}" alt="QR Code" class="qr-code" />
-                            <a href="{{booking.qrCodeDataUrl}}" target="_blank" class="btn-secondary">Download QR code</a>
-                            {{/if}}
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Cancellations -->
-                {{#if booking.cancellationUrl}}
-                <div class="cardless-body">
-                    <h2>Cancellations and refunds</h2>
-                    <div class="horizontal-rule-yellow"></div>
-                    <p class="cancellation-instructions">
-                        If you can no longer make the trip, please cancel your reservations to receive a refund and
-                        allow the passes to be re-allocated to other park visitors.
-                    </p>
-                    <a href="{{booking.cancellationUrl}}" target="_blank" class="btn-primary">Cancel your reservation</a>
+                {{#if booking.qrCid}}
+                <div class="card-full">
+                    <img src="cid:{{booking.qrCid}}" alt="Booking QR code" class="qr-code" />
+                    <div class="qr-caption">Show this code to BC Parks staff at check-in.</div>
                 </div>
                 {{/if}}
 
@@ -488,29 +379,17 @@
                         Please ensure you have your pass available to show BC Parks staff when required: print or
                         save/screenshot a copy of this email and the QR code to your phone as proof of your booking, as
                         Wi-Fi connectivity is not always reliable within the parks.
-                        <br>
-                        <br>
-                        If you have booked more than 1 trail pass on your reservation, please ensure all members of your
+                    </p>
+                    <p class="before-you-go-instructions">
+                        If you have booked more than one pass on your reservation, please ensure all members of your
                         party are in attendance when checking in.
                     </p>
                 </div>
 
-                <!-- Customer Service -->
-                <div class="customer-service">
-                    <h3>Customer Service</h3>
-                    <p>For any inquiries about your receipt or payment, please contact a customer service
-                        representative.</p>
-                    {{#if branding.contactEmail}}
-                    <span class="customer-service-text">Email</span>
-                    <a href="mailto:{{branding.contactEmail}}" class="customer-service-link">
-                        {{branding.contactEmail}}
-                    </a>
-                    {{/if}}
-                </div>
-
                 <p class="disclaimer">
-                    Please do not reply to this message. It was sent from an unmonitored email address. This message is
-                    a service email related to your BC Parks account use.
+                    This email is provided for information related to your BC Parks account only. The inbox is not
+                    monitored. If you need assistance, please contact
+                    <a href="mailto:parkinfo@gov.bc.ca">parkinfo@gov.bc.ca</a>.
                 </p>
             </div>
 
@@ -521,21 +400,15 @@
                     connection to the land and respect the importance of their diverse teachings, traditions, and practices
                     within these territories.
                 </div>
-                <div>
                 <div class="footer-content">
                     <div class="footer-logo">BC Parks</div>
-
                     <div class="footer-address">PO Box 9398</div>
                     <div class="footer-address">Victoria, BC V8W9M9</div>
                     <div class="footer-address">Canada</div>
-
-                </div>
-                <div class="footer-content">
                     <div class="social-icons">
                         <a href="https://www.facebook.com/BCParks/" target="_blank" class="social-icon">FB</a>
                         <a href="https://www.instagram.com/bcparks/" target="_blank" class="social-icon">IG</a>
                     </div>
-                </div>
                 </div>
             </div>
         </div>

--- a/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.txt
+++ b/lib/handlers/emailDispatch/templates/en/confirmation_bcparks_default.txt
@@ -3,71 +3,53 @@ BC PARKS
 YOUR BOOKING CONFIRMATION
 ========================================
 
-Your day-use passes for {{#if location.parkName}}{{location.parkName}}{{else}}your visit{{/if}}
+Your day-use {{pluralize booking.invQuantity "pass" "passes"}} for {{#if location.parkName}}{{{location.parkName}}}{{else}}your visit{{/if}}
 
 Success! You're all set.
 
-Save this email for entering with your pass online. Please bring your printed pass or saved screenshot with you during your visit.
+You must arrive and depart according to the times on the pass you have booked, to ensure access to the park.
 
 {{#if booking.accountBookingUrl}}
-View your booking: {{booking.accountBookingUrl}}
+View your booking: {{{booking.accountBookingUrl}}}
 {{/if}}
 
 ----------------------------------------
 BOOKING DETAILS
 ----------------------------------------
 
-Park: {{#if location.parkName}}{{location.parkName}}{{else}}Your visit{{/if}}
-{{#if booking.displayName}}Pass: {{booking.displayName}}{{/if}}
+Park: {{#if location.parkName}}{{{location.parkName}}}{{else}}Your visit{{/if}}
 
 {{#if booking.arrivalDate}}
-Arrival:   {{formatDate booking.arrivalDate 'EEEE MMMM d, yyyy'}}{{#if (formatTime booking.arrivalDate)}} at {{formatTime booking.arrivalDate}}{{/if}}
+Arrival:   {{formatDate booking.arrivalDate 'EEEE, MMMM d, yyyy'}}{{#if (formatTime booking.arrivalDate)}} at {{formatTime booking.arrivalDate}}{{/if}}
 {{/if}}
 {{#if booking.departureDate}}
-Departure: {{formatDate booking.departureDate 'EEEE MMMM d, yyyy'}}{{#if (formatTime booking.departureDate)}} at {{formatTime booking.departureDate}}{{/if}}
+Departure: {{formatDate booking.departureDate 'EEEE, MMMM d, yyyy'}}{{#if (formatTime booking.departureDate)}} at {{formatTime booking.departureDate}}{{/if}}
 {{/if}}
 {{#if booking.productName}}
-Pass type: {{booking.productName}}
+Pass type: {{{booking.productName}}}{{#if booking.arrivalDate}} ({{formatDate booking.arrivalDate 'short'}}){{/if}}
 {{/if}}
 {{#if booking.invQuantity}}
-Passes:    {{booking.invQuantity}}
+{{pluralize booking.invQuantity "Pass" "Passes"}}:    {{booking.invQuantity}}
 {{/if}}
 
-Named occupant: {{customer.firstName}} {{customer.lastName}}
+Named occupant: {{{customer.firstName}}} {{{customer.lastName}}}
 {{#if customer.licensePlate}}
-License plate:  {{customer.licensePlate}}
+License plate:  {{{customer.licensePlate}}}{{#if customer.licensePlateRegion}}, {{{customer.licensePlateRegion}}}{{/if}}
 {{/if}}
 
-Booking number: {{booking.bookingId}}
+Confirmation number: {{booking.bookingId}}
 
-{{#if booking.cancellationUrl}}
-----------------------------------------
-CANCELLATIONS AND REFUNDS
-----------------------------------------
+Your QR code for check-in is attached to this email as an image. Show it to BC Parks staff at check-in.
 
-If you can no longer make the trip, please cancel your reservation to receive a refund and allow the passes to be re-allocated to other park visitors.
-
-Cancel your reservation: {{booking.cancellationUrl}}
-
-{{/if}}
 ----------------------------------------
 BEFORE YOU GO
 ----------------------------------------
 
 Please ensure you have your pass available to show BC Parks staff when required: print or save/screenshot a copy of this email and the QR code to your phone as proof of your booking, as Wi-Fi connectivity is not always reliable within the parks.
 
-If you have booked more than 1 trail pass on your reservation, please ensure all members of your party are in attendance when checking in.
+If you have booked more than one pass on your reservation, please ensure all members of your party are in attendance when checking in.
 
-----------------------------------------
-CUSTOMER SERVICE
-----------------------------------------
-
-For any inquiries about your receipt or payment, please contact a customer service representative.
-{{#if branding.contactEmail}}
-Email: {{branding.contactEmail}}
-{{/if}}
-
-Please do not reply to this message. It was sent from an unmonitored email address. This message is a service email related to your BC Parks account use.
+This email is provided for information related to your BC Parks account only. The inbox is not monitored. If you need assistance, please contact parkinfo@gov.bc.ca.
 
 ========================================
 BC Parks

--- a/lib/handlers/emailDispatch/templates/en/receipt_bcparks_kootenay.html
+++ b/lib/handlers/emailDispatch/templates/en/receipt_bcparks_kootenay.html
@@ -151,16 +151,16 @@
             </div>
             
             <!-- QR Code Section (only shown if enabled for this facility/park) -->
-            {{#if booking.qrCodeDataUrl}}
+            {{#if booking.qrCid}}
             <div class="qr-code-section" style="background-color: #f9f9f9; padding: 20px; text-align: center; margin: 25px 0; border-radius: 8px; border: 2px dashed #ccc;">
                 <h3 style="margin-top: 0; color: #333;">Digital Pass</h3>
                 <p style="font-size: 14px; color: #666; margin-bottom: 15px;">
                     Show this QR code at park entrance for verification
                 </p>
-                
-                <!-- QR Code Image -->
+
+                <!-- QR Code Image (inline CID attachment — data: URIs are stripped by email clients) -->
                 <div style="margin: 15px 0;">
-                    {{qrCode booking}}
+                    <img src="cid:{{booking.qrCid}}" alt="Booking QR code" style="width: 200px; height: 200px; display: block; margin: 0 auto;" />
                 </div>
                 
                 <!-- Booking Number Fallback -->

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "luxon": "^3.7.2",
     "node-fetch": "2",
     "node-rsa": "^1.0.2",
+    "nodemailer": "^8.0.10",
     "qrcode": "^1.5.4",
     "winston": "^3.17.0",
     "xlsx": "^0.18.5"

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -1297,20 +1297,52 @@ async function generateEmailParams(booking) {
       ? `${publicDomain}/account/bookings/cancel/${booking.bookingId}`
       : null;
 
+    // Derive arrival/departure from the booking-date items. Each item carries
+    // the resolved reservation context whose temporalAnchors (checkInTime /
+    // checkOutTime) are epoch-millis values the email's formatDate/formatTime
+    // helpers can render directly — giving both the date and the time of day.
+    // We sort by date so the first item is arrival and the last is departure.
+    // (The prior code read `reservationContext.arrivalDate.ts`, which never
+    // existed on the booking — arrivalDate is stored as a plain date string —
+    // so Arrival/Departure silently dropped out of the email.)
+    const dateItems = (bookingDates?.items || [])
+      .filter((item) => item.date)
+      .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+    const firstDay = dateItems[0];
+    const lastDay = dateItems[dateItems.length - 1];
+    const arrivalDate = firstDay?.reservationContext?.temporalAnchors?.checkInTime || firstDay?.date || null;
+    const departureDate = lastDay?.reservationContext?.temporalAnchors?.checkOutTime || lastDay?.date || null;
+
+    // Clean product/pass name (e.g. "Lindsay's Loop Trail - AM"), without the
+    // date suffix that `displayName` carries.
+    const productName = booking.productDisplayName || booking.displayName;
+
+    // Friendly pass-type label for the booking-card subtitle (matches the
+    // confirmation design, e.g. "Day-use pass"). Falls back to the capitalized
+    // raw activityType for any type without an explicit label.
+    const ACTIVITY_TYPE_LABELS = {
+      dayuse: 'Day-use pass',
+      frontcountryCamp: 'Frontcountry camping',
+      backcountryCamp: 'Backcountry camping',
+      groupCamp: 'Group camping',
+      boating: 'Boating',
+      cabinStay: 'Cabin stay',
+      canoe: 'Canoe',
+    };
+    const activityTypeLabel = ACTIVITY_TYPE_LABELS[booking.activityType]
+      || (booking.activityType ? booking.activityType.charAt(0).toUpperCase() + booking.activityType.slice(1) : 'Pass');
+
     const emailParams = {
       booking: {
         bookingId: booking.bookingId,
         displayName: booking.displayName,
-        invQuantity: bookingDates?.items?.reduce((total, item) => {
-          const dailyInventory = item.quantity || 0;
-          return total + dailyInventory;
-        }, 0),
-        arrivalDate: booking.reservationContext?.arrivalDate?.ts,
-        departureDate: booking.reservationContext?.departureDate?.ts,
+        invQuantity: dateItems.reduce((total, item) => total + (item.quantity || 0), 0),
+        arrivalDate,
+        departureDate,
         accountBookingUrl,
         activityType: booking.activityType ? booking.activityType.charAt(0).toUpperCase() + booking.activityType.slice(1) : 'Activity',
-        productName: booking.displayName,
-        qrCodeDataUrl: null,
+        activityTypeLabel,
+        productName,
         cancellationUrl,
         namedOccupant: booking.namedOccupant || {},
       },

--- a/test/qrCode.test.js
+++ b/test/qrCode.test.js
@@ -13,7 +13,7 @@ process.env.NODE_ENV = 'test'; // Bypass environment validation
 process.env.QR_SECRET_KEY = 'test-secret-key-for-unit-tests-only-do-not-use-in-production';
 process.env.PUBLIC_FRONTEND_DOMAIN = 'test.reserve-rec.bcparks.ca';
 
-const { generateQRURL, validateHash, generateQRCodeDataURL, validateEnvironment } = require('../lib/handlers/emailDispatch/qrCodeHelper');
+const { generateQRURL, validateHash, generateQRCodeDataURL, generateQRCodeBuffer, validateEnvironment } = require('../lib/handlers/emailDispatch/qrCodeHelper');
 
 describe('QR Code Helper', () => {
   
@@ -200,13 +200,53 @@ describe('QR Code Helper', () => {
 
     it('should generate QR code in reasonable time', async () => {
       const url = 'https://test.reserve-rec.bcparks.ca/verify/BOOK-123/abc123';
-      
+
       const startTime = Date.now();
       await generateQRCodeDataURL(url);
       const duration = Date.now() - startTime;
-      
+
       // Should complete in less than 500ms (generous threshold)
       expect(duration).toBeLessThan(500);
+    });
+  });
+
+  describe('generateQRCodeBuffer', () => {
+    // PNG files always start with this 8-byte magic-number signature.
+    const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    it('should generate a PNG Buffer', async () => {
+      const url = 'https://test.reserve-rec.bcparks.ca/verify/BOOK-123/abc123';
+      const buffer = await generateQRCodeBuffer(url);
+
+      expect(Buffer.isBuffer(buffer)).toBe(true);
+      expect(buffer.length).toBeGreaterThan(100);
+      // Verify it is a real PNG by its magic-number signature.
+      expect(buffer.subarray(0, 8).equals(PNG_SIGNATURE)).toBe(true);
+    });
+
+    it('should throw error if URL is missing', async () => {
+      await expect(generateQRCodeBuffer(null)).rejects.toThrow('URL is required');
+      await expect(generateQRCodeBuffer(undefined)).rejects.toThrow('URL is required');
+      await expect(generateQRCodeBuffer('')).rejects.toThrow('URL is required');
+    });
+
+    it('should generate consistent buffers for the same URL', async () => {
+      const url = 'https://test.reserve-rec.bcparks.ca/verify/BOOK-123/abc123';
+      const buffer1 = await generateQRCodeBuffer(url);
+      const buffer2 = await generateQRCodeBuffer(url);
+
+      expect(buffer1.equals(buffer2)).toBe(true);
+    });
+
+    it('should encode the same data as the data-URL variant', async () => {
+      // The Buffer and data-URL paths share render options, so the Buffer must
+      // match the base64 payload of the data URL byte-for-byte.
+      const url = 'https://test.reserve-rec.bcparks.ca/verify/BOOK-123/abc123';
+      const buffer = await generateQRCodeBuffer(url);
+      const dataUrl = await generateQRCodeDataURL(url);
+      const fromDataUrl = Buffer.from(dataUrl.replace(/^data:image\/png;base64,/, ''), 'base64');
+
+      expect(buffer.equals(fromDataUrl)).toBe(true);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,6 +6894,11 @@ node-rsa@^1.0.2:
   dependencies:
     asn1 "^0.2.4"
 
+nodemailer@^8.0.10:
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.10.tgz#009d4deaa06f54b6bd7ddc6cac1bf78e3bcb0bf2"
+  integrity sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==
+
 normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#56

### Description:

Addresses the QA send-back on the booking confirmation email (11 defects).

- **QR now renders** — delivered as a CID inline attachment via `SendRawEmail`/`MailComposer` instead of a `data:` URI (Gmail strips data URIs). The non-functional "Download QR" button is removed.
- **Arrival/Departure restored** — root-cause bug: `generateEmailParams` read `reservationContext.arrivalDate.ts`, which never existed. Now derived (date **and** time) from the booking-date `temporalAnchors` (`checkInTime`/`checkOutTime`).
- **Copy/layout to design** — pluralized pass/passes, new intro + disclaimer copy (`parkinfo@gov.bc.ca`), gray-box subtitle shows the pass-type label ("Day-use pass"), pass-type field keeps product + date, cancellation section removed (cancelling not yet possible), empty Customer Service box removed, table-based layout for Outlook.
- **Receipt template** QR switched to the same CID approach (same latent bug).
- Adds `generateQRCodeBuffer()` + tests; `nodemailer` dependency (bundled).

**Logo (QA #3):** no colour BC Parks logo asset exists in the repos — only reversed/white variants. Ships an interim white wordmark on a brand-blue band; the colour-logo-on-white header needs a design asset (follow-up).

No new env vars; uses existing `ses:SendRawEmail` grant.