### PR TITLE
fix(bookings): send confirmation SMS at booking completion (#570)

### DIFF
--- a/src/handlers/bookings/POST/public.js
+++ b/src/handlers/bookings/POST/public.js
@@ -1,11 +1,10 @@
 // Create new booking
 const { Exception, logger, sendResponse, getRequestClaimsFromEvent } = require("/opt/base");
 const { createBooking, formatBookingResponsePublic, } = require("../methods");
-const { batchTransactData, unmarshall } = require("/opt/dynamodb");
+const { batchTransactData } = require("/opt/dynamodb");
 const { parseAdmissionCookie, validateToken } = require('../../waiting-room/utils/token');
 const { getHmacSigningKey } = require('../../waiting-room/utils/secrets');
 const { getQueueMeta, buildQueueId } = require('../../waiting-room/utils/dynamodb');
-const { enqueueSmsReminderIfNeeded } = require('../notifications');
 
 exports.handler = async (event, context) => {
   logger.info("Bookings POST Activated");
@@ -158,14 +157,10 @@ exports.handler = async (event, context) => {
 
     const response = formatBookingResponsePublic(bookingRequestItems);
 
-    // The booking record carries the occupant phone resolved from the Cognito
-    // profile; use it as the SMS fallback when the request body omits one.
-    const bookingItem = bookingRequestItems
-      .map((item) => (item?.action === 'Put' ? unmarshall(item?.data?.Item) : null))
-      .find((item) => item?.schema === 'booking');
-    const resolvedMobilePhone = bookingItem?.namedOccupant?.contactInfo?.mobilePhone || null;
-
-    await enqueueSmsReminderIfNeeded(body, response, resolvedMobilePhone);
+    // Note: the confirmation SMS is dispatched at booking completion, not here.
+    // At create time the booking is not yet confirmed and the FE has not sent
+    // the SMS opt-in (it arrives with the complete request). See the booking
+    // complete handlers and methods.completeBooking().
 
     return sendResponse(200, response, "Success", null, context);
 

--- a/src/handlers/bookings/PUT/public.js
+++ b/src/handlers/bookings/PUT/public.js
@@ -4,6 +4,7 @@
 // email for a booking that was never saved.
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { completeBooking, sendBookingConfirmationEmail } = require("../methods");
+const { enqueueSmsReminderIfNeeded } = require("../notifications");
 const { batchTransactData } = require("/opt/dynamodb");
 
 exports.handler = async (event, context) => {
@@ -28,7 +29,7 @@ exports.handler = async (event, context) => {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body, { sub });
+    const { updateRequests, emailParams, smsParams } = await completeBooking(bookingId, sessionId, body, { sub });
 
     const res = await batchTransactData(updateRequests);
 
@@ -39,6 +40,22 @@ exports.handler = async (event, context) => {
         bookingId,
         error: emailError?.message,
         stack: emailError?.stack,
+      });
+    }
+
+    // Confirmation SMS — opt-in and Cognito-resolved phone are only present
+    // once the booking is completed, so this is the correct dispatch point.
+    try {
+      await enqueueSmsReminderIfNeeded(
+        smsParams,
+        { bookingId },
+        smsParams?.namedOccupant?.contactInfo?.mobilePhone
+      );
+    } catch (smsError) {
+      logger.error("Booking completed but confirmation SMS enqueue failed", {
+        bookingId,
+        error: smsError?.message,
+        stack: smsError?.stack,
       });
     }
 

--- a/src/handlers/bookings/_bookingId/complete/POST/public.js
+++ b/src/handlers/bookings/_bookingId/complete/POST/public.js
@@ -4,6 +4,7 @@
 // email for a booking that was never saved.
 const { Exception, logger, sendResponse } = require("/opt/base");
 const { completeBooking, sendBookingConfirmationEmail } = require("../../../methods");
+const { enqueueSmsReminderIfNeeded } = require("../../../notifications");
 const { batchTransactData } = require("/opt/dynamodb");
 
 
@@ -29,12 +30,12 @@ exports.handler = async (event, context) => {
       throw new Exception("User authentication required", { code: 401 });
     }
 
-    const { updateRequests, emailParams } = await completeBooking(bookingId, sessionId, body, { sub });
+    const { updateRequests, emailParams, smsParams } = await completeBooking(bookingId, sessionId, body, { sub });
 
     const res = await batchTransactData(updateRequests);
 
-    // Booking is durable — now queue the email. Failures here are logged but
-    // do not roll back the cancellation; the user has a confirmed booking.
+    // Booking is durable — now queue the notifications. Failures here are
+    // logged but do not roll back the booking; the user has a confirmed booking.
     try {
       await sendBookingConfirmationEmail(emailParams, sub);
     } catch (emailError) {
@@ -42,6 +43,22 @@ exports.handler = async (event, context) => {
         bookingId,
         error: emailError?.message,
         stack: emailError?.stack,
+      });
+    }
+
+    // Confirmation SMS — the opt-in and Cognito-resolved phone are only present
+    // once the booking is completed, so this is the correct dispatch point.
+    try {
+      await enqueueSmsReminderIfNeeded(
+        smsParams,
+        { bookingId },
+        smsParams?.namedOccupant?.contactInfo?.mobilePhone
+      );
+    } catch (smsError) {
+      logger.error("Booking completed but confirmation SMS enqueue failed", {
+        bookingId,
+        error: smsError?.message,
+        stack: smsError?.stack,
       });
     }
 

--- a/src/handlers/bookings/methods.js
+++ b/src/handlers/bookings/methods.js
@@ -1235,14 +1235,29 @@ async function completeBooking(bookingId, sessionId, props, { sub } = {}) {
 
     const emailParams = await generateEmailParams(completeBookingForEmail);
 
-    // Return the update + email params for the handler to commit and dispatch
-    // in that order. We intentionally do NOT send the email here: the SQS
-    // enqueue must happen *after* batchTransactData succeeds, otherwise a
-    // failed DynamoDB write would leave the user with a confirmation email
-    // for a booking that was never saved.
+    // SMS confirmation params, dispatched by the handler alongside the email.
+    // The opt-in flag arrives with the FE complete request — post-#404 the FE
+    // no longer sends identity/opt-in fields at create — so prefer it here and
+    // fall back to the value captured on the booking record for server-side
+    // completions. The phone is the Cognito-resolved number now stored on the
+    // finalized booking (completeBookingForEmail.namedOccupant.contactInfo).
+    const smsParams = {
+      ...completeBookingForEmail,
+      smsOptIn:
+        typeof props?.smsOptIn === 'boolean'
+          ? props.smsOptIn
+          : Boolean(completeBookingForEmail?.smsOptIn),
+    };
+
+    // Return the update + notification params for the handler to commit and
+    // dispatch in that order. We intentionally do NOT send the email/SMS here:
+    // the SQS enqueue must happen *after* batchTransactData succeeds, otherwise
+    // a failed DynamoDB write would leave the user with a confirmation for a
+    // booking that was never saved.
     return {
       updateRequests: bookingUpdateRequest,
       emailParams,
+      smsParams,
     };
 
 

--- a/test/booking/sms-reminder.test.js
+++ b/test/booking/sms-reminder.test.js
@@ -1,0 +1,65 @@
+// Unit tests for the booking confirmation SMS enqueue. Issue #570: the SMS
+// opt-in and Cognito-resolved phone only exist once a booking is completed,
+// so the enqueue must run at the complete step. These tests pin the dispatch
+// gate (opt-in + phone) and the request-vs-fallback phone resolution.
+
+jest.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: jest.fn(() => ({ send: jest.fn().mockResolvedValue({ MessageId: 'msg-1' }) })),
+  SendMessageCommand: jest.fn((params) => ({ params })),
+}));
+
+const { SendMessageCommand } = require('@aws-sdk/client-sqs');
+const { enqueueSmsReminderIfNeeded } = require('../../src/handlers/bookings/notifications');
+
+const QUEUE_URL = 'https://sqs.ca-central-1.amazonaws.com/123456789012/sms-reminder';
+
+describe('enqueueSmsReminderIfNeeded', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SMS_REMINDER_QUEUE_URL = QUEUE_URL;
+  });
+
+  const baseBody = {
+    smsOptIn: true,
+    namedOccupant: { contactInfo: { mobilePhone: '7787000371' } },
+    startDate: '2026-06-18',
+    activityType: 'dayuse',
+    displayName: 'Joffre Lakes Day-use Pass - All day, 2026-06-18',
+  };
+
+  it('does not enqueue when smsOptIn is false', async () => {
+    await enqueueSmsReminderIfNeeded({ ...baseBody, smsOptIn: false }, { bookingId: 'b1' });
+    expect(SendMessageCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue when no mobile phone is available', async () => {
+    const noPhone = { ...baseBody, namedOccupant: { contactInfo: {} } };
+    await enqueueSmsReminderIfNeeded(noPhone, { bookingId: 'b1' }, null);
+    expect(SendMessageCommand).not.toHaveBeenCalled();
+  });
+
+  it('enqueues an SMS with the booking id and phone when opted in', async () => {
+    await enqueueSmsReminderIfNeeded(baseBody, { bookingId: 'b-123' });
+    expect(SendMessageCommand).toHaveBeenCalledTimes(1);
+    const { QueueUrl, MessageBody } = SendMessageCommand.mock.calls[0][0];
+    expect(QueueUrl).toBe(QUEUE_URL);
+    const payload = JSON.parse(MessageBody);
+    expect(payload.bookingId).toBe('b-123');
+    expect(payload.mobilePhone).toBe('7787000371');
+    expect(payload.smsOptIn).toBe(true);
+  });
+
+  it('falls back to the resolved phone when the body omits one', async () => {
+    const noBodyPhone = { ...baseBody, namedOccupant: { contactInfo: {} } };
+    await enqueueSmsReminderIfNeeded(noBodyPhone, { bookingId: 'b-9' }, '7780001111');
+    expect(SendMessageCommand).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(SendMessageCommand.mock.calls[0][0].MessageBody);
+    expect(payload.mobilePhone).toBe('7780001111');
+  });
+
+  it('skips quietly when the queue URL is not configured', async () => {
+    delete process.env.SMS_REMINDER_QUEUE_URL;
+    await enqueueSmsReminderIfNeeded(baseBody, { bookingId: 'b1' });
+    expect(SendMessageCommand).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Ticket:

#570

### Description:

Move the confirmation SMS enqueue from the create handler (where `smsOptIn` is always false) to booking completion, alongside the email. Adds a dispatch-gate test.
