### PR TITLE
PRDT: Purge use of cognitoSub for userId

### DIFF
--- a/lib/waiting-room-stack/waiting-room-stack.js
+++ b/lib/waiting-room-stack/waiting-room-stack.js
@@ -103,8 +103,8 @@ class WaitingRoomStack extends BaseStack {
 
     // GSI: look up all queue entries for a specific Cognito user
     this.waitingRoomTable.addGlobalSecondaryIndex({
-      indexName: 'cognitoSub-index',
-      partitionKey: { name: 'cognitoSub', type: dynamodb.AttributeType.STRING },
+      indexName: 'userId-index',
+      partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL,
     });
@@ -220,7 +220,7 @@ class WaitingRoomStack extends BaseStack {
     // API Gateway WebSocket API
     // -------------------------------------------------------------------------
 
-    // Lambda authorizer — validates JWT on $connect, passes cognitoSub+queueId in context
+    // Lambda authorizer — validates JWT on $connect, passes userId+queueId in context
     const wsLambdaAuthorizer = new WebSocketLambdaAuthorizer(
       this.getConstructId('wsLambdaAuthorizer'),
       this.wsAuthorizerLambda,

--- a/src/handlers/authorizers/admin.js
+++ b/src/handlers/authorizers/admin.js
@@ -170,7 +170,7 @@ exports.handler = async function (event, context, callback) {
             isAuthenticated: 'true',
             isAdmin: 'true',
             permissions: JSON.stringify({ superadmin: 'superadmin' }),
-            cognitoSub: sub,
+            userId: sub,
             username: payload.username || '',
           }
         };
@@ -224,7 +224,7 @@ exports.handler = async function (event, context, callback) {
         context: {
           isAuthenticated: 'true',
           permissions: JSON.stringify(permissions),
-          cognitoSub: sub,
+          userId: sub,
           username: payload.username || '',
         }
       };

--- a/src/handlers/bookings/GET/admin.js
+++ b/src/handlers/bookings/GET/admin.js
@@ -1,6 +1,6 @@
 // Search bookings by various filters - POST /bookings/admin/search
 
-const { logger, sendResponse, getRequestClaimsFromEvent, Exception, handleCORS, checkAuthContext} = require("/opt/base");
+const { logger, sendResponse, Exception, handleCORS, checkAuthContext} = require("/opt/base");
 const {
   getBookingByBookingId,
   validateAdminRequirements,

--- a/src/handlers/featureFlags/PUT/admin.js
+++ b/src/handlers/featureFlags/PUT/admin.js
@@ -40,7 +40,7 @@ exports.handler = async (event, context) => {
       flags: body.flags,
       metadata: {
         lastUpdated: timestamp,
-        updatedBy: authContext.cognitoSub || 'unknown',
+        updatedBy: authContext.userId || 'unknown',
         updatedByUsername: authContext.username || 'unknown'
       },
       version: (currentConfig?.version || 0) + 1
@@ -55,13 +55,13 @@ exports.handler = async (event, context) => {
 
     // Write audit log
     await writeAuditLog(
-      authContext.cognitoSub,
+      authContext.userId,
       'featureFlags',
       'FEATURE_FLAGS_UPDATE',
       {
         previousFlags,
         newFlags: body.flags,
-        changedBy: authContext.username || authContext.cognitoSub,
+        changedBy: authContext.username || authContext.userId,
         timestamp
       },
       marshall,
@@ -69,7 +69,7 @@ exports.handler = async (event, context) => {
       AUDIT_TABLE_NAME
     );
 
-    logger.info('Feature flags updated successfully', { updatedBy: authContext.cognitoSub, newFlags: body.flags });
+    logger.info('Feature flags updated successfully', { updatedBy: authContext.userId, newFlags: body.flags });
 
     return sendResponse(200, {
       flags: updatedConfig.flags,

--- a/src/handlers/waiting-room/admin/close-queue.js
+++ b/src/handlers/waiting-room/admin/close-queue.js
@@ -32,7 +32,7 @@ exports.handler = async (event) => {
     let abandonedCount = 0;
 
     for (const entry of activeEntries) {
-      await updateQueueEntryStatus(entry.pk, entry.cognitoSub, 'abandoned', null, { abandonedAt: now });
+      await updateQueueEntryStatus(entry.pk, entry.userId, 'abandoned', null, { abandonedAt: now });
       abandonedCount++;
     }
 

--- a/src/handlers/waiting-room/admin/toggle-mode2.js
+++ b/src/handlers/waiting-room/admin/toggle-mode2.js
@@ -154,7 +154,7 @@ exports.handler = async (event) => {
       for (const q of mode2Queues) {
         const activeEntries = await queryQueueEntries(q.pk, { statuses: ['waiting', 'admitting'] });
         for (const entry of activeEntries) {
-          await updateQueueEntryStatus(entry.pk, entry.cognitoSub, 'abandoned', null, { abandonedAt: now });
+          await updateQueueEntryStatus(entry.pk, entry.userId, 'abandoned', null, { abandonedAt: now });
           releasedCount++;
         }
         if (endpoint && activeEntries.length > 0) {

--- a/src/handlers/waiting-room/claim/handler.js
+++ b/src/handlers/waiting-room/claim/handler.js
@@ -15,7 +15,7 @@ exports.handler = async (event, context) => {
     if (!claims || !claims.sub) {
       throw new Exception('Authentication required', { code: 401 });
     }
-    const cognitoSub = claims.sub;
+    const userId = claims.sub;
 
     const body = JSON.parse(event?.body || '{}');
     const { queueId } = body;
@@ -24,7 +24,7 @@ exports.handler = async (event, context) => {
     }
 
     // Get queue entry for this user
-    const entry = await getQueueEntry(queueId, cognitoSub);
+    const entry = await getQueueEntry(queueId, userId);
     if (!entry) {
       throw new Exception('Queue entry not found', { code: 404 });
     }
@@ -52,7 +52,7 @@ exports.handler = async (event, context) => {
     // Generate a fresh HMAC token
     const hmacKey = await getHmacSigningKey();
     const token = generateToken(
-      cognitoSub,
+      userId,
       entry.facilityKey,
       entry.dateKey,
       hmacKey,
@@ -61,7 +61,7 @@ exports.handler = async (event, context) => {
 
     const tokenExpiry = now + ADMISSION_TTL_MINUTES * 60;
 
-    logger.info(`User ${cognitoSub} claimed admission for queue ${queueId}`);
+    logger.info(`User ${userId} claimed admission for queue ${queueId}`);
 
     // Return Set-Cookie header with HttpOnly admission cookie
     return {

--- a/src/handlers/waiting-room/cleanup/handler.js
+++ b/src/handlers/waiting-room/cleanup/handler.js
@@ -51,7 +51,7 @@ exports.handler = async (event, context) => {
     // 1. Expire admitted entries past admissionExpiry
     const expiredAdmitted = await scanExpiredEntries('admitted', 'admissionExpiry', now);
     for (const entry of expiredAdmitted) {
-      const updated = await updateQueueEntryStatus(entry.pk, entry.cognitoSub, 'expired', 'admitted');
+      const updated = await updateQueueEntryStatus(entry.pk, entry.userId, 'expired', 'admitted');
       if (updated) {
         expiredCount++;
         freedQueues.add(entry.pk);
@@ -64,7 +64,7 @@ exports.handler = async (event, context) => {
     const disconnectedEntries = await scanExpiredEntries('waiting', 'disconnectedAt', graceThreshold);
     const abandonedByQueue = {};
     for (const entry of disconnectedEntries) {
-      const updated = await updateQueueEntryStatus(entry.pk, entry.cognitoSub, 'abandoned', 'waiting', {
+      const updated = await updateQueueEntryStatus(entry.pk, entry.userId, 'abandoned', 'waiting', {
         abandonedAt: now,
       });
       if (updated) {
@@ -85,7 +85,7 @@ exports.handler = async (event, context) => {
     const stuckEntries = await scanExpiredEntries('admitting', 'admittedAt', stuckThreshold);
     const recoveredByQueue = {};
     for (const entry of stuckEntries) {
-      const updated = await updateQueueEntryStatus(entry.pk, entry.cognitoSub, 'waiting', 'admitting');
+      const updated = await updateQueueEntryStatus(entry.pk, entry.userId, 'waiting', 'admitting');
       if (updated) {
         recoveredCount++;
         recoveredByQueue[entry.pk] = (recoveredByQueue[entry.pk] || 0) + 1;

--- a/src/handlers/waiting-room/heartbeat/handler.js
+++ b/src/handlers/waiting-room/heartbeat/handler.js
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
     if (!claims || !claims.sub) {
       throw new Exception('Authentication required', { code: 401 });
     }
-    const cognitoSub = claims.sub;
+    const userId = claims.sub;
 
     // Parse and validate the admission cookie
     const cookieHeader = event.headers?.cookie || event.headers?.Cookie || '';
@@ -51,7 +51,7 @@ exports.handler = async (event, context) => {
       };
     }
 
-    if (payload.sid !== cognitoSub) {
+    if (payload.sid !== userId) {
       return {
         statusCode: 403,
         headers: {
@@ -70,7 +70,7 @@ exports.handler = async (event, context) => {
     }
 
     // Verify the queue entry is still admitted
-    const entry = await getQueueEntry(queueId, cognitoSub);
+    const entry = await getQueueEntry(queueId, userId);
     if (!entry || entry.status !== 'admitted') {
       return {
         statusCode: 403,
@@ -88,7 +88,7 @@ exports.handler = async (event, context) => {
 
     // Check absolute max admission time
     if (now >= maxExpiryTime) {
-      await updateQueueEntryStatus(queueId, cognitoSub, 'expired', 'admitted');
+      await updateQueueEntryStatus(queueId, userId, 'expired', 'admitted');
       return {
         statusCode: 403,
         headers: {
@@ -104,10 +104,10 @@ exports.handler = async (event, context) => {
     const newTtlMinutes = Math.ceil((newExpiry - now) / 60);
 
     // Generate refreshed token
-    const newToken = generateToken(cognitoSub, payload.fk, payload.dk, hmacKey, newTtlMinutes);
+    const newToken = generateToken(userId, payload.fk, payload.dk, hmacKey, newTtlMinutes);
 
     // Update DynamoDB — conditional on entry still being 'admitted'
-    const updated = await updateQueueEntryStatus(queueId, cognitoSub, 'admitted', 'admitted', {
+    const updated = await updateQueueEntryStatus(queueId, userId, 'admitted', 'admitted', {
       admissionToken: newToken,
       admissionExpiry: newExpiry,
     });
@@ -124,7 +124,7 @@ exports.handler = async (event, context) => {
       };
     }
 
-    logger.info(`Heartbeat extended admission for ${cognitoSub}, new expiry: ${newExpiry}`);
+    logger.info(`Heartbeat extended admission for ${userId}, new expiry: ${newExpiry}`);
 
     return {
       statusCode: 200,

--- a/src/handlers/waiting-room/join/handler.js
+++ b/src/handlers/waiting-room/join/handler.js
@@ -7,7 +7,7 @@ const {
   getQueueEntry,
   putQueueEntry,
   incrementQueueTotalEntries,
-  queryEntriesByCognitoSub,
+  queryEntriesByUserId,
   queryEntriesByClientIp,
   abandonQueueEntry,
   incrementAbandonedCount,
@@ -25,7 +25,7 @@ exports.handler = async (event, context) => {
     if (!claims || !claims.sub) {
       throw new Exception('Authentication required', { code: 401 });
     }
-    const cognitoSub = claims.sub;
+    const userId = claims.sub;
 
     const body = JSON.parse(event?.body || '{}');
     const { collectionId, activityType, activityId, startDate } = body;
@@ -44,7 +44,7 @@ exports.handler = async (event, context) => {
 
     // Check for existing entry BEFORE checking queue status — an admitted user who
     // reloads the page after queue closes should get their admission status back.
-    const existingEntries = await queryEntriesByCognitoSub(cognitoSub);
+    const existingEntries = await queryEntriesByUserId(userId);
     for (const entry of existingEntries) {
       if (entry.pk === queueId) {
         // Already in this queue — idempotent return (works even if queue is closed)
@@ -57,9 +57,9 @@ exports.handler = async (event, context) => {
         }, 'Already joined this queue');
       }
       // In a different queue — abandon it
-      await abandonQueueEntry(entry.pk, cognitoSub);
+      await abandonQueueEntry(entry.pk, userId);
       await incrementAbandonedCount(entry.pk, 1);
-      logger.info(`Abandoned previous queue entry: ${entry.pk} for user ${cognitoSub}`);
+      logger.info(`Abandoned previous queue entry: ${entry.pk} for user ${userId}`);
     }
 
     // No existing entry — reject if queue is closed
@@ -82,13 +82,13 @@ exports.handler = async (event, context) => {
           const cognitoClient = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION || 'ca-central-1' });
           const userResult = await cognitoClient.send(new AdminGetUserCommand({
             UserPoolId: process.env.COGNITO_USER_POOL_ID,
-            Username: cognitoSub,
+            Username: userId,
           }));
           if (userResult.UserCreateDate) {
             accountCreatedAt = Math.floor(new Date(userResult.UserCreateDate).getTime() / 1000);
           }
         } catch (err) {
-          logger.warn(`Could not fetch account creation time for ${cognitoSub}: ${err.message}. Skipping age check.`);
+          logger.warn(`Could not fetch account creation time for ${userId}: ${err.message}. Skipping age check.`);
         }
       } else {
         logger.warn('MIN_ACCOUNT_AGE_HOURS set but cognito:user_creation_date claim unavailable and COGNITO_USER_POOL_ID not configured — age check skipped');
@@ -129,8 +129,8 @@ exports.handler = async (event, context) => {
 
     const entry = {
       pk: queueId,
-      sk: `ENTRY#${cognitoSub}`,
-      cognitoSub,
+      sk: `ENTRY#${userId}`,
+      userId,
       clientIp,
       facilityKey,
       dateKey: startDate,
@@ -143,7 +143,7 @@ exports.handler = async (event, context) => {
     // Strongly-consistent read before write — the GSI check above is eventually
     // consistent and may miss an active entry created milliseconds earlier.
     // This prevents unconditional PutItem from overwriting an admitted/admitting entry.
-    const existingEntry = await getQueueEntry(queueId, cognitoSub);
+    const existingEntry = await getQueueEntry(queueId, userId);
     if (existingEntry && ['waiting', 'admitting', 'admitted'].includes(existingEntry.status)) {
       return sendResponse(200, {
         queueId,
@@ -159,7 +159,7 @@ exports.handler = async (event, context) => {
     // Increment queue's totalEntries count
     await incrementQueueTotalEntries(queueId);
 
-    logger.info(`User ${cognitoSub} joined queue ${queueId}`);
+    logger.info(`User ${userId} joined queue ${queueId}`);
 
     return sendResponse(200, {
       queueId,

--- a/src/handlers/waiting-room/release/handler.js
+++ b/src/handlers/waiting-room/release/handler.js
@@ -84,14 +84,14 @@ async function handleMode2Release(queueId, queueMeta, force = false) {
   let failCount = 0;
 
   for (const entry of batch) {
-    const cognitoSub = entry.cognitoSub;
+    const userId = entry.userId;
     const admissionExpiry = now + ADMISSION_TTL_MINUTES * 60;
 
-    const token = generateToken(cognitoSub, facilityKey, '', hmacKey, ADMISSION_TTL_MINUTES);
+    const token = generateToken(userId, facilityKey, '', hmacKey, ADMISSION_TTL_MINUTES);
 
-    const set = await setEntryAdmitting(queueId, cognitoSub, token, admissionExpiry);
+    const set = await setEntryAdmitting(queueId, userId, token, admissionExpiry);
     if (!set) {
-      logger.warn(`Mode2: could not set admitting for ${cognitoSub} (status changed)`);
+      logger.warn(`Mode2: could not set admitting for ${userId} (status changed)`);
       failCount++;
       continue;
     }
@@ -100,10 +100,10 @@ async function handleMode2Release(queueId, queueMeta, force = false) {
     // Always mark admitted — if WS push failed the user has no active connection,
     // but they will be admitted on their next page load: the join handler returns
     // status='admitted' which triggers handleAdmission() → claim → redirect.
-    await setEntryAdmitted(queueId, cognitoSub);
+    await setEntryAdmitted(queueId, userId);
     successCount++;
     if (!pushed) {
-      logger.info(`Mode2: admitted ${cognitoSub} without WS push (will claim on next page load)`);
+      logger.info(`Mode2: admitted ${userId} without WS push (will claim on next page load)`);
     }
   }
 
@@ -193,16 +193,16 @@ exports.handler = async (event, context) => {
     let failCount = 0;
 
     for (const entry of batch) {
-      const cognitoSub = entry.cognitoSub;
+      const userId = entry.userId;
       const admissionExpiry = now + ADMISSION_TTL_MINUTES * 60;
 
       // Generate admission token
-      const token = generateToken(cognitoSub, entry.facilityKey, entry.dateKey, hmacKey, ADMISSION_TTL_MINUTES);
+      const token = generateToken(userId, entry.facilityKey, entry.dateKey, hmacKey, ADMISSION_TTL_MINUTES);
 
       // Phase 1: transition to 'admitting' with token
-      const set = await setEntryAdmitting(queueId, cognitoSub, token, admissionExpiry);
+      const set = await setEntryAdmitting(queueId, userId, token, admissionExpiry);
       if (!set) {
-        logger.warn(`Could not set admitting for ${cognitoSub} (status changed)`);
+        logger.warn(`Could not set admitting for ${userId} (status changed)`);
         failCount++;
         continue;
       }
@@ -212,14 +212,14 @@ exports.handler = async (event, context) => {
 
       if (pushed) {
         // Success — transition to 'admitted'
-        await setEntryAdmitted(queueId, cognitoSub);
+        await setEntryAdmitted(queueId, userId);
         successCount++;
       } else {
         // Stale connection — revert to 'waiting' and free the reserved slot
-        await updateQueueEntryStatus(queueId, cognitoSub, 'waiting', 'admitting');
+        await updateQueueEntryStatus(queueId, userId, 'waiting', 'admitting');
         await decrementAdmittedCount(queueId, 1);
         failCount++;
-        logger.info(`Reverted ${cognitoSub} to waiting (no WebSocket connection)`);
+        logger.info(`Reverted ${userId} to waiting (no WebSocket connection)`);
       }
     }
 

--- a/src/handlers/waiting-room/utils/dynamodb.js
+++ b/src/handlers/waiting-room/utils/dynamodb.js
@@ -35,8 +35,8 @@ function buildMetaSk() {
   return 'META';
 }
 
-function buildEntrySk(cognitoSub) {
-  return `ENTRY#${cognitoSub}`;
+function buildEntrySk(userId) {
+  return `ENTRY#${userId}`;
 }
 
 // ─── Queue Meta operations ────────────────────────────────────────────────────
@@ -213,10 +213,10 @@ async function decrementAdmittedCount(queueId, count) {
 /**
  * Reads a Queue Entry record.
  */
-async function getQueueEntry(queueId, cognitoSub) {
+async function getQueueEntry(queueId, userId) {
   const result = await getClient().send(new GetItemCommand({
     TableName: TABLE_NAME,
-    Key: marshall({ pk: queueId, sk: buildEntrySk(cognitoSub) }),
+    Key: marshall({ pk: queueId, sk: buildEntrySk(userId) }),
   }));
   return result.Item ? unmarshall(result.Item) : null;
 }
@@ -235,13 +235,13 @@ async function putQueueEntry(item) {
  * Updates a Queue Entry's status with optional condition.
  *
  * @param {string} queueId
- * @param {string} cognitoSub
+ * @param {string} userId
  * @param {string} newStatus
  * @param {string|null} expectedStatus - If provided, only updates if current status matches
  * @param {object} extraUpdates - Additional SET expressions (attribute: value pairs)
  * @returns {boolean} true if updated, false if condition failed
  */
-async function updateQueueEntryStatus(queueId, cognitoSub, newStatus, expectedStatus = null, extraUpdates = {}) {
+async function updateQueueEntryStatus(queueId, userId, newStatus, expectedStatus = null, extraUpdates = {}) {
   const setExpressions = ['#status = :newStatus', 'updatedAt = :now'];
   const attrNames = { '#status': 'status' };
   const attrValues = {
@@ -257,7 +257,7 @@ async function updateQueueEntryStatus(queueId, cognitoSub, newStatus, expectedSt
 
   const params = {
     TableName: TABLE_NAME,
-    Key: marshall({ pk: queueId, sk: buildEntrySk(cognitoSub) }),
+    Key: marshall({ pk: queueId, sk: buildEntrySk(userId) }),
     UpdateExpression: `SET ${setExpressions.join(', ')}`,
     ExpressionAttributeNames: attrNames,
     ExpressionAttributeValues: marshall(attrValues),
@@ -283,8 +283,8 @@ async function updateQueueEntryStatus(queueId, cognitoSub, newStatus, expectedSt
 /**
  * Sets an entry to 'abandoned' status (used when user joins a new queue).
  */
-async function abandonQueueEntry(queueId, cognitoSub) {
-  return updateQueueEntryStatus(queueId, cognitoSub, 'abandoned', null, {
+async function abandonQueueEntry(queueId, userId) {
+  return updateQueueEntryStatus(queueId, userId, 'abandoned', null, {
     abandonedAt: Math.floor(Date.now() / 1000),
   });
 }
@@ -292,10 +292,10 @@ async function abandonQueueEntry(queueId, cognitoSub) {
 /**
  * Sets disconnectedAt on a Queue Entry (called by WebSocket disconnect handler).
  */
-async function setDisconnectedAt(queueId, cognitoSub) {
+async function setDisconnectedAt(queueId, userId) {
   await getClient().send(new UpdateItemCommand({
     TableName: TABLE_NAME,
-    Key: marshall({ pk: queueId, sk: buildEntrySk(cognitoSub) }),
+    Key: marshall({ pk: queueId, sk: buildEntrySk(userId) }),
     UpdateExpression: 'SET disconnectedAt = :now',
     ExpressionAttributeValues: marshall({ ':now': Math.floor(Date.now() / 1000) }),
   }));
@@ -304,10 +304,10 @@ async function setDisconnectedAt(queueId, cognitoSub) {
 /**
  * Sets a connectionId on a Queue Entry (called by WebSocket connect handler).
  */
-async function setConnectionId(queueId, cognitoSub, connectionId) {
+async function setConnectionId(queueId, userId, connectionId) {
   await getClient().send(new UpdateItemCommand({
     TableName: TABLE_NAME,
-    Key: marshall({ pk: queueId, sk: buildEntrySk(cognitoSub) }),
+    Key: marshall({ pk: queueId, sk: buildEntrySk(userId) }),
     UpdateExpression: 'SET connectionId = :cid REMOVE disconnectedAt',
     ExpressionAttributeValues: marshall({ ':cid': connectionId }),
   }));
@@ -317,8 +317,8 @@ async function setConnectionId(queueId, cognitoSub, connectionId) {
  * Sets an entry to 'admitting' with the admission token.
  * Used by Release Lambda (phase 1 of two-phase admission).
  */
-async function setEntryAdmitting(queueId, cognitoSub, admissionToken, admissionExpiry) {
-  return updateQueueEntryStatus(queueId, cognitoSub, 'admitting', 'waiting', {
+async function setEntryAdmitting(queueId, userId, admissionToken, admissionExpiry) {
+  return updateQueueEntryStatus(queueId, userId, 'admitting', 'waiting', {
     admissionToken,
     admissionExpiry,
     admittedAt: Math.floor(Date.now() / 1000),
@@ -329,8 +329,8 @@ async function setEntryAdmitting(queueId, cognitoSub, admissionToken, admissionE
  * Sets an entry from 'admitting' to 'admitted'.
  * Used by Release Lambda after successful WebSocket push.
  */
-async function setEntryAdmitted(queueId, cognitoSub) {
-  return updateQueueEntryStatus(queueId, cognitoSub, 'admitted', 'admitting');
+async function setEntryAdmitted(queueId, userId) {
+  return updateQueueEntryStatus(queueId, userId, 'admitted', 'admitting');
 }
 
 // ─── Query operations ─────────────────────────────────────────────────────────
@@ -378,23 +378,23 @@ async function queryQueueEntries(queueId, options = {}) {
 }
 
 /**
- * Queries entries for a user across all queues via the cognitoSub GSI.
+ * Queries entries for a user across all queues via the userId GSI.
  * Used for one-queue-at-a-time enforcement.
  *
- * @param {string} cognitoSub
+ * @param {string} userId
  * @param {string[]} activeStatuses - Only return entries with these statuses
  * @returns {Promise<object[]>}
  */
-async function queryEntriesByCognitoSub(cognitoSub, activeStatuses = ['waiting', 'admitting', 'admitted']) {
+async function queryEntriesByUserId(userId, activeStatuses = ['waiting', 'admitting', 'admitted']) {
   const statusPlaceholders = activeStatuses.map((_, i) => `:s${i}`);
 
   const params = {
     TableName: TABLE_NAME,
-    IndexName: 'cognitoSub-index',
-    KeyConditionExpression: 'cognitoSub = :sub',
+    IndexName: 'userId-index',
+    KeyConditionExpression: 'userId = :sub',
     FilterExpression: `#status IN (${statusPlaceholders.join(', ')})`,
     ExpressionAttributeNames: { '#status': 'status' },
-    ExpressionAttributeValues: marshall({ ':sub': cognitoSub }),
+    ExpressionAttributeValues: marshall({ ':sub': userId }),
   };
   for (let i = 0; i < activeStatuses.length; i++) {
     params.ExpressionAttributeValues[`:s${i}`] = { S: activeStatuses[i] };
@@ -521,20 +521,20 @@ async function scanExpiredEntries(status, expiredAttr = null, expiryThreshold = 
 
 // ─── Connection record operations ─────────────────────────────────────────────
 // Stored as pk=CONN#{connectionId}, sk=META
-// Used to look up (queueId, cognitoSub) in the $disconnect handler.
+// Used to look up (queueId, userId) in the $disconnect handler.
 
 /**
- * Writes a connection record mapping connectionId → (queueId, cognitoSub).
+ * Writes a connection record mapping connectionId → (queueId, userId).
  * Called by the WebSocket $connect handler. TTL defaults to 1 hour.
  */
-async function putConnectionRecord(connectionId, queueId, cognitoSub, ttlSeconds = 3600) {
+async function putConnectionRecord(connectionId, queueId, userId, ttlSeconds = 3600) {
   await getClient().send(new PutItemCommand({
     TableName: TABLE_NAME,
     Item: marshall({
       pk: `CONN#${connectionId}`,
       sk: 'META',
       queueId,
-      cognitoSub,
+      userId,
       ttl: Math.floor(Date.now() / 1000) + ttlSeconds,
     }),
   }));
@@ -542,7 +542,7 @@ async function putConnectionRecord(connectionId, queueId, cognitoSub, ttlSeconds
 
 /**
  * Reads a connection record by connectionId.
- * Returns { queueId, cognitoSub } or null.
+ * Returns { queueId, userId } or null.
  */
 async function getConnectionRecord(connectionId) {
   const result = await getClient().send(new GetItemCommand({
@@ -684,7 +684,7 @@ module.exports = {
   setEntryAdmitted,
   // Queries
   queryQueueEntries,
-  queryEntriesByCognitoSub,
+  queryEntriesByUserId,
   queryEntriesByClientIp,
   // Scans
   scanQueuesByStatus,

--- a/src/handlers/waiting-room/websocket/authorizer.js
+++ b/src/handlers/waiting-room/websocket/authorizer.js
@@ -9,7 +9,7 @@ const { CognitoJwtVerifier } = require('aws-jwt-verify');
  * Validates the Cognito JWT passed as a query parameter:
  *   wss://<endpoint>?token=<jwt>&queueId=<queueId>
  *
- * Returns ALLOW policy with { cognitoSub, queueId } in the authorizer context,
+ * Returns ALLOW policy with { userId, queueId } in the authorizer context,
  * which is available to the $connect handler via event.requestContext.authorizer.
  */
 exports.handler = async (event) => {
@@ -51,11 +51,11 @@ exports.handler = async (event) => {
     throw new Error('Unauthorized');
   }
 
-  const cognitoSub = payload.sub;
-  logger.info(`WebSocket auth: authorized ${cognitoSub} for queue ${queueId}`);
+  const userId = payload.sub;
+  logger.info(`WebSocket auth: authorized ${userId} for queue ${queueId}`);
 
   return {
-    principalId: cognitoSub,
+    principalId: userId,
     policyDocument: {
       Version: '2012-10-17',
       Statement: [
@@ -67,7 +67,7 @@ exports.handler = async (event) => {
       ],
     },
     context: {
-      cognitoSub,
+      userId,
       queueId,
     },
   };

--- a/src/handlers/waiting-room/websocket/connect.js
+++ b/src/handlers/waiting-room/websocket/connect.js
@@ -13,7 +13,7 @@ const ACTIVE_STATUSES = ['waiting', 'admitting', 'admitted'];
  * WebSocket $connect handler.
  *
  * Called after the Lambda authorizer approves the connection.
- * The authorizer context provides cognitoSub and queueId.
+ * The authorizer context provides userId and queueId.
  *
  * Responsibilities:
  * 1. Verify user has an active entry in the queue
@@ -25,23 +25,23 @@ exports.handler = async (event) => {
   logger.debug('WebSocket $connect:', JSON.stringify(event));
 
   const connectionId = event.requestContext?.connectionId;
-  const cognitoSub = event.requestContext?.authorizer?.cognitoSub;
+  const userId = event.requestContext?.authorizer?.userId;
   const queueId = event.requestContext?.authorizer?.queueId;
 
-  if (!connectionId || !cognitoSub || !queueId) {
-    logger.error('Connect: missing connectionId, cognitoSub, or queueId', { connectionId, cognitoSub, queueId });
+  if (!connectionId || !userId || !queueId) {
+    logger.error('Connect: missing connectionId, userId, or queueId', { connectionId, userId, queueId });
     return { statusCode: 400 };
   }
 
   try {
     // Verify active queue entry exists
-    const entry = await getQueueEntry(queueId, cognitoSub);
+    const entry = await getQueueEntry(queueId, userId);
     if (!entry) {
-      logger.info(`Connect: no entry for ${cognitoSub} in queue ${queueId}`);
+      logger.info(`Connect: no entry for ${userId} in queue ${queueId}`);
       return { statusCode: 403 };
     }
     if (!ACTIVE_STATUSES.includes(entry.status)) {
-      logger.info(`Connect: entry status '${entry.status}' is not active for ${cognitoSub}`);
+      logger.info(`Connect: entry status '${entry.status}' is not active for ${userId}`);
       return { statusCode: 403 };
     }
 
@@ -53,7 +53,7 @@ exports.handler = async (event) => {
           const { ApiGatewayManagementApiClient, DeleteConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
           const wsClient = new ApiGatewayManagementApiClient({ endpoint });
           await wsClient.send(new DeleteConnectionCommand({ ConnectionId: entry.connectionId }));
-          logger.info(`Disconnected previous connection ${entry.connectionId} for ${cognitoSub}`);
+          logger.info(`Disconnected previous connection ${entry.connectionId} for ${userId}`);
         } catch (err) {
           // Ignore GoneException — old connection is already gone
           logger.debug(`Could not delete previous connection ${entry.connectionId}:`, err.message);
@@ -63,10 +63,10 @@ exports.handler = async (event) => {
 
     // Write connection record first (idempotent by connectionId PK; an orphan from a crash
     // here is cleaned up by TTL in 1h — benign). Then update the queue entry.
-    await putConnectionRecord(connectionId, queueId, cognitoSub);
+    await putConnectionRecord(connectionId, queueId, userId);
 
     // Store new connectionId on the entry (clears disconnectedAt if present)
-    await setConnectionId(queueId, cognitoSub, connectionId);
+    await setConnectionId(queueId, userId, connectionId);
 
     // If user is already admitted, re-push the admitted notification so they
     // can call /claim even if they missed the original push (e.g. reconnect after disconnect)
@@ -87,11 +87,11 @@ exports.handler = async (event) => {
       }
     }
 
-    logger.info(`WebSocket connected: ${connectionId} → ${cognitoSub} in ${queueId}`);
+    logger.info(`WebSocket connected: ${connectionId} → ${userId} in ${queueId}`);
     return { statusCode: 200 };
 
   } catch (err) {
-    logger.error('WebSocket $connect error:', { connectionId, cognitoSub, queueId, error: err.message });
+    logger.error('WebSocket $connect error:', { connectionId, userId, queueId, error: err.message });
     return { statusCode: 500 };
   }
 };

--- a/src/handlers/waiting-room/websocket/disconnect.js
+++ b/src/handlers/waiting-room/websocket/disconnect.js
@@ -14,7 +14,7 @@ const {
  * Does NOT immediately mark the entry as abandoned — the Cleanup Lambda
  * applies the grace period check (disconnectedAt + disconnectGracePeriodSeconds < now).
  *
- * Uses the connection record (written by $connect) to map connectionId → (queueId, cognitoSub).
+ * Uses the connection record (written by $connect) to map connectionId → (queueId, userId).
  */
 exports.handler = async (event) => {
   logger.debug('WebSocket $disconnect:', JSON.stringify(event));
@@ -32,15 +32,15 @@ exports.handler = async (event) => {
       return { statusCode: 200 };
     }
 
-    const { queueId, cognitoSub } = conn;
+    const { queueId, userId } = conn;
 
     // Record disconnect time — Cleanup Lambda will handle grace period
-    await setDisconnectedAt(queueId, cognitoSub);
+    await setDisconnectedAt(queueId, userId);
 
     // Remove the connection record
     await deleteConnectionRecord(connectionId);
 
-    logger.info(`WebSocket disconnected: ${connectionId} (${cognitoSub} in ${queueId})`);
+    logger.info(`WebSocket disconnected: ${connectionId} (${userId} in ${queueId})`);
     return { statusCode: 200 };
 
   } catch (err) {

--- a/src/layers/base/base.js
+++ b/src/layers/base/base.js
@@ -356,9 +356,9 @@ function getRequestClaimsFromEvent(event) {
       }
 
       // New context format - construct claims object from individual fields
-      if (authContext.cognitoSub && authContext.cognitoSub !== 'guest') {
+      if (authContext.userId && authContext.userId !== 'guest') {
         return {
-          sub: authContext.cognitoSub,
+          sub: authContext.userId,
           email: authContext.email || '',
           username: authContext.username || '',
           'cognito:username': authContext.username || '',

--- a/test/waiting-room/admin.test.js
+++ b/test/waiting-room/admin.test.js
@@ -222,8 +222,8 @@ describe('close-queue handler', () => {
     db.getQueueMeta.mockResolvedValue({ queueStatus: 'releasing' });
     db.updateQueueMetaStatus.mockResolvedValue({});
     db.queryQueueEntries.mockResolvedValue([
-      { pk: queueId, cognitoSub: 'user1' },
-      { pk: queueId, cognitoSub: 'user2' },
+      { pk: queueId, userId: 'user1' },
+      { pk: queueId, userId: 'user2' },
     ]);
     db.updateQueueEntryStatus.mockResolvedValue({});
 
@@ -240,8 +240,8 @@ describe('close-queue handler', () => {
     db.getQueueMeta.mockResolvedValue({ queueStatus: 'releasing' });
     db.updateQueueMetaStatus.mockResolvedValue({});
     db.queryQueueEntries.mockResolvedValue([
-      { pk: queueId, cognitoSub: 'user1', connectionId: 'conn-1' },
-      { pk: queueId, cognitoSub: 'user2', connectionId: 'conn-2' },
+      { pk: queueId, userId: 'user1', connectionId: 'conn-1' },
+      { pk: queueId, userId: 'user2', connectionId: 'conn-2' },
     ]);
     db.updateQueueEntryStatus.mockResolvedValue({});
     mockWsSend.mockResolvedValue({});

--- a/test/waiting-room/claim.test.js
+++ b/test/waiting-room/claim.test.js
@@ -36,7 +36,7 @@ const now = Math.floor(Date.now() / 1000);
 const validEntry = {
   pk: queueId,
   sk: 'ENTRY#test-user-123',
-  cognitoSub: 'test-user-123',
+  userId: 'test-user-123',
   status: 'admitted',
   facilityKey: 'golden-ears#camping#standard-sites',
   dateKey: '2025-06-15',

--- a/test/waiting-room/cleanup.test.js
+++ b/test/waiting-room/cleanup.test.js
@@ -16,8 +16,8 @@ const db = require('../../src/handlers/waiting-room/utils/dynamodb');
 
 const queueId = 'QUEUE#golden-ears#camping#standard-sites#2025-06-15';
 
-function makeEntry(cognitoSub, status) {
-  return { pk: queueId, sk: `ENTRY#${cognitoSub}`, cognitoSub, status };
+function makeEntry(userId, status) {
+  return { pk: queueId, sk: `ENTRY#${userId}`, userId, status };
 }
 
 describe('WaitingRoom CLEANUP handler', () => {

--- a/test/waiting-room/heartbeat.test.js
+++ b/test/waiting-room/heartbeat.test.js
@@ -81,7 +81,7 @@ const validPayload = {
 const admittedEntry = {
   pk: 'QUEUE#golden-ears#camping#standard#2025-06-15',
   sk: 'ENTRY#user-sub-123',
-  cognitoSub: 'user-sub-123',
+  userId: 'user-sub-123',
   status: 'admitted',
   admittedAt: NOW - 300,
   admissionExpiry: NOW + 600,

--- a/test/waiting-room/join.test.js
+++ b/test/waiting-room/join.test.js
@@ -18,7 +18,7 @@ jest.mock('../../src/handlers/waiting-room/utils/dynamodb', () => ({
   getQueueEntry: jest.fn(),
   putQueueEntry: jest.fn(),
   incrementQueueTotalEntries: jest.fn(),
-  queryEntriesByCognitoSub: jest.fn(),
+  queryEntriesByUserId: jest.fn(),
   queryEntriesByClientIp: jest.fn(),
   abandonQueueEntry: jest.fn(),
   incrementAbandonedCount: jest.fn(),
@@ -55,7 +55,7 @@ describe('WaitingRoom JOIN handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     db.getQueueMeta.mockResolvedValue(validMeta);
-    db.queryEntriesByCognitoSub.mockResolvedValue([]);
+    db.queryEntriesByUserId.mockResolvedValue([]);
     db.queryEntriesByClientIp.mockResolvedValue([]);
     db.putQueueEntry.mockResolvedValue();
     db.incrementQueueTotalEntries.mockResolvedValue(1);
@@ -89,11 +89,11 @@ describe('WaitingRoom JOIN handler', () => {
   it('returns 200 and existing entry data on idempotent re-join', async () => {
     const existingEntry = {
       pk: 'QUEUE#golden-ears#camping#standard-sites#2025-06-15',
-      cognitoSub: 'test-user-123',
+      userId: 'test-user-123',
       status: 'waiting',
       joinedAt: 1000000,
     };
-    db.queryEntriesByCognitoSub.mockResolvedValue([existingEntry]);
+    db.queryEntriesByUserId.mockResolvedValue([existingEntry]);
 
     const result = await handler(makeEvent(), {});
     expect(result.status).toBe(200);
@@ -105,11 +105,11 @@ describe('WaitingRoom JOIN handler', () => {
   it('abandons previous queue entry when joining a new queue', async () => {
     const otherQueueEntry = {
       pk: 'QUEUE#other#camping#sites#2025-06-16',
-      cognitoSub: 'test-user-123',
+      userId: 'test-user-123',
       status: 'waiting',
       joinedAt: 1000000,
     };
-    db.queryEntriesByCognitoSub.mockResolvedValue([otherQueueEntry]);
+    db.queryEntriesByUserId.mockResolvedValue([otherQueueEntry]);
 
     await handler(makeEvent(), {});
     expect(db.abandonQueueEntry).toHaveBeenCalledWith(otherQueueEntry.pk, 'test-user-123');
@@ -118,7 +118,7 @@ describe('WaitingRoom JOIN handler', () => {
   });
 
   it('returns 429 when IP limit is exceeded', async () => {
-    const ipEntries = Array(4).fill({ pk: 'QUEUE#...', cognitoSub: 'other-user', status: 'waiting' });
+    const ipEntries = Array(4).fill({ pk: 'QUEUE#...', userId: 'other-user', status: 'waiting' });
     db.queryEntriesByClientIp.mockResolvedValue(ipEntries);
 
     const result = await handler(makeEvent(), {});
@@ -130,7 +130,7 @@ describe('WaitingRoom JOIN handler', () => {
     expect(result.status).toBe(200);
     expect(db.putQueueEntry).toHaveBeenCalledWith(
       expect.objectContaining({
-        cognitoSub: 'test-user-123',
+        userId: 'test-user-123',
         status: 'waiting',
         facilityKey: 'golden-ears#camping#standard-sites',
         dateKey: '2025-06-15',

--- a/test/waiting-room/randomizer.test.js
+++ b/test/waiting-room/randomizer.test.js
@@ -22,7 +22,7 @@ function makeEntries(count) {
   return Array.from({ length: count }, (_, i) => ({
     pk: queueId,
     sk: `ENTRY#user-${i}`,
-    cognitoSub: `user-${i}`,
+    userId: `user-${i}`,
     clientIp: `10.0.0.${i % 10}`,
     status: 'waiting',
     facilityKey: 'golden-ears#camping#standard-sites',

--- a/test/waiting-room/release.test.js
+++ b/test/waiting-room/release.test.js
@@ -49,7 +49,7 @@ function makeWaitingEntry(i) {
   return {
     pk: queueId,
     sk: `ENTRY#user-${i}`,
-    cognitoSub: `user-${i}`,
+    userId: `user-${i}`,
     status: 'waiting',
     randomOrder: i,
     facilityKey: 'golden-ears#camping#standard-sites',
@@ -191,7 +191,7 @@ describe('WaitingRoom RELEASE handler — MODE2 path', () => {
     return {
       pk: mode2QueueId,
       sk: `ENTRY#user-${i}`,
-      cognitoSub: `user-${i}`,
+      userId: `user-${i}`,
       status: 'waiting',
       joinedAt: 1700000000 + i,
       connectionId: `conn-${i}`,

--- a/test/waiting-room/websocket-authorizer.test.js
+++ b/test/waiting-room/websocket-authorizer.test.js
@@ -38,7 +38,7 @@ const makeEvent = (overrides = {}) => ({
 });
 
 describe('WebSocket Lambda authorizer', () => {
-  it('returns ALLOW policy with cognitoSub and queueId when token is valid', async () => {
+  it('returns ALLOW policy with userId and queueId when token is valid', async () => {
     mockVerify.mockResolvedValue({ sub: 'user-sub-123' });
 
     const result = await handler(makeEvent());
@@ -46,7 +46,7 @@ describe('WebSocket Lambda authorizer', () => {
     expect(result.principalId).toBe('user-sub-123');
     expect(result.policyDocument.Statement[0].Effect).toBe('Allow');
     expect(result.policyDocument.Statement[0].Action).toBe('execute-api:Invoke');
-    expect(result.context.cognitoSub).toBe('user-sub-123');
+    expect(result.context.userId).toBe('user-sub-123');
     expect(result.context.queueId).toBe('QUEUE#golden-ears#camping#standard#2025-06-15');
   });
 

--- a/test/waiting-room/websocket-handlers.test.js
+++ b/test/waiting-room/websocket-handlers.test.js
@@ -44,7 +44,7 @@ describe('WebSocket $connect handler', () => {
     requestContext: {
       connectionId: 'conn-abc123',
       authorizer: {
-        cognitoSub: 'user-sub-456',
+        userId: 'user-sub-456',
         queueId: 'QUEUE#golden-ears#camping#standard#2025-06-15',
       },
       ...overrides.requestContext,
@@ -54,7 +54,7 @@ describe('WebSocket $connect handler', () => {
   const waitingEntry = {
     pk: 'QUEUE#golden-ears#camping#standard#2025-06-15',
     sk: 'ENTRY#user-sub-456',
-    cognitoSub: 'user-sub-456',
+    userId: 'user-sub-456',
     status: 'waiting',
     connectionId: null,
   };
@@ -79,12 +79,12 @@ describe('WebSocket $connect handler', () => {
   });
 
   it('returns 400 if connectionId is missing', async () => {
-    const event = { requestContext: { authorizer: { cognitoSub: 'sub', queueId: 'QUEUE#x' } } };
+    const event = { requestContext: { authorizer: { userId: 'sub', queueId: 'QUEUE#x' } } };
     const result = await connectHandler.handler(event);
     expect(result.statusCode).toBe(400);
   });
 
-  it('returns 400 if cognitoSub is missing from authorizer context', async () => {
+  it('returns 400 if userId is missing from authorizer context', async () => {
     const event = { requestContext: { connectionId: 'conn-1', authorizer: { queueId: 'QUEUE#x' } } };
     const result = await connectHandler.handler(event);
     expect(result.statusCode).toBe(400);
@@ -173,7 +173,7 @@ describe('WebSocket $disconnect handler', () => {
   it('sets disconnectedAt and deletes connection record on disconnect', async () => {
     db.getConnectionRecord.mockResolvedValue({
       queueId: 'QUEUE#golden-ears#camping#standard#2025-06-15',
-      cognitoSub: 'user-sub-456',
+      userId: 'user-sub-456',
     });
     db.setDisconnectedAt.mockResolvedValue();
     db.deleteConnectionRecord.mockResolvedValue();


### PR DESCRIPTION
### Description:
- When the admin authorizer was created, someone (it was me) decided to store a user's Cognito sub as `cognitoSub` on the claims object.
- This is a departure from the rest of the app's standardization where we reference a user's `sub` as `userId`.
- Therefore, this change purges the use of `cognitoSub` everywhere in the API and changes it to `userId` for consistency.
