### PR TITLE
fix(identity): send Cognito verification emails via SES when configured

### DIFF
--- a/lib/public-identity-stack/public-identity-stack.js
+++ b/lib/public-identity-stack/public-identity-stack.js
@@ -186,9 +186,27 @@ class PublicIdentityStack extends BaseStack {
       return; // Skip resource creation
     }
 
+    // Send verification emails through SES from the verified bcparks.ca identity
+    // when configured. The Cognito default sender (no-reply@verificationemail.com)
+    // fails SPF/DKIM alignment and lands in spam. Unset means COGNITO_DEFAULT —
+    // sandboxes stay on the default sender since SES sandbox mode only delivers
+    // to verified recipients.
+    const userPoolFromEmail = this.getConfigValue('userPoolFromEmail');
+
     // Create a public Cognito User Pool
     this.publicUserPool = new cognito.UserPool(this, this.getConstructId('publicUserPool'), {
       userPoolName: this.getConstructId('publicUserPool'),
+      email: userPoolFromEmail
+        ? cognito.UserPoolEmail.withSES({
+            fromEmail: userPoolFromEmail,
+            fromName: this.getConfigValue('userPoolFromName') || 'BC Parks',
+            sesRegion: this.getConfigValue('sesRegion') || 'ca-central-1',
+            // The SES-verified identity is the domain, not the address; without
+            // this the sourceArn references an unverified email identity and
+            // the deploy fails.
+            sesVerifiedDomain: this.getConfigValue('userPoolSesVerifiedDomain'),
+          })
+        : undefined,
       autoVerify: { email: true },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       userVerification: {


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#565

### Description:

- Add config-gated `UserPoolEmail.withSES` to the public user pool (`userPoolFromEmail` / `userPoolFromName` / `userPoolSesVerifiedDomain` in the publicIdentityStack SSM config)
- The Cognito default sender (`no-reply@verificationemail.com`) fails SPF/DKIM alignment, which is why verification emails land in spam; `bcparks.ca` is already SES-verified with DKIM passing
- Unset config keeps COGNITO_DEFAULT (sandboxes), since SES sandbox mode only delivers to verified recipients
- Note: enabling on test/prod also needs the SSM config keys added and an SES production-access request per account — emails to unverified recipients will not send while the account is in SES sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)