### PR TITLE
fix(bookings): limit vehicle parking passes to 1 per booking

### DIFF
--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -511,6 +511,12 @@ async function validateBookingRequest(product, productDates, props) {
 
     logger.debug(`Validating booking request against ProductDate data for each day of the booking...`);
 
+    // Vehicle parking day-use passes are one pass per booking (one vehicle).
+    // The public site caps the selector at 1; enforce it server-side too (#566).
+    if (product?.activitySubType === 'vehicleParking' && Number(props?.invQuantity) > 1) {
+      throw `Vehicle parking passes are limited to one pass per booking`;
+    }
+
     for (const productDate of productDates?.items) {
 
       console.log('productDate', productDate);


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#566

### Description:

Server-side enforcement that a vehicle parking day-use pass is one pass per booking — booking creation now rejects `invQuantity > 1` for `vehicleParking` products. Mirrors the public-site selector cap (bcgov/reserve-rec-public#566) so the limit can't be bypassed.