### PR TITLE
fix(waiting-room) : waiting room summary for the Mode 2 resetting after reactivation.

### DIFF
--- a/src/handlers/waiting-room/admin/toggle-mode2.js
+++ b/src/handlers/waiting-room/admin/toggle-mode2.js
@@ -7,7 +7,7 @@ const {
   UpdateFunctionCommand,
   PublishFunctionCommand,
 } = require('@aws-sdk/client-cloudfront');
-const { putQueueMeta, updateQueueMetaStatus, scanQueuesByStatus, queryQueueEntries } = require('../utils/dynamodb');
+const { putQueueMeta, updateQueueMetaStatus, scanQueuesByStatus, getQueueMeta } = require('../utils/dynamodb');
 
 const REGION = 'us-east-1'; // CloudFront is a global service, API endpoint is us-east-1
 
@@ -111,12 +111,15 @@ exports.handler = async (event) => {
     const now = Math.floor(Date.now() / 1000);
 
     if (body.active) {
-      // Count existing waiting entries so totalEntries is correct on re-activation
-      // (re-joining users return early from the join handler without incrementing the counter).
-      const existingEntries = await queryQueueEntries(queueId, { statuses: ['waiting', 'admitting', 'admitted'] });
-      const totalEntries = existingEntries.length;
+      // Re-activating an existing same-day queue must preserve its counters —
+      // entries (and their admitted status) survive across activate/deactivate
+      // cycles, so recomputing/zeroing here would desync the meta from reality.
+      // Only a brand-new queue (no prior meta) starts at 0/0.
+      const existingMeta = await getQueueMeta(queueId);
+      const totalEntries = existingMeta?.totalEntries ?? 0;
+      const admittedCount = existingMeta?.admittedCount ?? 0;
 
-      // Create (or reset) the Mode 2 queue in 'releasing' state.
+      // Create (or reactivate) the Mode 2 queue in 'releasing' state.
       // Use unconditional put so re-activation on the same day works cleanly.
       await putQueueMeta({
         pk: queueId,
@@ -125,12 +128,12 @@ exports.handler = async (event) => {
         batchSize,
         releaseIntervalSeconds,
         releaseMode,
-        lastReleasedAt: 0,
+        lastReleasedAt: existingMeta?.lastReleasedAt ?? 0,
         totalEntries,
-        admittedCount: 0,
+        admittedCount,
         facilityKey: `${MODE2_COLLECTION_ID}#${MODE2_ACTIVITY_TYPE}#${MODE2_ACTIVITY_ID}`,
-        openingTime: new Date().toISOString(), // used by join handler for TTL calc
-        createdAt: now,
+        openingTime: existingMeta?.openingTime ?? new Date().toISOString(), // used by join handler for TTL calc
+        createdAt: existingMeta?.createdAt ?? now,
         updatedAt: now,
       });
       logger.info(`Mode 2 queue created: ${queueId} (batchSize=${batchSize}, interval=${releaseIntervalSeconds}s, releaseMode=${releaseMode})`);


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/264

### Description
- cause: toggle-mode2.js activate path always hardcoded admittedCount: 0 and recomputed totalEntries via a query, then did an unconditional overwrite of the queue meta. Since queryQueueEntries uses eventually-consistent reads, an occasional stale/empty result would wipe totalEntries to 0 too — while the real entries (visible in the per-queue breakdown) stayed intact.
- fix: On activate, read existing queue meta first and carry forward totalEntries, admittedCount, lastReleasedAt, openingTime, createdAt if present. Only initialize a queue at 0/0 when no prior meta exists (true first-time creation for that day).
