### PR TITLE
PRDT-74: Implement Sales Endpoints

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/test', '<rootDir>/src'],
   testMatch: ['**/*.test.js'],
   transformIgnorePatterns: ['node_modules/'],
   collectCoverage: true,
@@ -25,6 +25,7 @@ module.exports = {
     '^/opt/dynamodb$': '<rootDir>/src/layers/awsUtils/dynamodb.js',
     '^/opt/locations/configs$': '<rootDir>/src/layers/dataUtils/locations/configs.js',
     '^/opt/locations/methods$': '<rootDir>/src/layers/dataUtils/locations/methods.js',
+    '^/opt/opensearch$': '<rootDir>/src/layers/awsUtils/opensearch.js',
     '^/opt/resources/configs$': '<rootDir>/src/layers/dataUtils/resources/configs.js',
     '^/opt/resources/methods$': '<rootDir>/src/layers/dataUtils/resources/methods.js',
     '^/opt/users/configs$': '<rootDir>/src/layers/dataUtils/users/configs.js',

--- a/src/handlers/bookings/_bookingId/check-in/PUT/__tests__/check-in-PUT.test.js
+++ b/src/handlers/bookings/_bookingId/check-in/PUT/__tests__/check-in-PUT.test.js
@@ -1,0 +1,220 @@
+"use strict";
+
+jest.mock("/opt/base", () => ({
+  Exception: jest.fn(function (message, data) {
+    this.message = message;
+    this.code = data?.code;
+    this.data = data;
+  }),
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  sendResponse: jest.fn((status, data, message, error, context) => ({
+    status,
+    data,
+    message,
+    error,
+    context,
+  })),
+  getRequestClaimsFromEvent: jest.fn((event) => {
+    const authHeader = event?.headers?.Authorization || "";
+    const token = authHeader.replace("Bearer ", "");
+    try {
+      const payloadBase64 = token.split(".")[1];
+      const payloadJson = Buffer.from(payloadBase64, "base64").toString("utf-8");
+      return JSON.parse(payloadJson);
+    } catch (e) {
+      return null;
+    }
+  }),
+  calculatePartySize: jest.fn(() => 4),
+  writeAuditLog: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("/opt/dynamodb", () => ({
+  batchTransactData: jest.fn(),
+  batchWriteData: jest.fn(),
+  marshall: jest.fn((value) => value),
+  AUDIT_TABLE_NAME: "AuditTable",
+  TRANSACTIONAL_DATA_TABLE_NAME: "TransactionalDataTable",
+}));
+
+jest.mock("../../../../../bookings/methods", () => ({
+  getBookingByBookingId: jest.fn(),
+}));
+
+const { handler } = require("../admin");
+const { getBookingByBookingId } = require("../../../../../bookings/methods");
+const { batchTransactData } = require("/opt/dynamodb");
+const { writeAuditLog } = require("/opt/base");
+
+function makeToken(sub) {
+  const base64Payload = Buffer.from(JSON.stringify({ sub })).toString("base64");
+  return `header.${base64Payload}.signature`;
+}
+
+function makeEvent({ bookingId = "booking-123", sub = "admin-123", body = {} } = {}) {
+  const headers = sub ? { Authorization: `Bearer ${makeToken(sub)}` } : {};
+  return {
+    httpMethod: "PUT",
+    pathParameters: { bookingId },
+    body: JSON.stringify(body),
+    headers,
+  };
+}
+
+const BOOKING_ID = "booking-123";
+const ADMIN_ID = "admin-123";
+
+const baseBooking = {
+  bookingId: BOOKING_ID,
+  status: "confirmed",
+  pk: "booking::1",
+  sk: "1",
+  reservationContext: {
+    checkedInTime: new Date("2026-06-11T08:00:00Z").getTime(), // Window starts 8am
+    checkOutTime: new Date("2026-06-11T20:00:00Z").getTime(),  // Window ends 8pm
+  }
+};
+
+describe("Bookings Check-In PUT handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock implementation
+    getBookingByBookingId.mockResolvedValue({ ...baseBooking });
+    batchTransactData.mockResolvedValue({});
+    
+    // Mock current time to 12pm on June 11, 2026
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-11T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns 200 for OPTIONS request", async () => {
+    const result = await handler({ httpMethod: "OPTIONS" }, {});
+    expect(result.status).toBe(200);
+  });
+
+  it("returns 401 when there is no auth token", async () => {
+    const event = makeEvent({ sub: null });
+    const result = await handler(event, {});
+    expect(result.status).toBe(401);
+    expect(result.message).toContain("Unauthorized");
+  });
+
+  it("returns 400 when booking status is not confirmed", async () => {
+    getBookingByBookingId.mockResolvedValue({ ...baseBooking, status: "pending" });
+    const event = makeEvent({});
+    const result = await handler(event, {});
+    expect(result.status).toBe(400);
+    expect(result.message).toContain('Booking has status "pending" and cannot be checked in');
+  });
+
+  it("returns 400 when booking is already checked in", async () => {
+    getBookingByBookingId.mockResolvedValue({ ...baseBooking, checkedInTime: 123456789 });
+    const event = makeEvent({});
+    const result = await handler(event, {});
+    expect(result.status).toBe(400);
+    expect(result.message).toContain("is already checked in");
+  });
+
+  it("returns 400 when checking in before scheduled time", async () => {
+    // System time is 12pm, but window starts at 2pm
+    jest.setSystemTime(new Date("2026-06-11T12:00:00Z"));
+    getBookingByBookingId.mockResolvedValue({
+      ...baseBooking,
+      reservationContext: {
+        checkedInTime: new Date("2026-06-11T14:00:00Z").getTime(),
+      }
+    });
+    
+    const event = makeEvent({});
+    const result = await handler(event, {});
+    expect(result.status).toBe(400);
+    expect(result.message).toContain("cannot be checked in until");
+  });
+
+  it("returns 400 when checking in after scheduled checkout time", async () => {
+    // System time is 12pm, but window ended at 10am
+    jest.setSystemTime(new Date("2026-06-11T12:00:00Z"));
+    getBookingByBookingId.mockResolvedValue({
+      ...baseBooking,
+      reservationContext: {
+        checkOutTime: new Date("2026-06-11T10:00:00Z").getTime(),
+      }
+    });
+    
+    const event = makeEvent({});
+    const result = await handler(event, {});
+    expect(result.status).toBe(400);
+    expect(result.message).toContain("cannot be checked after");
+  });
+
+  it("successfully checks in a booking", async () => {
+    const event = makeEvent({});
+    const result = await handler(event, {});
+
+    expect(result.status).toBe(200);
+    expect(result.data.message).toBe("Booking checked in");
+    expect(batchTransactData).toHaveBeenCalledWith([
+      {
+        action: "Update",
+        data: expect.objectContaining({
+          TableName: "TransactionalDataTable",
+          Key: {
+            pk: { S: baseBooking.pk },
+            sk: { S: baseBooking.sk },
+          },
+          UpdateExpression: expect.stringContaining("SET #checkedInTime = :checkedInTime"),
+          ExpressionAttributeValues: expect.objectContaining({
+            ":checkedInTime": { N: expect.any(String) },
+            ":checkedInByUser": { S: ADMIN_ID },
+          }),
+        }),
+      },
+    ]);
+    expect(writeAuditLog).toHaveBeenCalledWith(
+      ADMIN_ID,
+      BOOKING_ID,
+      "BOOKING-CHECK-IN-SUCCESS",
+      expect.objectContaining({
+        status: "confirmed",
+        partySize: 4,
+        collectionId: undefined,
+        activityType: undefined,
+        startDate: undefined,
+        endDate: undefined,
+      }),
+      expect.any(Function),
+      expect.any(Function),
+      "AuditTable",
+    );
+  });
+
+  it("writes a failure audit when booking status is invalid", async () => {
+    getBookingByBookingId.mockResolvedValue({ ...baseBooking, status: "pending" });
+
+    const event = makeEvent({});
+    const result = await handler(event, {});
+
+    expect(result.status).toBe(400);
+    expect(writeAuditLog).toHaveBeenCalledWith(
+      ADMIN_ID,
+      BOOKING_ID,
+      "BOOKING-CHECK-IN-FAILED",
+      expect.objectContaining({
+        reason: "Booking status is not confirmed",
+        status: "pending",
+      }),
+      expect.any(Function),
+      expect.any(Function),
+      "AuditTable",
+    );
+  });
+});

--- a/src/handlers/bookings/_bookingId/check-in/PUT/admin.js
+++ b/src/handlers/bookings/_bookingId/check-in/PUT/admin.js
@@ -1,0 +1,245 @@
+/**
+ */
+const {
+  calculatePartySize,
+  Exception,
+  getRequestClaimsFromEvent,
+  logger,
+  sendResponse,
+  writeAuditLog
+} = require("/opt/base");
+const {
+  AUDIT_TABLE_NAME,
+  batchTransactData,
+  batchWriteData,
+  marshall,
+  TRANSACTIONAL_DATA_TABLE_NAME,
+} = require("/opt/dynamodb");
+const {
+  getBookingByBookingId,
+  flagCancelledBooking,
+  generateEmailParams,
+  sendBookingCancellationEmail,
+} = require("../../../methods");
+
+exports.handler = async (event, context) => {
+  logger.info("Bookings Cancel POST:", event);
+
+  // Allow CORS
+  if (event.httpMethod === "OPTIONS") {
+    return sendResponse(200, {}, "Success", null, context);
+  }
+
+  try {
+    const bookingId = event?.pathParameters?.bookingId;
+    const claims = getRequestClaimsFromEvent(event);
+    const adminUserId = claims?.sub || null;
+    const sourceIp = event.requestContext?.identity?.sourceIp || "unknown";
+    const userAgent = event.requestContext?.identity?.userAgent || "unknown";
+
+    const writeFailureAudit = async (reason, metadata = {}) => {
+      await writeAuditLog(
+        adminUserId || "UNAUTHORIZED",
+        bookingId || "unknown",
+        "BOOKING-CHECK-IN-FAILED",
+        {
+          reason,
+          sourceIp,
+          userAgent,
+          ...metadata,
+        },
+        marshall,
+        batchWriteData,
+        AUDIT_TABLE_NAME,
+      );
+    };
+
+    if (!adminUserId) {
+      await writeAuditLog(
+        "UNAUTHORIZED",
+        bookingId || "unknown",
+        "BOOKING-CHECK-IN-UNAUTHORIZED",
+        {
+          reason: "Missing request claims",
+          sourceIp,
+          userAgent,
+          hasToken: !!claims,
+        },
+        marshall,
+        batchWriteData,
+        AUDIT_TABLE_NAME,
+      );
+
+      throw new Exception("Unauthorized: User ID not found in request claims", {
+        code: 401,
+      });
+    }
+
+    const booking = await getBookingByBookingId(bookingId);
+
+    // Check if booking status is confirmed (only status allowed)
+    if (booking.status !== "confirmed") {
+      await writeFailureAudit("Booking status is not confirmed", {
+        status: booking.status,
+        allowedStatuses: ["confirmed"],
+      });
+
+      logger.error("Status check failed", {
+        bookingId,
+        status: booking.status,
+        allowedStatuses: ["confirmed"],
+      });
+      throw new Exception(
+        `Booking has status "${booking.status}" and cannot be checked in`,
+        { code: 400 },
+      );
+    }
+
+    // Check if booking is already checked in, attribute shouldn't exist yet
+    if (booking.checkedInTime) {
+      await writeFailureAudit("Booking is already checked in", {
+        checkedInTime: booking.checkedInTime,
+      });
+
+      throw new Exception(`Booking ${bookingId} is already checked in`, {
+        code: 400,
+      });
+    }
+
+    const queryTime = new Date().getTime();
+    const scheduledCheckInTime = booking.reservationContext?.checkedInTime;
+    const scheduledCheckOutTime = booking.reservationContext?.checkOutTime;
+    const partySize = calculatePartySize(booking.partyInformation);
+
+    // Confirm we're within check-in window
+    if (scheduledCheckInTime && scheduledCheckInTime > queryTime) {
+      await writeFailureAudit("Booking cannot be checked in before the scheduled time", {
+        scheduledCheckInTime,
+        queryTime,
+      });
+
+      const d = new Date(scheduledCheckInTime);
+      const time = d.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      });
+      const date = d.toISOString().split("T")[0];
+      throw new Exception(
+        `Booking ${bookingId} cannot be checked in until ${time} on ${date}`,
+        {
+          code: 400,
+        },
+      );
+    }
+
+    // Confirm we're not past the check-out time
+    if (scheduledCheckOutTime && scheduledCheckOutTime < queryTime) {
+      await writeFailureAudit("Booking cannot be checked in after the scheduled check-out time", {
+        scheduledCheckOutTime,
+        queryTime,
+      });
+
+      const d = new Date(scheduledCheckOutTime);
+      const time = d.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      });
+      const date = d.toISOString().split("T")[0];
+      throw new Exception(
+        `Booking ${bookingId} cannot be checked after ${time} on ${date}`,
+        {
+          code: 400,
+        },
+      );
+    }
+
+    // Update item for batch transaction
+    const expressionAttributeNames = {
+      "#checkedInTime": "checkedInTime",
+      "#checkedInByUser": "checkedInByUser",
+      "#pk": "pk",
+    };
+    const expressionAttributeValues = {
+      ":checkedInTime": { N: queryTime.toString() },
+      ":checkedInByUser": { S: adminUserId },
+    };
+
+    let updateExpression =
+      "SET #checkedInTime = :checkedInTime, #checkedInByUser = :checkedInByUser";
+    const updateItem = {
+      TableName: TRANSACTIONAL_DATA_TABLE_NAME,
+      Key: {
+        pk: { S: booking.pk },
+        sk: { S: booking.sk },
+      },
+      UpdateExpression: updateExpression,
+      ConditionExpression: "attribute_exists(#pk)",
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
+    };
+
+    // Write successful check-in to audit log
+    await writeAuditLog(adminUserId, bookingId, 'BOOKING-CHECK-IN-SUCCESS', {
+      status: booking.status,
+      partySize,
+      collectionId: booking.collectionId,
+      activityType: booking.activityType,
+      startDate: booking.startDate,
+      endDate: booking.endDate,
+    }, marshall, batchWriteData, AUDIT_TABLE_NAME);
+
+    await batchTransactData([
+      {
+        data: updateItem,
+        action: "Update",
+      },
+    ]);
+
+    logger.info(`Booking ${bookingId} checked in.`);
+
+    return sendResponse(
+      200,
+      {
+        message: "Booking checked in",
+        bookingId,
+      },
+      "Success",
+      null,
+      context,
+    );
+  } catch (error) {
+    if (error?.code !== 401) {
+      await writeAuditLog(
+        getRequestClaimsFromEvent(event)?.sub || "unknown",
+        event?.pathParameters?.bookingId || "unknown",
+        "BOOKING-CHECK-IN-ERROR",
+        {
+          errorName: error?.name,
+          errorMessage: error?.message,
+          errorCode: error?.code,
+        },
+        marshall,
+        batchWriteData,
+        AUDIT_TABLE_NAME,
+      );
+    }
+
+    logger.error("Error during check-in", {
+      bookingId: event?.pathParameters?.bookingId,
+      errorName: error?.name,
+      errorCode: error?.code,
+      errorMessage: error?.message,
+      stack: error?.stack,
+    });
+
+    return sendResponse(
+      Number(error?.code) || 400,
+      error?.data || null,
+      error?.message || "Error checking in booking",
+      error?.error || error,
+      context,
+    );
+  }
+};

