### PR TITLE
feat(identity): email sign-in via new versioned public pool (#561)

### DIFF
--- a/lib/public-identity-stack/public-identity-stack.js
+++ b/lib/public-identity-stack/public-identity-stack.js
@@ -6,6 +6,13 @@ const { BaseStack } = require('../helpers/base-stack');
 const iam = require('aws-cdk-lib/aws-iam');
 const publicRoles = require('./public-roles.json');
 
+// Sign-in config (signInAliases) is immutable on an existing Cognito pool, so
+// switching the public pool to email sign-in requires a NEW pool. Bump this
+// version to force CloudFormation to create a fresh pool + domain (the old ones
+// are removed per removalPolicy) instead of an illegal in-place update.
+// Ref reserve-rec-public#561.
+const PUBLIC_POOL_VERSION = 'v2';
+
 // Load CSS file for Cognito User Pool UI customization
 const fs = require('fs');
 const path = require('path');
@@ -31,7 +38,7 @@ const defaults = {
       name: 'UserPoolDomain',
     },
     publicUserPool: {
-      name: 'PublicUserPool',
+      name: `PublicUserPool-${PUBLIC_POOL_VERSION}`,
     },
     publicUserGroup: {
       name: 'PublicUserGroup',
@@ -193,9 +200,14 @@ class PublicIdentityStack extends BaseStack {
     // to verified recipients.
     const userPoolFromEmail = this.getConfigValue('userPoolFromEmail');
 
-    // Create a public Cognito User Pool
+    // Create a public Cognito User Pool. Its construct name carries the pool
+    // version (see PUBLIC_POOL_VERSION) so email sign-in lands on a fresh pool
+    // (new logical id → replacement) rather than an illegal in-place update.
     this.publicUserPool = new cognito.UserPool(this, this.getConstructId('publicUserPool'), {
       userPoolName: this.getConstructId('publicUserPool'),
+      // Email is the sign-in identity (no username) and is unique across the pool.
+      signInAliases: { email: true },
+      signInCaseSensitive: false,
       email: userPoolFromEmail
         ? cognito.UserPoolEmail.withSES({
             fromEmail: userPoolFromEmail,
@@ -207,11 +219,6 @@ class PublicIdentityStack extends BaseStack {
             sesVerifiedDomain: this.getConfigValue('userPoolSesVerifiedDomain'),
           })
         : undefined,
-      // Email is the sign-in identity (no separate username). This also makes
-      // email unique across the pool (Ref reserve-rec-public#561). Note: sign-in
-      // config is immutable on an existing pool, so applying this replaces the pool.
-      signInAliases: { email: true },
-      signInCaseSensitive: false,
       autoVerify: { email: true },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       userVerification: {
@@ -450,7 +457,9 @@ class PublicIdentityStack extends BaseStack {
 
   createDomainPrefix() {
     const prefix = this.getConfigValue('domainPrefix');
-    return `${prefix}-${this.getDeploymentName()}`.toLowerCase();
+    // Include the pool version so the new pool's hosted-UI domain doesn't collide
+    // with the old pool's domain during replacement (Ref reserve-rec-public#561).
+    return `${prefix}-${PUBLIC_POOL_VERSION}-${this.getDeploymentName()}`.toLowerCase();
   }
 
   getPublicIdentityPoolId() {


### PR DESCRIPTION
### Ticket:
bcgov/reserve-rec-public#561

### Description:
- Supersedes the reverts (#442). #438 failed because Cognito rejects an in-place `UsernameAttributes` change. This bumps a `PUBLIC_POOL_VERSION` that versions the pool construct name + hosted-UI domain, so CFN creates a **fresh** pool with `signInAliases: { email: true }` (email = unique sign-in) and removes the old one — a clean replacement, no illegal update, no domain collision.
- Replaces the public pool → wipes dev/test users (pre-prod, acceptable); SSM exports repoint downstream stacks. Pairs with the already-merged FE email-login (reserve-rec-public#625).

Ref bcgov/reserve-rec-public#561