### PR TITLE
fix(collections): return adminNotes to superadmins, accept timezone field

### DIFF
--- a/src/handlers/collections/GET/admin.js
+++ b/src/handlers/collections/GET/admin.js
@@ -46,8 +46,10 @@ exports.handler = async (event, context) => {
       res = await getAllCollections(filters, queryParams);
     }
 
+    const isSuperAdmin = authContext.permissions?.['superadmin'] === 'superadmin';
+
     // If the user isn't a superadmin, remove adminNotes from the response
-    if (res && authContext.permissions !== 'superadmin') {
+    if (res && !isSuperAdmin) {
       const removedFields = ({ adminNotes, ...allowedFields }) => allowedFields;
       if (Array.isArray(res)) {
         res = res.map(removedFields);
@@ -59,7 +61,6 @@ exports.handler = async (event, context) => {
     }
 
     // Filter out the collections the user doesn't have (at least) the 'staff' permission for
-    const isSuperAdmin = authContext.permissions?.['superadmin'] === 'superadmin';
     if (!isSuperAdmin && res) {
       const TIER_ORDER = ['limited', 'staff', 'superadmin'];
       const minTierIndex = TIER_ORDER.indexOf('staff');

--- a/src/handlers/collections/configs.js
+++ b/src/handlers/collections/configs.js
@@ -83,6 +83,12 @@ const COLLECTION_API_PUT_CONFIG = {
         rf.expectAction(action, ['set']);
       }
     },
+    timezone: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, TIMEZONE_ENUMS);
+        rf.expectAction(action, ['set']);
+      }
+    },
   }
 };
 
@@ -130,6 +136,12 @@ const COLLECTION_API_UPDATE_CONFIG = {
     searchTerms: {
       rulesFn: ({ value, action }) => {
         rf.expectArray(value, ['string']);
+        rf.expectAction(action, ['set']);
+      }
+    },
+    timezone: {
+      rulesFn: ({ value, action }) => {
+        rf.expectValueInList(value, TIMEZONE_ENUMS);
         rf.expectAction(action, ['set']);
       }
     },


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-admin#265

### Description:

- Fix superadmin check in collections GET handler that compared the permissions object to a string, stripping adminNotes from every response
- Add timezone (validated against TIMEZONE_ENUMS) to collection PUT/UPDATE configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)