### PR TITLE
fix(bookings): restore confirmation SMS phone resolution

### DIFF
--- a/src/handlers/bookings/POST/public.js
+++ b/src/handlers/bookings/POST/public.js
@@ -1,7 +1,7 @@
 // Create new booking
 const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
 const { createBooking, formatBookingResponsePublic, } = require("../methods");
-const { batchTransactData } = require("/opt/dynamodb");
+const { batchTransactData, unmarshall } = require("/opt/dynamodb");
 const { parseAdmissionCookie, validateToken } = require('../../waiting-room/utils/token');
 const { getHmacSigningKey } = require('../../waiting-room/utils/secrets');
 const { getQueueMeta, buildQueueId } = require('../../waiting-room/utils/dynamodb');
@@ -157,7 +157,15 @@ exports.handler = async (event, context) => {
     const res = await batchTransactData(bookingRequestItems);
 
     const response = formatBookingResponsePublic(bookingRequestItems);
-    await enqueueSmsReminderIfNeeded(body, response);
+
+    // The booking record carries the occupant phone resolved from the Cognito
+    // profile; use it as the SMS fallback when the request body omits one.
+    const bookingItem = bookingRequestItems
+      .map((item) => (item?.action === 'Put' ? unmarshall(item?.data?.Item) : null))
+      .find((item) => item?.schema === 'booking');
+    const resolvedMobilePhone = bookingItem?.namedOccupant?.contactInfo?.mobilePhone || null;
+
+    await enqueueSmsReminderIfNeeded(body, response, resolvedMobilePhone);
 
     return sendResponse(200, response, "Success", null, context);
 

--- a/src/handlers/bookings/notifications.js
+++ b/src/handlers/bookings/notifications.js
@@ -35,11 +35,14 @@ function getSmsReminderSqsClient(queueUrl) {
   return smsReminderSqsClient;
 }
 
-function buildSmsReminderPayload(body, response) {
+function buildSmsReminderPayload(body, response, fallbackMobilePhone) {
   return {
     bookingId: response?.bookingId || response?.globalId || null,
     userId: body?.userId || null,
-    mobilePhone: body?.namedOccupant?.contactInfo?.mobilePhone || null,
+    // Prefer a number supplied with the booking; fall back to the phone resolved
+    // from the authenticated Cognito profile when the request omits one (Ref #404
+    // stopped the FE sending identity fields, so this fallback keeps SMS working).
+    mobilePhone: body?.namedOccupant?.contactInfo?.mobilePhone || fallbackMobilePhone || null,
     startDate: body?.startDate || null,
     collectionId: body?.collectionId || null,
     activityType: body?.activityType || null,
@@ -49,12 +52,12 @@ function buildSmsReminderPayload(body, response) {
   };
 }
 
-async function enqueueSmsReminderIfNeeded(body, response) {
+async function enqueueSmsReminderIfNeeded(body, response, fallbackMobilePhone) {
   if (!body?.smsOptIn) {
     return;
   }
 
-  const smsReminderPayload = buildSmsReminderPayload(body, response);
+  const smsReminderPayload = buildSmsReminderPayload(body, response, fallbackMobilePhone);
   const queueUrl = process.env.SMS_REMINDER_QUEUE_URL;
 
   try {


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#570

### Description:

- Confirmation SMS stopped sending because #404 moved occupant identity resolution server-side and the FE no longer sends `mobilePhone` in the booking body — but the SMS enqueue still read the phone from that (now-empty) field, so nothing was queued.
- Source the SMS phone from the Cognito-resolved booking record as a fallback when the request omits one; a body-supplied number still wins.