### PR TITLE
feat(identity): email as unique sign-in identity for public pool

### DIFF
--- a/lib/public-identity-stack/public-identity-stack.js
+++ b/lib/public-identity-stack/public-identity-stack.js
@@ -207,6 +207,11 @@ class PublicIdentityStack extends BaseStack {
             sesVerifiedDomain: this.getConfigValue('userPoolSesVerifiedDomain'),
           })
         : undefined,
+      // Email is the sign-in identity (no separate username). This also makes
+      // email unique across the pool (Ref reserve-rec-public#561). Note: sign-in
+      // config is immutable on an existing pool, so applying this replaces the pool.
+      signInAliases: { email: true },
+      signInCaseSensitive: false,
       autoVerify: { email: true },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       userVerification: {


### PR DESCRIPTION
### Ticket:
bcgov/reserve-rec-public#561

### Description:
- `signInAliases: { email: true }` on the public pool → email is the unique sign-in identity. Admin pool untouched.
- Deploy note: replaces the public pool (wipes dev/test users; drops the #63 `custom:unitNumber` — re-add after deploy).