### PR TITLE
fix(waiting-room): add CORS preflight to admin waiting-room API resources

### DIFF
--- a/src/handlers/waiting-room/admin/constructs.js
+++ b/src/handlers/waiting-room/admin/constructs.js
@@ -135,6 +135,16 @@ class AdminWaitingRoomConstruct extends LambdaConstruct {
     // /waiting-room/mode2/release
     const mode2ReleaseResource = mode2Resource.addResource('release');
     mode2ReleaseResource.addMethod('POST', new apigw.LambdaIntegration(this.releaseMode2Function), authOptions);
+
+    this.addCorsPreflightForResources([
+      wrResource,
+      queuesResource,
+      queueResource,
+      closeResource,
+      metricsResource,
+      mode2Resource,
+      mode2ReleaseResource,
+    ]);
   }
 }
 


### PR DESCRIPTION
### Description:
Added CORS preflight to the admin waiting-room API routes in reserve-rec-api, which was causing the "Failed to load queues" 403 error when setting up on localhost. 

Once merged the sandbox redeploy should fix the admin waiting-room api and waiting room loads.
