### PR TITLE
PRDT-297 : Implementing soft delete [WIP]

### DIFF
--- a/src/handlers/activities/_collectionId/DELETE/admin.js
+++ b/src/handlers/activities/_collectionId/DELETE/admin.js
@@ -33,8 +33,9 @@ exports.handler = async (event, context) => {
     const relationshipResult = await deleteEntityRelationships(pk, sk);
     logger.info(`Deleted ${relationshipResult.deletedCount} relationships`);
 
-    // Then delete the activity itself
-    const deleteItem = createDeleteCommand(collectionId, activityType, activityId);
+    // Then soft-delete the activity itself (keep the row, mark it deleted so it's hidden)
+    const user = authContext?.sub || "system";
+    const deleteItem = createSoftDeleteCommand(collectionId, activityType, activityId, user);
 
     const res = await batchTransactData([deleteItem]);
     
@@ -54,17 +55,23 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(collectionId, activityType, activityId) {
+function createSoftDeleteCommand(collectionId, activityType, activityId, user) {
   // Use sk if provided in a batch request, otherwise there won't be an sk
   // so use the pathParams to create sk
   const sortKey = `${activityType}::${activityId}`;
   return {
-    action: "Delete",
+    action: "Update",
     data: {
       TableName: REFERENCE_DATA_TABLE_NAME,
       Key: marshall({
         pk: `activity::${collectionId}`,
         sk: sortKey,
+      }),
+      UpdateExpression: "SET isDeleted = :true, deletedAt = :deletedAt, deletedBy = :deletedBy",
+      ExpressionAttributeValues: marshall({
+        ":true": true,
+        ":deletedAt": new Date().toISOString(),
+        ":deletedBy": user,
       }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",
     },

--- a/src/handlers/activities/methods.js
+++ b/src/handlers/activities/methods.js
@@ -1,4 +1,4 @@
-const { REFERENCE_DATA_TABLE_NAME, batchGetData, runQuery, getOne, marshall, incrementCounter } = require("/opt/dynamodb");
+const { REFERENCE_DATA_TABLE_NAME, batchGetData, runQuery, getOne, marshall, incrementCounter, excludeDeletedItems } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("./configs");
 /**
@@ -81,6 +81,7 @@ async function getActivitiesByCollectionId(collectionId, filters, params = null)
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Activities: ${res?.items?.length} found.`);
@@ -134,6 +135,7 @@ async function getActivitiesByActivityType(
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Activities: ${res?.items?.length} found.`);
@@ -166,6 +168,10 @@ async function getActivityByActivityId(collectionId, activityType, activityId, f
       `activity::${collectionId}`,
       `${activityType}::${activityId}`
     );
+    // Soft-deleted activities are treated as not found
+    if (res?.isDeleted) {
+      return null;
+    }
     // if (fetchGeozones && res?.geozone?.pk && res?.geozone?.sk) {
     //   const geozone = await getOne(res.geozone.pk, res.geozone.sk);
     //   res.geozone = geozone;

--- a/src/handlers/dynamoStream/refDataStream.js
+++ b/src/handlers/dynamoStream/refDataStream.js
@@ -81,12 +81,20 @@ exports.handler = async function (event, context) {
       switch (record.eventName) {
         case 'MODIFY':
         case 'INSERT': {
-          // Upsert document (update if exists, create if not).
           const doc = {
             ...unmarshall(newImage),
           };
           doc['id'] = openSearchId;
 
+          // Soft-deleted items stay in DynamoDB but must not appear in search.
+          // Remove them from the index instead of upserting.
+          if (doc.isDeleted) {
+            refDataIndexDeleteDocs.push({ id: openSearchId });
+            logger.debug(`Removing soft-deleted item from index: ${openSearchId}`);
+            break;
+          }
+
+          // Upsert document (update if exists, create if not).
           // put doc by index, based on schema
           refDataIndexUpsertDocs.push(doc);
           logger.debug(JSON.stringify(doc));

--- a/src/handlers/facilities/_collectionId/DELETE/admin.js
+++ b/src/handlers/facilities/_collectionId/DELETE/admin.js
@@ -30,8 +30,9 @@ exports.handler = async (event, context) => {
     const relationshipResult = await deleteEntityRelationships(pk, sk);
     logger.info(`Deleted ${relationshipResult.deletedCount} relationships`);
 
-    // Then delete the facility itself
-    const deleteItem = createDeleteCommand(collectionId, facilityType, facilityId);
+    // Then soft-delete the facility itself (keep the row, mark it deleted so it's hidden)
+    const user = event?.requestContext?.authorizer?.principalId || "system";
+    const deleteItem = createSoftDeleteCommand(collectionId, facilityType, facilityId, user);
 
     const res = await batchTransactData([deleteItem]);
     
@@ -51,17 +52,23 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(collectionId, facilityType, facilityId, sk = undefined) {
+function createSoftDeleteCommand(collectionId, facilityType, facilityId, user, sk = undefined) {
   // Use sk if provided in a batch request, otherwise there won't be an sk
   // so use the pathParams to create sk
   const sortKey = sk || `${facilityType}::${facilityId}`;
   return {
-    action: "Delete",
+    action: "Update",
     data: {
       TableName: REFERENCE_DATA_TABLE_NAME,
       Key: marshall({
         pk: `facility::${collectionId}`,
         sk: sortKey,
+      }),
+      UpdateExpression: "SET isDeleted = :true, deletedAt = :deletedAt, deletedBy = :deletedBy",
+      ExpressionAttributeValues: marshall({
+        ":true": true,
+        ":deletedAt": new Date().toISOString(),
+        ":deletedBy": user,
       }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",
     },

--- a/src/handlers/facilities/methods.js
+++ b/src/handlers/facilities/methods.js
@@ -5,6 +5,7 @@ const {
   getOne,
   marshall,
   incrementCounter,
+  excludeDeletedItems,
 } = require("/opt/dynamodb");
 const { Exception, logger, filterByRole, effectiveCollectionRole } = require("/opt/base");
 const { ALLOWED_FILTERS, ROLE_BASED_FILTERS } = require("./configs");
@@ -91,6 +92,7 @@ async function getFacilitiesByCollectionId(
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Facilities: ${res?.items?.length} found.`);
@@ -144,6 +146,7 @@ async function getFacilitiesByFacilityType(
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Facilities: ${res?.items?.length} found.`);
@@ -182,6 +185,10 @@ async function getFacilityByFacilityId(
       `facility::${collectionId}`,
       `${facilityType}::${facilityId}`,
     );
+    // Soft-deleted facilities are treated as not found
+    if (res?.isDeleted) {
+      return null;
+    }
     if (fetchActivities && res) {
       const activityRelationships = await runQuery({
         TableName: REFERENCE_DATA_TABLE_NAME,

--- a/src/handlers/geozones/_collectionId/DELETE/admin.js
+++ b/src/handlers/geozones/_collectionId/DELETE/admin.js
@@ -38,8 +38,9 @@ exports.handler = async (event, context) => {
     
     logger.info(`Deleted ${relCount.deletedCount} relationship(s) for geozone ${pk}::${sk}`);
 
-    // Now delete the geozone itself
-    const deleteItem = createDeleteCommand(pk, sk);
+    // Now soft-delete the geozone itself (keep the row, mark it deleted so it's hidden)
+    const user = event?.requestContext?.authorizer?.principalId || "system";
+    const deleteItem = createSoftDeleteCommand(pk, sk, user);
     const res = await batchTransactData([deleteItem]);
     
     return sendResponse(200, { ...res, relationshipsDeleted: relCount.deletedCount }, "Success", null, context);
@@ -54,12 +55,18 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(pk, sk) {
+function createSoftDeleteCommand(pk, sk, user) {
   return {
-    action: "Delete",
+    action: "Update",
     data: {
       TableName: REFERENCE_DATA_TABLE_NAME,
       Key: marshall({ pk, sk }),
+      UpdateExpression: "SET isDeleted = :true, deletedAt = :deletedAt, deletedBy = :deletedBy",
+      ExpressionAttributeValues: marshall({
+        ":true": true,
+        ":deletedAt": new Date().toISOString(),
+        ":deletedBy": user,
+      }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",
     },
   };

--- a/src/handlers/geozones/methods.js
+++ b/src/handlers/geozones/methods.js
@@ -2,7 +2,8 @@ const {
   REFERENCE_DATA_TABLE_NAME,
   runQuery,
   marshall,
-  incrementCounter
+  incrementCounter,
+  excludeDeletedItems
 } = require("/opt/dynamodb");
 const { Exception, logger } = require("/opt/base");
 const { ALLOWED_FILTERS } = require("./configs");
@@ -86,6 +87,7 @@ async function getGeozonesByCollectionId(
     };
 
     queryObj = addFilters(queryObj, filters);
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
 
@@ -144,6 +146,7 @@ async function getGeozonesByGeozoneId(
     };
 
     queryObj = addFilters(queryObj, filters);
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Geozones: ${res?.items?.length} found.`);

--- a/src/handlers/products/_collectionId/DELETE/admin.js
+++ b/src/handlers/products/_collectionId/DELETE/admin.js
@@ -33,8 +33,9 @@ exports.handler = async (event, context) => {
     const relationshipResult = await deleteEntityRelationships(pk, sk);
     logger.info(`Deleted ${relationshipResult.deletedCount} relationships`);
 
-    // Then delete the product itself
-    const deleteItem = createDeleteCommand(collectionId, activityType, activityId, productId);
+    // Then soft-delete the product itself (keep the row, mark it deleted so it's hidden)
+    const user = authContext?.sub || "system";
+    const deleteItem = createSoftDeleteCommand(collectionId, activityType, activityId, productId, user);
 
     const res = await batchTransactData([deleteItem]);
 
@@ -54,14 +55,20 @@ exports.handler = async (event, context) => {
   }
 };
 
-function createDeleteCommand(collectionId, activityType, activityId, productId) {
+function createSoftDeleteCommand(collectionId, activityType, activityId, productId, user) {
   return {
-    action: "Delete",
+    action: "Update",
     data: {
       TableName: REFERENCE_DATA_TABLE_NAME,
       Key: marshall({
         pk: `product::${collectionId}::${activityType}::${activityId}`,
         sk: `${productId}`,
+      }),
+      UpdateExpression: "SET isDeleted = :true, deletedAt = :deletedAt, deletedBy = :deletedBy",
+      ExpressionAttributeValues: marshall({
+        ":true": true,
+        ":deletedAt": new Date().toISOString(),
+        ":deletedBy": user,
       }),
       ConditionExpression: "attribute_exists(pk) AND attribute_exists(sk)",
     },

--- a/src/handlers/products/methods.js
+++ b/src/handlers/products/methods.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const { TABLE_NAME, REFERENCE_DATA_TABLE_NAME, batchTransactData, runQuery, getOne, parallelizedBatchGetData, marshall, incrementCounter, batchGetData } = require('/opt/dynamodb');
+const { TABLE_NAME, REFERENCE_DATA_TABLE_NAME, batchTransactData, runQuery, getOne, parallelizedBatchGetData, marshall, incrementCounter, batchGetData, excludeDeletedItems } = require('/opt/dynamodb');
 const {
   Exception,
   buildDateRange,
@@ -103,6 +103,7 @@ async function getProductsByCollectionId(collectionId, activityType, activityId,
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Products: ${res?.items?.length} found.`);
@@ -162,6 +163,7 @@ async function getProductsByActivityType(
     if (Object.keys(filters).length > 0) {
       queryObj = addFilters(queryObj, filters);
     }
+    queryObj = excludeDeletedItems(queryObj);
 
     const res = await runQuery(queryObj, limit, lastEvaluatedKey, paginated);
     logger.info(`Products: ${res?.items?.length} found.`);
@@ -206,6 +208,11 @@ async function getProductByProductId(
       `product::${collectionId}::${activityType}::${activityId}`,
       `${productId}`
     );
+
+    // Soft-deleted products are treated as not found
+    if (res?.isDeleted) {
+      return null;
+    }
 
     logger.debug(`Product: ${JSON.stringify(res, null, 2)}`);
     return res;

--- a/src/layers/awsUtils/dynamodb.js
+++ b/src/layers/awsUtils/dynamodb.js
@@ -349,6 +349,30 @@ async function getByGSI(gsiProperty, gsiValue, tableName = REFERENCE_DATA_TABLE_
 }
 
 
+/**
+ * Adds a filter to a query so soft-deleted items are excluded from the results.
+ * A soft-deleted item has `isDeleted = true`. Items that were never deleted either
+ * have no `isDeleted` attribute or have it set to false, so both are kept.
+ *
+ * @param {Object} queryObj - The DynamoDB query object to mutate.
+ * @returns {Object} The same query object with the not-deleted filter applied.
+ */
+function excludeDeletedItems(queryObj) {
+  const notDeletedClause = "(attribute_not_exists(#isDeleted) OR #isDeleted = :notDeleted)";
+  queryObj.FilterExpression = queryObj.FilterExpression
+    ? `(${queryObj.FilterExpression}) AND ${notDeletedClause}`
+    : notDeletedClause;
+  queryObj.ExpressionAttributeNames = {
+    ...queryObj.ExpressionAttributeNames,
+    "#isDeleted": "isDeleted",
+  };
+  queryObj.ExpressionAttributeValues = {
+    ...queryObj.ExpressionAttributeValues,
+    ":notDeleted": { BOOL: false },
+  };
+  return queryObj;
+}
+
 async function runQuery(query, limit = null, lastEvaluatedKey = null, paginated = true) {
   let data = [];
   let pageData = {};
@@ -660,6 +684,7 @@ module.exports = {
   deleteItem,
   dynamodb,
   dynamodbClient,
+  excludeDeletedItems,
   getOne,
   incrementCounter,
   getOneByGlobalId,

--- a/test/integration/geozones.test.js
+++ b/test/integration/geozones.test.js
@@ -106,9 +106,19 @@ describe("Geozones", () => {
     it("returns 200 for the deleted geozone", async () => {
       if (!createdGeozoneId) return;
       const res = await client.delete(`/geozones/${TEST_COLLECTION_ID}/${createdGeozoneId}`);
-      
+
       expect(res.data.msg).toEqual('Success');
       expect(res.status).toBe(200);
+    });
+
+    // Soft delete: the geozone row stays in DynamoDB but must no longer be
+    // returned by the read endpoints.
+    it("no longer returns the geozone after a soft delete", async () => {
+      if (!createdGeozoneId) return;
+      const res = await client.get(
+        `/geozones/${TEST_COLLECTION_ID}/${createdGeozoneId}`,
+      );
+      expect(res.data.data.items).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/297

### Description:
  Switch inventory deletes (geozone, facility, activity, product) from
  hard delete to soft delete.

Why
  Per June 23 refinement (#297): deleting an item should not remove its
  associated inventory. Soft delete keeps the row, hides it from the app.

Changes
  - DELETE handlers set `isDeleted`/`deletedAt`/`deletedBy` via Update
    instead of removing the row.
  - New `excludeDeletedItems()` helper filters soft-deleted items out of
    list queries; get-by-id returns null for deleted items.
  - `refDataStream` removes soft-deleted items from OpenSearch so they
    don't show in public search.