--- a/src/handlers/bookings/_bookingId/check-in/PUT/admin.js
+++ b/src/handlers/bookings/_bookingId/check-in/PUT/admin.js
@@ -148,7 +148,7 @@ exports.handler = async (event, context) => {
       });
       const date = d.toISOString().split("T")[0];
       throw new Exception(
-        `Booking ${bookingId} cannot be checked after ${time} on ${date}`,
+        `Booking ${bookingId} cannot be checked in after ${time} on ${date}`,
         {
           code: 400,
         },

--- a/src/handlers/bookings/configs.js
+++ b/src/handlers/bookings/configs.js
@@ -371,6 +371,18 @@ const BOOKING_PUT_CONFIG_TEMP = {
         rf.expectAction(action, ['set']);
       }
     },
+    checkedInTime: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['number']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    checkedInByUser: {
+      rulesFn: ({ value, action }) => {
+        rf.expectType(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
     entryPoint: {
       isMandatory: false,
       allowEmpty: true,

--- a/src/handlers/bookings/constructs.js
+++ b/src/handlers/bookings/constructs.js
@@ -19,6 +19,9 @@ const defaults = {
     bookingsSearchPOSTFunction: {
       name: 'bookingsSearchPOST',
     },
+    bookingsCheckInPUTFunction: {
+      name: 'bookingsCheckInPUT',
+    },
     bookingsPUTFunction: {
       name: 'BookingsPUT',
     },
@@ -47,10 +50,16 @@ class AdminBookingsConstruct extends LambdaConstruct {
     // /bookings/search resource
     this.bookingsSearchResource = this.bookingsResource.addResource('search');
 
+    // /bookings/{bookingId} and /bookings/{bookingId}/checkin resources
+    this.bookingsByBookingIdResource = this.bookingsResource.addResource('{bookingId}');
+    this.bookingsByBookingIdCheckinResource = this.bookingsByBookingIdResource.addResource('checkin');
+    
     this.addCorsPreflightForResources([
       this.bookingsResource,
       this.bookingsAdminResource,
       this.bookingsSearchResource,
+      this.bookingsByBookingIdResource,
+      this.bookingsByBookingIdCheckinResource,
     ]);
 
     // GET /bookings/admin Lambda function
@@ -87,6 +96,32 @@ class AdminBookingsConstruct extends LambdaConstruct {
       authorizer: this.resolveAuthorizer(),
     });
 
+    // PUT /bookings/{bookingId}/checkin Lambda function
+    this.bookingsCheckInPutFunction = this.generateBasicLambdaFn(
+      scope,
+      'bookingsCheckInPUTFunction',
+      'src/handlers/bookings/_bookingId/check-in/PUT',
+      'admin.handler',
+      {
+        transDataBasicReadWrite: true,
+        basicRead: true,
+      }
+    );
+
+    this.bookingsCheckInPutFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:ListUsers",
+      ],
+      resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
+    }));
+
+    // PUT /bookings/{bookingId}/checkin
+    this.bookingsByBookingIdCheckinResource.addMethod('PUT', new apigw.LambdaIntegration(this.bookingsCheckInPutFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+
     // Add permissions to read functions
     const readFunctions = [
       this.bookingsAdminGetFunction,
@@ -95,6 +130,17 @@ class AdminBookingsConstruct extends LambdaConstruct {
     for (const func of readFunctions) {
       this.grantBasicTransDataTableRead(func);
       this.grantBasicRefDataTableRead(func);
+    }
+
+    // Add permissions to write functions
+    const writeFunctions = [
+      this.bookingsCheckInPutFunction,
+    ];
+
+    for (const func of writeFunctions) {
+      this.grantBasicTransDataTableReadWrite(func);
+      this.grantBasicRefDataTableReadWrite(func);
+      this.grantAuditTableWrite(func);
     }
 
     // Grant OpenSearch permissions to search function
@@ -251,14 +297,51 @@ class PublicBookingsConstruct extends LambdaConstruct {
       resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
     }));
 
+    // PUT /bookings/{bookingId}/checkin Lambda function
+    this.bookingsCheckInPutFunction = this.generateBasicLambdaFn(
+      scope,
+      'bookingsCheckInPUTFunction',
+      'src/handlers/bookings/_bookingId/check-in/PUT',
+      'admin.handler',
+      {
+        transDataBasicReadWrite: true,
+        basicRead: true,
+      }
+    );
+
+    this.bookingsCheckInPutFunction.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:ListUsers",
+      ],
+      resources: ["*"], // Consider restricting this to specific user pool ARNs if possible
+    }));
+
+    // Child action resources under /bookings/{bookingId}
+    this.bookingsByBookingIdCompleteResource = this.bookingsByBookingIdResource.addResource('complete');
+    this.bookingsByBookingIdCancelResource = this.bookingsByBookingIdResource.addResource('cancel');
+    this.bookingsByBookingIdCheckinResource = this.bookingsByBookingIdResource.addResource('checkin');
+
+    this.addCorsPreflightForResources([
+      this.bookingsByBookingIdCompleteResource,
+      this.bookingsByBookingIdCancelResource,
+      this.bookingsByBookingIdCheckinResource,
+    ]);
+
     // POST /bookings/{bookingId}/complete
