### PR TITLE
feat(waf): add ENABLE_ORIGIN_VERIFY_WAF env flag to skip WAF in sandbox

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -712,45 +712,48 @@ class PublicApiStack extends BaseStack {
 
     // WAF: enforce X-Origin-Verify header so only CloudFront can reach the API Gateway stage
     // Path uses reserveRecApi (camelCase) matching sandbox-setup.sh APP_NAME convention
-    const originVerifySecretPath = `/reserveRecApi/${this.getDeploymentName()}/originVerifySecret`;
-    const originVerifySecret = ssm.StringParameter.valueForStringParameter(this, originVerifySecretPath);
+    // Set ENABLE_ORIGIN_VERIFY_WAF=false to skip WAF deployment (e.g. sandbox local dev)
+    if (process.env.ENABLE_ORIGIN_VERIFY_WAF !== 'false') {
+      const originVerifySecretPath = `/reserveRecApi/${this.getDeploymentName()}/originVerifySecret`;
+      const originVerifySecret = ssm.StringParameter.valueForStringParameter(this, originVerifySecretPath);
 
-    const originVerifyWebAcl = new wafv2.CfnWebACL(this, this.getConstructId('originVerifyWebAcl'), {
-      scope: 'REGIONAL',
-      defaultAction: { allow: {} },
-      visibilityConfig: {
-        cloudWatchMetricsEnabled: true,
-        metricName: `${this.getConstructId('originVerifyWebAcl')}Metrics`,
-        sampledRequestsEnabled: true,
-      },
-      rules: [{
-        name: 'RequireOriginVerifyHeader',
-        priority: 0,
-        statement: {
-          notStatement: {
-            statement: {
-              byteMatchStatement: {
-                fieldToMatch: { singleHeader: { name: 'x-origin-verify' } },
-                positionalConstraint: 'EXACTLY',
-                searchString: originVerifySecret,
-                textTransformations: [{ priority: 0, type: 'NONE' }],
+      const originVerifyWebAcl = new wafv2.CfnWebACL(this, this.getConstructId('originVerifyWebAcl'), {
+        scope: 'REGIONAL',
+        defaultAction: { allow: {} },
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: `${this.getConstructId('originVerifyWebAcl')}Metrics`,
+          sampledRequestsEnabled: true,
+        },
+        rules: [{
+          name: 'RequireOriginVerifyHeader',
+          priority: 0,
+          statement: {
+            notStatement: {
+              statement: {
+                byteMatchStatement: {
+                  fieldToMatch: { singleHeader: { name: 'x-origin-verify' } },
+                  positionalConstraint: 'EXACTLY',
+                  searchString: originVerifySecret,
+                  textTransformations: [{ priority: 0, type: 'NONE' }],
+                },
               },
             },
           },
-        },
-        action: { block: {} },
-        visibilityConfig: {
-          cloudWatchMetricsEnabled: true,
-          metricName: 'RequireOriginVerifyHeaderMetric',
-          sampledRequestsEnabled: true,
-        },
-      }],
-    });
+          action: { block: {} },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'RequireOriginVerifyHeaderMetric',
+            sampledRequestsEnabled: true,
+          },
+        }],
+      });
 
-    new wafv2.CfnWebACLAssociation(this, this.getConstructId('originVerifyWebAclAssociation'), {
-      resourceArn: `arn:aws:apigateway:${this.region}::/restapis/${publicApiId}/stages/${stage.stageName}`,
-      webAclArn: originVerifyWebAcl.attrArn,
-    });
+      new wafv2.CfnWebACLAssociation(this, this.getConstructId('originVerifyWebAclAssociation'), {
+        resourceArn: `arn:aws:apigateway:${this.region}::/restapis/${publicApiId}/stages/${stage.stageName}`,
+        webAclArn: originVerifyWebAcl.attrArn,
+      });
+    }
 
     // Export References
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "sandbox:setup": "./scripts/sandbox-setup.sh",
     "sandbox:teardown": "./scripts/sandbox-teardown.sh",
     "sandbox:edit-config": "./scripts/sandbox-edit-config.sh",
-    "sandbox:synth": "cdk synth -c @context=dev -c sandboxName=${SANDBOX_NAME} --all",
-    "sandbox:deploy": "cdk deploy -c @context=dev -c sandboxName=${SANDBOX_NAME} --all --require-approval never",
+    "sandbox:synth": "ENABLE_ORIGIN_VERIFY_WAF=false cdk synth -c @context=dev -c sandboxName=${SANDBOX_NAME} --all",
+    "sandbox:deploy": "ENABLE_ORIGIN_VERIFY_WAF=false cdk deploy -c @context=dev -c sandboxName=${SANDBOX_NAME} --all --require-approval never",
     "sandbox:destroy": "cdk destroy -c @context=dev -c sandboxName=${SANDBOX_NAME} --all --force"
   },
   "devDependencies": {


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:
N/A
#

### Description:
  - Wraps WAF WebACL deployment in an `ENABLE_ORIGIN_VERIFY_WAF` env flag guard
  - Prevents WAF from being deployed in sandbox/local dev environments
  - Sets flag to `false` in `sandbox:synth` and `sandbox:deploy` npm scripts
