### PR TITLE
revert: email sign-in on public pool (unblock dev deploy) (#561)

### DIFF
--- a/lib/public-identity-stack/public-identity-stack.js
+++ b/lib/public-identity-stack/public-identity-stack.js
@@ -207,11 +207,6 @@ class PublicIdentityStack extends BaseStack {
             sesVerifiedDomain: this.getConfigValue('userPoolSesVerifiedDomain'),
           })
         : undefined,
-      // Email is the sign-in identity (no separate username). This also makes
-      // email unique across the pool (Ref reserve-rec-public#561). Note: sign-in
-      // config is immutable on an existing pool, so applying this replaces the pool.
-      signInAliases: { email: true },
-      signInCaseSensitive: false,
       autoVerify: { email: true },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       userVerification: {


### PR DESCRIPTION
### Ticket:
bcgov/reserve-rec-public#561

### Description:
- Reverts #438. `signInAliases: { email: true }` on the existing public pool makes CloudFormation attempt an in-place `UsernameAttributes` update, which Cognito rejects ("Updates are not allowed for property - UsernameAttributes") — **every dev deploy fails at PublicIdentityStack**. Reverting to unblock the pipeline.
- Email-as-sign-in requires a **new pool** (new construct/logical ID) + SSM/client rewiring + user migration; re-scoping #561 for that.

Ref bcgov/reserve-rec-public#561