-    this.bookingsByBookingIdResource.addResource('complete').addMethod('POST', new apigw.LambdaIntegration(this.bookingsCompleteFunction), {
+    this.bookingsByBookingIdCompleteResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsCompleteFunction), {
       authorizationType: apigw.AuthorizationType.CUSTOM,
       authorizer: this.resolveAuthorizer(),
     });
 
     // POST /bookings/{bookingId}/cancel
-    this.bookingsByBookingIdResource.addResource('cancel').addMethod('POST', new apigw.LambdaIntegration(this.bookingsCancelPostFunction), {
+    this.bookingsByBookingIdCancelResource.addMethod('POST', new apigw.LambdaIntegration(this.bookingsCancelPostFunction), {
+      authorizationType: apigw.AuthorizationType.CUSTOM,
+      authorizer: this.resolveAuthorizer(),
+    });
+    
+    // PUT /bookings/{bookingId}/checkin
+    this.bookingsByBookingIdCheckinResource.addMethod('PUT', new apigw.LambdaIntegration(this.bookingsCheckInPutFunction), {
       authorizationType: apigw.AuthorizationType.CUSTOM,
       authorizer: this.resolveAuthorizer(),
     });
@@ -283,6 +366,7 @@ class PublicBookingsConstruct extends LambdaConstruct {
     const writeFunctions = [
       this.bookingsPostFunction,
       this.bookingsCancelPostFunction,
+      this.bookingsCheckInPutFunction
     ];
 
     for (const func of writeFunctions) {

--- a/src/handlers/bookings/search/POST/__tests__/search-POST.test.js
+++ b/src/handlers/bookings/search/POST/__tests__/search-POST.test.js
@@ -1,0 +1,224 @@
+"use strict";
+
+// Set up the spy functions to track what our handler passes to OpenSearch
+const mockAddMatchQueryStringRule = jest.fn();
+const mockAddFilterTermsRule = jest.fn();
+const mockAddRangeQueryRule = jest.fn();
+const mockAddExistsQueryRule = jest.fn();
+const mockSearch = jest.fn();
+
+// Mock the OpenSearch Layer
+jest.mock("/opt/opensearch", () => ({
+  OSQuery: jest.fn().mockImplementation(() => ({
+    addMatchQueryStringRule: mockAddMatchQueryStringRule,
+    addFilterTermsRule: mockAddFilterTermsRule,
+    addRangeQueryRule: mockAddRangeQueryRule,
+    addExistsQueryRule: mockAddExistsQueryRule,
+    search: mockSearch,
+    request: { some: "request" },
+  })),
+  OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME: "test-index",
+  nonKeyableTerms: [],
+}));
+
+// Mock the Base Layer (Utilities and Auth)
+jest.mock("/opt/base", () => ({
+  sendResponse: jest.fn((status, data, message, error, context) => ({
+    status,
+    data,
+    message,
+    error,
+    context,
+  })),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+  handleCORS: jest.fn(),
+  checkAuthContext: jest.fn(),
+  effectiveCollectionRole: jest.fn(),
+  calculatePartySize: jest.fn(() => 4),
+}));
+
+const { handler } = require("../index");
+const { checkAuthContext, effectiveCollectionRole, handleCORS } = require("/opt/base");
+
+describe("Bookings Admin Search POST handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockSearch.mockResolvedValue({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                bookingId: "booking_123",
+                collectionId: "collection_123",
+                status: "confirmed",
+                bookingCompletionTime: 1781106147626,
+                displayName: "Camping Day-use Pass - AM",
+                endDate: "2026-06-10",
+                facilityDisplayName: "Camping",
+                geozoneDisplayName: "Garibaldi Provincial Park",
+                namedOccupant: {
+                  contactInfo: {
+                    email: "test@example.com",
+                    mobilePhone: "1231231234",
+                  },
+                  firstName: "John",
+                  lastName: "Camper"
+                },
+                productDisplayName: "Camping Day-use Pass - AM",
+                reservationContext: {
+                  checkInTime: 1781100000000,
+                  checkOutTime: 1781136000000,
+                },
+                timezone: "America/Vancouver",
+                userId: "123-123-123-123-123",
+              }
+            }
+          ]
+        }
+      }
+    });
+
+    handleCORS.mockReturnValue(null);
+    checkAuthContext.mockReturnValue({ permissions: { superadmin: "superadmin" } });
+  });
+
+  it("handles CORS preflight requests correctly", async () => {
+    handleCORS.mockReturnValue({ status: 200 }); // Simulate an OPTIONS request intercept
+    const result = await handler({ httpMethod: "OPTIONS" }, {});
+    expect(result.status).toBe(200);
+  });
+
+  it("triggers a fuzzy search across all fields when text is provided", async () => {
+    const event = {
+      body: JSON.stringify({ text: "Camping" })
+    };
+    
+    await handler(event, {});
+    expect(mockAddMatchQueryStringRule).toHaveBeenCalledWith("Camping");
+  });
+
+  it("filters by exact email using the .keyword field", async () => {
+    const event = {
+      body: JSON.stringify({ email: "test@example.com" })
+    };
+    
+    await handler(event, {});
+    expect(mockAddFilterTermsRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'namedOccupant.contactInfo.email.keyword': "test@example.com"
+      })
+    );
+  });
+
+  it("adds an exists query and confirmed filter for 'reserved' status", async () => {
+    const event = {
+      body: JSON.stringify({ checkinStatus: "reserved" })
+    };
+    
+    await handler(event, {});
+    expect(mockAddExistsQueryRule).toHaveBeenCalledWith('checkedInTime', false);
+    expect(mockAddFilterTermsRule).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "confirmed" })
+    );
+  });
+
+  it("adds an exists query and confirmed filter for 'active' status", async () => {
+    const event = {
+      body: JSON.stringify({ checkinStatus: "active" })
+    };
+    
+    await handler(event, {});
+    expect(mockAddExistsQueryRule).toHaveBeenCalledWith('checkedInTime', true);
+    expect(mockAddFilterTermsRule).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "confirmed" })
+    );
+  });
+
+  it("translates startDate and endDate into a valid range query", async () => {
+    const event = {
+      body: JSON.stringify({ 
+        startDate: "2026-06-01",
+        endDate: "2026-06-30" 
+      })
+    };
+    
+    await handler(event, {});
+    expect(mockAddRangeQueryRule).toHaveBeenCalledWith(
+      'startDate', 
+      '2026-06-01', 
+      '2026-06-30'
+    );
+  });
+
+  it("returns raw, unpruned data directly from OpenSearch for superadmins", async () => {
+    checkAuthContext.mockReturnValue({ permissions: { superadmin: "superadmin" } });
+    
+    const event = {
+      body: JSON.stringify({ text: "give me everything" })
+    };
+    
+    const result = await handler(event, {});
+    const hits = result.data.hits;
+    
+    expect(result.status).toBe(200);
+    expect(hits[0]).toHaveProperty("namedOccupant.contactInfo.mobilePhone");
+    expect(hits[0]).toHaveProperty("namedOccupant.contactInfo.email", "test@example.com");
+  });
+
+  it("prunes sensitive response data for non-superadmin staff", async () => {
+    checkAuthContext.mockReturnValue({
+      permissions: { superadmin: "not-superadmin" }
+    });
+    effectiveCollectionRole.mockReturnValue("staff");
+    
+    const event = {
+      body: JSON.stringify({ text: "test" })
+    };
+    
+    const result = await handler(event, {});
+    const hits = result.data.hits;
+
+    expect(result.status).toBe(200);
+    // The namedOccupant object should have been flattened/removed in the .map()
+    expect(hits[0]).not.toHaveProperty("namedOccupant.mobilePhone");
+    // But core verification fields should survive
+    expect(hits[0]).toHaveProperty("email", "test@example.com");
+    expect(hits[0]).toHaveProperty("bookingId", "booking_123");
+  });
+
+  it("filters out hits completely if the user has no recognized role for that collection", async () => {
+    checkAuthContext.mockReturnValue({
+      permissions: { superadmin: "not-superadmin" }
+    });
+    effectiveCollectionRole.mockReturnValue(null); // User has no role for "collection_123"
+    
+    const event = {
+      body: JSON.stringify({ text: "test" })
+    };
+    
+    const result = await handler(event, {});
+    
+    // The array should be empty because the filter() stripped it out
+    expect(result.data.hits).toHaveLength(0);
+  });
+
+  it("catches OpenSearch exceptions and returns a formatted error response", async () => {
+    const mockError = { code: 503, msg: "OpenSearch cluster unavailable", error: "Timeout" };
+    mockSearch.mockRejectedValue(mockError); // Force a failure
+
+    const event = {
+      body: JSON.stringify({ text: "test" })
+    };
+    
+    const result = await handler(event, {});
+    
+    expect(result.status).toBe(503);
+    expect(result.message).toBe("OpenSearch cluster unavailable");
+  });
+});

