### PR TITLE
fix(bookings): wire SMS reminder queue to booking-complete Lambda

### DIFF
--- a/lib/public-api-stack/public-api-stack.js
+++ b/lib/public-api-stack/public-api-stack.js
@@ -469,24 +469,25 @@ class PublicApiStack extends BaseStack {
           this.getConstructId('publicBookingsConstruct'),
           bookingsProps,
         );
-        // Add waiting room and SMS reminder props to the booking POST Lambda
+        // Add waiting room props to the booking POST Lambda
         this.publicBookingsConstruct.bookingsPostFunction.addEnvironment(
           'WAITING_ROOM_TABLE_NAME', scope.resolveWaitingRoomTableName()
         );
         this.publicBookingsConstruct.bookingsPostFunction.addEnvironment(
           'HMAC_SIGNING_KEY_ARN', scope.resolveHmacSigningKeyArn()
         );
-        this.publicBookingsConstruct.bookingsPostFunction.addEnvironment(
-          'SMS_REMINDER_QUEUE_URL', smsReminderQueueUrl
-        );
         scope.getWaitingRoomTable().grantReadData(this.publicBookingsConstruct.bookingsPostFunction);
         scope.getHmacSigningKey().grantRead(this.publicBookingsConstruct.bookingsPostFunction);
-        this.publicBookingsConstruct.bookingsPostFunction.addToRolePolicy(new iam.PolicyStatement({
+        // Wire the email dispatch and SMS reminder queues to the booking-complete
+        // Lambda. The confirmation SMS is dispatched at completion (not create),
+        // so the SMS queue must be wired here.
+        this.publicBookingsConstruct.bookingsCompleteFunction.addEnvironment(
+          'SMS_REMINDER_QUEUE_URL', smsReminderQueueUrl
+        );
+        this.publicBookingsConstruct.bookingsCompleteFunction.addToRolePolicy(new iam.PolicyStatement({
           actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
           resources: [smsReminderQueueArn],
         }));
-        // Wire the email dispatch queue to the booking-complete Lambda so it can
-        // enqueue confirmation emails.
         this.publicBookingsConstruct.bookingsCompleteFunction.addEnvironment(
           'EMAIL_QUEUE_URL', emailQueueUrl
         );

--- a/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
+++ b/lib/public-api-stack/public-bookings-nested-stack/public-bookings-nested-stack.js
@@ -45,7 +45,7 @@ class PublicBookingsNestedStack extends NestedStack {
       activitiesActivityIdResourceId: props.activitiesActivityIdResourceId,
     });
 
-    // Add waiting room and SMS reminder props to the bookings POST Lambda
+    // Add waiting room props to the bookings POST Lambda
     const postFn = this.publicBookingsConstruct.bookingsPostFunction;
 
     if (props.waitingRoomTableName) {
@@ -54,25 +54,27 @@ class PublicBookingsNestedStack extends NestedStack {
     if (props.hmacSigningKeyArn) {
       postFn.addEnvironment('HMAC_SIGNING_KEY_ARN', props.hmacSigningKeyArn);
     }
-    if (props.smsReminderQueueUrl) {
-      postFn.addEnvironment('SMS_REMINDER_QUEUE_URL', props.smsReminderQueueUrl);
-    }
     if (props.waitingRoomTable) {
       props.waitingRoomTable.grantReadData(postFn);
     }
     if (props.hmacSigningKey) {
       props.hmacSigningKey.grantRead(postFn);
     }
+
+    // Wire the email dispatch and SMS reminder queues to the booking-complete
+    // Lambda so it can enqueue the confirmation email and SMS. The confirmation
+    // SMS is dispatched at completion (not create), so the SMS queue must be
+    // wired here — where smsOptIn and the resolved phone are available.
+    const completeFn = this.publicBookingsConstruct.bookingsCompleteFunction;
+    if (props.smsReminderQueueUrl) {
+      completeFn.addEnvironment('SMS_REMINDER_QUEUE_URL', props.smsReminderQueueUrl);
+    }
     if (props.smsReminderQueueArn) {
-      postFn.addToRolePolicy(new iam.PolicyStatement({
+      completeFn.addToRolePolicy(new iam.PolicyStatement({
         actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
         resources: [props.smsReminderQueueArn],
       }));
     }
-
-    // Wire the email dispatch queue to the booking-complete Lambda so it can
-    // enqueue confirmation emails.
-    const completeFn = this.publicBookingsConstruct.bookingsCompleteFunction;
     if (props.emailQueueUrl) {
       completeFn.addEnvironment('EMAIL_QUEUE_URL', props.emailQueueUrl);
     }


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#570

### Description:

- The confirmation SMS enqueue was moved to the booking-complete handler (#427), but the `SMS_REMINDER_QUEUE_URL` env var and SQS send grant were left wired to the booking-**create** Lambda.
- As a result the complete handler logged `SMS reminder enqueue skipped: queue URL not configured` and never enqueued — verified in TEST logs for the QA bookings (smsOptIn:true and phone both present; only the queue URL was missing).
- Move the env var + send grant to the complete Lambda in both the nested-stack and local/SAM wiring paths. Synth confirms `SMS_REMINDER_QUEUE_URL` now lands on BookingsCompletePOST and is gone from BookingsPOST.
- Note: End User Messaging on the account is still in sandbox ($1/mo cap) — fine for whitelisted QA numbers, but production access is needed before broader testing/prod.