--- a/src/handlers/bookings/search/POST/index.js
+++ b/src/handlers/bookings/search/POST/index.js
@@ -1,48 +1,184 @@
 // Import necessary libraries and modules
-const { OSQuery, OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME, nonKeyableTerms } = require('/opt/opensearch');
-const { sendResponse, logger, handleCORS } = require('/opt/base');
+const {
+  OSQuery,
+  OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME,
+  nonKeyableTerms,
+} = require("/opt/opensearch");
+const {
+  sendResponse,
+  logger,
+  handleCORS,
+  checkAuthContext,
+  effectiveCollectionRole,
+  calculatePartySize,
+} = require("/opt/base");
 // Lambda function entry point
 exports.handler = async function (event, context) {
-  logger.debug('Search:', event); // Log the search event
-  
+  logger.debug("Search:", event);
+
   // Handle CORS preflight
   const corsResponse = handleCORS(event, context);
   if (corsResponse) return corsResponse;
 
   try {
-    // Extract query parameters from the event
+    const authContext = checkAuthContext(event, "limited");
+
     const body = JSON.parse(event?.body) || {};
     const userQuery = body?.text;
 
-    // Construct the search query
-    let query = new OSQuery(OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME, body);
+    // Use a dedicated filter object for precise field matching
+    // and a text string for the general fuzzy search.
+    const searchOptions = {
+      from: body?.from || 0,
+      size: body?.size || 5, // Match frontend default
+      sortField: body?.sortField || 'startDate',
+      sortOrder: body?.sortOrder || 'desc'
+    };
 
-    // Text search
+    // Construct the search query
+    let query = new OSQuery(OPENSEARCH_TRANSACTIONAL_DATA_INDEX_NAME, searchOptions);
+
+    // Fuzzy search across all searchable fields
     if (userQuery) {
-      query.addMatchQueryStringRule(body?.text);
+      query.addMatchQueryStringRule(userQuery);
     }
 
-    // Term filtering
-    let termQuery = { ...body };
-    for (const term in termQuery) {
-      if (nonKeyableTerms.indexOf(term) > -1) {
-        delete termQuery[term];
+    // Structured filtering to apply exact matches for specific attributes
+    const filters = {};
+
+    if (body.email) {
+      // Use the .keyword sub-field for exact matching on the email.
+      filters['namedOccupant.contactInfo.email.keyword'] = body.email;
+    }
+
+    if (body.checkinStatus?.toLowerCase() === 'reserved') {
+      // For 'reserved', we want confirmed items that have NOT been checked in yet
+      query.addExistsQueryRule('checkedInTime', false);
+    }
+
+    if (body.checkinStatus?.toLowerCase() === 'active') {
+      // For 'active', we specifically want items where checkInTime exists
+      query.addExistsQueryRule('checkedInTime', true);
+    }
+
+    if (body.checkinStatus) {
+      // Map frontend status labels back to the backend 'status' values
+      const statusMap = {
+        'reserved': 'confirmed',
+        'active': 'confirmed',
+        'cancelled': 'cancelled',
+        'expired': 'confirmed'
+      };
+      const statusValue = statusMap[body.checkinStatus.toLowerCase()] || body.checkinStatus;
+      if (statusValue) {
+        filters['status'] = statusValue;
       }
     }
 
-    query.addFilterTermsRule(termQuery, true);
+    if (Object.keys(filters).length > 0) {
+      query.addFilterTermsRule(filters);
+    }
+
+    // Date range filtering
+    if (body.startDate || body.endDate) {
+      // Ensure range covering the requested period
+      query.addRangeQueryRule(
+        'startDate', 
+        body.startDate || '1970-01-01', 
+        body.endDate || '2099-12-31'
+      );
+    }
 
     // Send the query to the OpenSearch cluster
     let response = await query.search();
-    logger.debug('Request:', query.request); // Log the request (available after sending)
-    logger.debug('Response:', response); // Log the response
+    logger.debug("Request:", query.request); // Log the request (available after sending)
+    logger.debug("Response:", response); // Log the response
+
+    const isSuperAdmin = authContext?.permissions?.superadmin === "superadmin";
+    if (response && isSuperAdmin) {
+      response.body.hits.hits = response.body.hits.hits.map((hit) => {
+        return hit._source
+      });
+    } else if (response && !isSuperAdmin) {
+      // We want to remove hits where the user doesn't have the correct permissions
+      response.body.hits.hits = response.body.hits.hits.filter((hit) => {
+        const role = effectiveCollectionRole(
+          authContext,
+          hit._source.collectionId,
+        );
+        // For now, return for both limited and staff (TODO: this may change later)
+        return role === "limited" || role === "staff";
+      });
+
+      // We also want to remove unneeded data attributes from the item (phone, address)
+      // and restructure the response accordingly
+      response.body.hits.hits = response.body.hits.hits.map((hit) => {
+        const booking = hit._source;
+        
+        // Calculate party size
+        const partySize = calculatePartySize(booking.partyInformation);
+
+        return {
+          // Core verification info only
+          bookingId: booking?.bookingId,
+          displayName: booking?.displayName,
+          status: booking.status,
+          bookingCompletionTime: booking?.bookingCompletionTime || booking?.bookedAt,
+          
+          // Dates (needed to verify reservation period)
+          startDate: booking?.startDate,
+          endDate: booking?.endDate,
+          
+          // Guest contact info
+          firstName: booking?.firstName || booking?.namedOccupant?.firstName,
+          lastName: booking?.lastName || booking?.namedOccupant?.lastName,
+          email: booking?.email || booking?.namedOccupant?.contactInfo?.email,
+
+          // Checked-in time (if it exists)
+          checkedInTime: booking?.checkedInTime,
+
+          // checkOutTime needed to calculate statuses (Active, Expired, etc.)
+          reservationContext: {
+            checkOutTime: booking?.reservationContext?.checkOutTime
+          },
+
+          // Party size only (not detailed age breakdown)
+          partySize: partySize,
+          partyInformation: booking?.partyInformation,
+          
+          // Location info (needed to verify correct park/activity)
+          collectionId: booking?.collectionId,
+          activityType: booking?.activityType,
+          facilityDisplayName: booking?.facilityDisplayName,
+          geozoneDisplayName: booking?.geozoneDisplayName,
+          
+          // Access points (if available, for trail/backcountry permits)
+          entryPoint: booking?.entryPoint ? {
+            text: booking.entryPoint.text,
+            category: booking.entryPoint.category
+          } : undefined,
+          exitPoint: booking?.exitPoint ? {
+            text: booking.exitPoint.text,
+            category: booking.exitPoint.category
+          } : undefined,
+          location: booking?.location,
+          
+          // Vehicle info (if available, for parking passes)
+          vehicleInformation: booking?.vehicleInformation,
+        }
+      });
+    }
 
     // Send a success response
-    return sendResponse(200, response.body.hits, 'Success', null, context);
+    return sendResponse(200, response.body.hits, "Success", null, context);
   } catch (err) {
-    logger.error(JSON.stringify(err)); // Log the error
-
-    // Send an error response
-    return sendResponse(err?.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+    logger.error("Error in Bookings Admin Search POST:", err);
+    return sendResponse(
+      Number(err?.code) || 400,
+      err?.data || null,
+      err?.msg || "Error",
+      err?.error || err,
+      context,
+    );
   }
 };

--- a/src/handlers/verify/GET/admin.js
+++ b/src/handlers/verify/GET/admin.js
@@ -38,7 +38,7 @@ exports.handler = async (event, context) => {
   try {
     // Validate admin authorization
     try {
-      claims = checkAuthContext(event, 'superadmin');
+      claims = checkAuthContext(event, 'limited');
     } catch (authError) {
       // Log unauthorized attempt to audit table
       const sourceIp = event.requestContext?.identity?.sourceIp || 'unknown';
@@ -108,7 +108,7 @@ exports.handler = async (event, context) => {
 
     logger.info("Verifying QR code", { bookingId, userId: claims.sub });
 
-    // Step 1: Fetch the booking from database FIRST (before hash validation)
+    // Fetch the booking from database FIRST (before hash validation)
     // This prevents timing attacks that could reveal if a bookingId exists
     let booking;
     try {
@@ -133,7 +133,7 @@ exports.handler = async (event, context) => {
       return sendInvalidQRResponse(context);
     }
 
-    // Step 2: Validate the hash (after confirming booking exists)
+    // Validate the hash (after confirming booking exists)
     logger.info("About to validate hash", { bookingId, hash, secretKeyLength: process.env.QR_SECRET_KEY?.length });
     const isValidHash = validateHash(bookingId, hash);
     logger.info("Hash validation complete", { bookingId, hash, isValidHash });
@@ -150,21 +150,12 @@ exports.handler = async (event, context) => {
 
     logger.info("QR code hash validated successfully", { bookingId, verifiedBy: claims.sub });
 
-    // Step 3: Check booking status
-    const bookingStatus = booking.status;
-    const isExpired = booking.sessionExpiry && new Date(booking.sessionExpiry) < new Date();
-    const isCancelled = bookingStatus === "cancelled";
-    const isConfirmed = bookingStatus === "confirmed";
-
     // Calculate party size using utility function
     const partySize = calculatePartySize(booking.partyInformation);
 
     // Write successful verification to audit log
     await writeAuditLog(claims.sub, bookingId, 'QR_VERIFY_SUCCESS', {
-      bookingStatus,
-      isExpired,
-      isCancelled,
-      isConfirmed,
+      status: booking.status,
       partySize,
       collectionId: booking.collectionId,
       activityType: booking.activityType,
@@ -175,70 +166,68 @@ exports.handler = async (event, context) => {
 
     logger.info("QR code verification completed", {
       bookingId,
-      status: bookingStatus,
-      isExpired,
-      isCancelled,
-      isConfirmed,
+      status: booking.status,
       verifiedBy: claims.sub,
       verifiedAt: timestamp
     });
 
-    // Step 4: Return MINIMAL booking details (prevent excessive PII disclosure)
+    // Return MINIMAL booking details (prevent excessive PII disclosure)
     // Only include information necessary for park staff to verify the reservation
     const response = {
-      valid: true,
-      bookingId: booking.bookingId,
-      status: bookingStatus,
-      statusDetails: {
-        isConfirmed,
-        isCancelled,
-        isExpired,
-        isPending: bookingStatus === "in progress"
+      // Core verification info only
+      bookingId: booking?.bookingId,
+      displayName: booking?.displayName,
+      status: booking.status,
+      bookingCompletionTime: booking?.bookingCompletionTime || booking?.bookedAt,
+      
+      // Dates (needed to verify reservation period)
+      startDate: booking?.startDate,
+      endDate: booking?.endDate,
+      
+      // Guest contact info
+      firstName: booking?.firstName || booking?.namedOccupant?.firstName,
+      lastName: booking?.lastName || booking?.namedOccupant?.lastName,
+      email: booking?.email || booking?.namedOccupant?.contactInfo?.email,
+
+      // Checked-in time (if it exists)
+      checkedInTime: booking?.checkedInTime,
+
+      // checkOutTime needed to calculate statuses (Active, Expired, etc.)
+      reservationContext: {
+        checkOutTime: booking?.reservationContext?.checkOutTime
       },
-      booking: {
-        // Core verification info only
-        bookingId: booking.bookingId,
-        displayName: booking.displayName,
-        
-        // Dates (needed to verify reservation period)
-        startDate: booking.startDate,
-        endDate: booking.endDate,
-        
-        // Guest name only (no email, phone, or address)
-        guestName: booking.namedOccupant 
-          ? `${booking.namedOccupant.firstName} ${booking.namedOccupant.lastName}`
-          : null,
-        
-        // Party size only (not detailed age breakdown)
-        partySize: partySize,
-        
-        // Location info (needed to verify correct park/activity)
-        collectionId: booking.collectionId,
-        activityType: booking.activityType,
-        displayName: booking.displayName,
-        
-        // Access points (if available, for trail/backcountry permits)
-        entryPoint: booking.entryPoint,
-        exitPoint: booking.exitPoint,
-        location: booking.location,
-        
-        // Vehicle info (if available, for parking passes)
-        vehicleInformation: booking.vehicleInformation,
-        
-        // DO NOT include: 
-        // - namedOccupant (contains email, phone, address)
-        // - partyInformation (age breakdown not needed)
-        // - feeInformation (payment details not needed for verification)
-        // - sessionId, sessionExpiry (internal session state)
-        // - globalId, activityId (internal IDs)
-        // - equipmentInformation (not needed for basic verification)
-        // - bookedAt (not needed for verification)
-      },
-      verificationMetadata: {
-        verifiedAt: new Date().toISOString(),
-        verifiedBy: claims.sub
-        // DO NOT include verifierEmail (not needed in response)
-      }
+
+      // Party size only (not detailed age breakdown)
+      partySize: partySize,
+      partyInformation: booking?.partyInformation,
+      
+      // Location info (needed to verify correct park/activity)
+      collectionId: booking?.collectionId,
+      activityType: booking?.activityType,
+      facilityDisplayName: booking?.facilityDisplayName,
+      geozoneDisplayName: booking?.geozoneDisplayName,
+      
+      // Access points (if available, for trail/backcountry permits)
+      entryPoint: booking?.entryPoint ? {
+        text: booking.entryPoint.text,
+        category: booking.entryPoint.category
+      } : undefined,
+      exitPoint: booking?.exitPoint ? {
+        text: booking.exitPoint.text,
+        category: booking.exitPoint.category
+      } : undefined,
+      location: booking?.location,
+      
+      // Vehicle info (if available, for parking passes)
+      vehicleInformation: booking?.vehicleInformation,
+      
+      // DO NOT include: 
+      // - namedOccupant (contains phone, address)
+      // - feeInformation (payment details not needed for verification)
+      // - sessionId, sessionExpiry (internal session state)
+      // - globalId, activityId (internal IDs)
+      // - equipmentInformation (not needed for basic verification)
+      // - bookedAt (not needed for verification)
     };
 
     return sendResponse(200, response, "Success", null, context);

--- a/src/layers/awsUtils/opensearch.js
+++ b/src/layers/awsUtils/opensearch.js
@@ -315,6 +315,22 @@ class OSQuery {
   }
 
   /**
+   * Adds an exists query rule to the OpenSearch query.
+   * Returns documents that contain any indexed value for the field.
+   *
+   * @param {string} field - The field to check for existence.
+   * @param {boolean} exists - If true (default), returns docs where field exists. If false, returns docs where field does NOT exist.
+   */
+  addExistsQueryRule(field, exists = true) {
+    const clause = exists ? "must" : "must_not";
+    setNestedValue(this.query, ["bool", clause], {
+      exists: {
+        field: field,
+      },
+    });
+  }
+
+  /**
    * BBox filter for geo_point field.
    * The bbox is an array of two arrays, each containing [longitude, latitude].
    * The orientation of the root array is [[northwest_corner],[southeast_corner]].


### PR DESCRIPTION
### Ticket:

PRDT-74

### Ticket URL:

[#74](https://github.com/bcgov/reserve-rec-admin/issues/74)

### Description:
- Add a `checkin` endpoint for admin users to use to check-in a booking
  - This captures a `checkedInTime` and `checkedInByUser`
  - Ensures the booking is within check-in timeframe and not already checked in
  - Tracks check-in and logs any failures and successes to Audit table
- Updates to the Booking Search endpoint
  - Added some filters for check-in status, email keyword filtering, and date ranges
  - Cleaned up the returned `response` to match more closely with what was returned in Verify GET (only necessary data - i.e. PII compliant)
- Cleaned up the Verify GET endpoint (used for QR scanning) to return a booking in a similar manner to the booking search

- Added `addExistsQueryRule` to check for the existence of a data attribute (`checkedInStatus`) in Opensearch to better filter checked-in bookings
- Added some testing for search-POST and checkin-PUT